### PR TITLE
feat(grzctl): Add --dry-run option to print pruefbericht, then exit

### DIFF
--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -110,7 +110,11 @@ def _get_library_type(metadata: GrzSubmissionMetadata) -> LibraryType:
 @click.option(
     "--token", help="Access token to try instead of requesting a new one.", envvar="GRZ_PRUEFBERICHT_ACCESS_TOKEN"
 )
-@click.option("--dry-run", help="Do not perform the request, only output the pruefbericht. Can be combined with --json.", is_flag=True)
+@click.option(
+    "--dry-run",
+    help="Do not perform the request, only output the pruefbericht. Can be combined with --json.",
+    is_flag=True,
+)
 def pruefbericht(config_file, submission_dir, output_json, failed, token, dry_run):
     """
     Submit a Prüfbericht to BfArM.
@@ -147,6 +151,7 @@ def pruefbericht(config_file, submission_dir, output_json, failed, token, dry_ru
             click.echo(pruefbericht.model_dump_json(indent=2))
         else:
             from rich import print
+
             print(pruefbericht.submitted_case)
         sys.exit(0)
 

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -149,7 +149,7 @@ def pruefbericht(config_file, submission_dir, output_json, failed, token, dry_ru
 
     if dry_run:
         if output_json:
-            click.echo(pruefbericht.model_dump_json(indent=2))
+            click.echo(pruefbericht.model_dump_json(indent=None, by_alias=True))
         else:
             rich.print(pruefbericht.submitted_case)
         sys.exit(0)

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -115,7 +115,7 @@ def _get_library_type(metadata: GrzSubmissionMetadata) -> LibraryType:
     help="Do not perform the request, only output the pruefbericht. Can be combined with --json.",
     is_flag=True,
 )
-def pruefbericht(config_file, submission_dir, output_json, failed, token, dry_run):
+def pruefbericht(config_file, submission_dir, output_json, failed, token, dry_run):  # noqa: C901, PLR0913, PLR0912
     """
     Submit a Prüfbericht to BfArM.
     """

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -7,6 +7,7 @@ import sys
 
 import click
 import requests
+import rich
 from grz_common.cli import config_file, output_json, submission_dir
 from grz_common.workers.submission import Submission
 from grz_pydantic_models.pruefbericht import LibraryType, Pruefbericht, SubmittedCase
@@ -150,8 +151,6 @@ def pruefbericht(config_file, submission_dir, output_json, failed, token, dry_ru
         if output_json:
             click.echo(pruefbericht.model_dump_json(indent=2))
         else:
-            import rich
-
             rich.print(pruefbericht.submitted_case)
         sys.exit(0)
 

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -110,7 +110,8 @@ def _get_library_type(metadata: GrzSubmissionMetadata) -> LibraryType:
 @click.option(
     "--token", help="Access token to try instead of requesting a new one.", envvar="GRZ_PRUEFBERICHT_ACCESS_TOKEN"
 )
-def pruefbericht(config_file, submission_dir, output_json, failed, token):
+@click.option("--dry-run", help="Do not perform the request, only output the pruefbericht. Can be combined with --json.", is_flag=True)
+def pruefbericht(config_file, submission_dir, output_json, failed, token, dry_run):
     """
     Submit a Prüfbericht to BfArM.
     """
@@ -140,6 +141,14 @@ def pruefbericht(config_file, submission_dir, output_json, failed, token):
             dataQualityCheckPassed=not failed,
         )
     )
+
+    if dry_run:
+        if output_json:
+            click.echo(pruefbericht.model_dump_json(indent=2))
+        else:
+            from rich import print
+            print(pruefbericht.submitted_case)
+        sys.exit(0)
 
     if token:
         # replace newlines in token if accidentally present from pasting

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -150,9 +150,9 @@ def pruefbericht(config_file, submission_dir, output_json, failed, token, dry_ru
         if output_json:
             click.echo(pruefbericht.model_dump_json(indent=2))
         else:
-            from rich import print
+            import rich
 
-            print(pruefbericht.submitted_case)
+            rich.print(pruefbericht.submitted_case)
         sys.exit(0)
 
     if token:


### PR DESCRIPTION
Adds a `--dry-run` option to `pruefbericht`, such that the Pruefbericht is only built (and printed to stdout), not submitted.
If combined with `--json`, outputs the Pruefbericht as JSON.
For `--dry-run` without `--json`, omits the wrapping `Pruefbericht`.

Resolves https://github.com/BfArM-MVH/grz-tools/issues/111