### PR TITLE
fix(grz-common): improve missing file error message

### DIFF
--- a/packages/grz-common/src/grz_common/workers/submission.py
+++ b/packages/grz-common/src/grz_common/workers/submission.py
@@ -194,7 +194,7 @@ class Submission:
 
         # Check if path exists
         if not local_file_path.exists():
-            yield f"{str(metadata.file_path)} does not exist!"
+            yield f"{str(Path('files') / metadata.file_path)} does not exist! Ensure filePath is relative to the files/ directory under the submission root."
             # Return here as following tests cannot work
             return
 


### PR DESCRIPTION
Until the upstream schema is updated this will help guide users towards the right relative path.

Related to https://github.com/BfArM-MVH/grz-tools/issues/106