### PR TITLE
fix(grz-common): simplify read_multiple_json

### DIFF
--- a/packages/grz-common/src/grz_common/utils/io.py
+++ b/packages/grz-common/src/grz_common/utils/io.py
@@ -8,40 +8,14 @@ from typing import TextIO
 log = logging.getLogger(__name__)
 
 
-def read_multiple_json(input: TextIO, buffer_size=65536, max_buffer_size=134217728):
+def read_multiple_json(input_file: TextIO):
     """
     Read multiple JSON objects from a text stream.
-    :param input:
-    :param buffer_size:
-    :param max_buffer_size:
+    :param input_file:
     """
-    decoder = json.JSONDecoder()
-    buffer = io.StringIO()  # Use StringIO as the buffer
-
-    while chunk := input.read(buffer_size):
-        if len(buffer.getvalue()) + len(chunk) > max_buffer_size:
-            raise MemoryError("Reached maximum buffer size while reading input")
-
-        # append chunk to buffer
-        buffer.write(chunk)
-
-        while True:
-            try:
-                data = buffer.getvalue().lstrip()
-                # Attempt to decode a JSON object from the current buffer content
-                obj, idx = decoder.raw_decode(data)
-                yield obj  # Process the decoded object
-
-                # Reset the buffer with the unprocessed content
-                buffer = io.StringIO(data[idx:])
-            except json.JSONDecodeError:
-                # If a JSONDecodeError occurs, we need more data, so break out to read the next chunk
-                break
-
-    # If there is any remaining content after the loop, try to process it
-    remaining_data = buffer.getvalue().strip()
-    if remaining_data != "":
-        raise ValueError("Remaining data is not empty. Is there invalid JSON?")
+    for line in input_file:
+        if line.strip():
+            yield json.loads(line)
 
 
 class TqdmIOWrapper(io.RawIOBase):

--- a/tests/test_read_multiple_json.py
+++ b/tests/test_read_multiple_json.py
@@ -22,46 +22,18 @@ def test_read_multiple_json_basic():
     ]
 
 
-# Basic JSON objects without white spaces
-def test_read_multiple_json_nowhitespace():
-    json_data = """{"name": "Alice", "age": 30}{"name": "Bob", "age": 25}{"name": "Charlie", "age": 35}"""
-    input_stream = io.StringIO(json_data)
-
-    result = list(read_multiple_json(input_stream))
-
-    assert result == [
-        {"name": "Alice", "age": 30},
-        {"name": "Bob", "age": 25},
-        {"name": "Charlie", "age": 35},
-    ]
-
-
-# Multiline JSON objects (JSON objects span multiple lines)
-def test_read_multiple_json_multiline():
-    json_data = """{
-                    "name": "Alice",
-                    "age": 30
-                   }
-                   {
-                    "name": "Bob",
-                    "age": 25
-                   }"""
-    input_stream = io.StringIO(json_data)
-
-    result = list(read_multiple_json(input_stream))
-
-    assert result == [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]
-
-
-# JSON objects that span across chunks (larger buffer)
-def test_read_multiple_json_large_buffer():
+# Basic JSON objects (single-line JSON objects)
+def test_read_multiple_json_newlines():
     json_data = """{"name": "Alice", "age": 30}
+    
                    {"name": "Bob", "age": 25}
-                   {"name": "Charlie", "age": 35}"""
+                   {"name": "Charlie", "age": 35}
+                   
+                   
+                   """
     input_stream = io.StringIO(json_data)
 
-    # Simulate reading in smaller buffer chunks to ensure that multiple reads work properly
-    result = list(read_multiple_json(input_stream, buffer_size=10))
+    result = list(read_multiple_json(input_stream))
 
     assert result == [
         {"name": "Alice", "age": 30},


### PR DESCRIPTION
We only ever made use of the jsonl style (exactly one json object on each line). The previous buffer based implementation (which also supports multi-line json objects etc) sometimes ended up with a non-empty buffer (for valid files) at the end, resulting in aborted progress logger resume processes.
We could also consider making use of the jsonlines package, would be yet another dependency.