### PR TITLE
fix(grzctl,grz-db): Add `db submission modify` to allow setting tanG/pseudonym

### DIFF
--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -275,6 +275,7 @@ class SubmissionDb:
                 return db_submission
             except IntegrityError as e:
                 session.rollback()
+                raise e
             except Exception:
                 session.rollback()
                 raise

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -256,8 +256,6 @@ class SubmissionDb:
 
         Args:
             submission_id: Submission ID.
-            tan_g: tanG if in phase 0
-            pseudonym: pseudonym if phase >= 0
 
         Returns:
             An instance of Submission.
@@ -277,9 +275,6 @@ class SubmissionDb:
                 return db_submission
             except IntegrityError as e:
                 session.rollback()
-                if "UNIQUE constraint failed: submissions.tanG" in str(e) and tan_g:
-                    raise DuplicateTanGError(tan_g) from e
-                raise
             except Exception:
                 session.rollback()
                 raise
@@ -305,6 +300,11 @@ class SubmissionDb:
                 session.commit()
                 session.refresh(submission)
                 return submission
+            except IntegrityError as e:
+                session.rollback()
+                if "UNIQUE constraint failed: submissions.tanG" in str(e) and key == "tan_g":
+                    raise DuplicateTanGError(value) from e
+                raise
             except Exception:
                 session.rollback()
                 raise

--- a/packages/grzctl/src/grzctl/commands/db.py
+++ b/packages/grzctl/src/grzctl/commands/db.py
@@ -411,9 +411,7 @@ def modify(ctx: click.Context, submission_id: str, key: str, value: str):
         submission = db_service.get_submission(submission_id)
         if not submission:
             raise SubmissionNotFoundError(submission_id)
-        _, _ = submission.tan_g, submission.pseudonym
-        updated_submission = db_service.modify_submission(submission_id, key, value)
-        _, _ = updated_submission.tan_g, updated_submission.pseudonym
+        _ = db_service.modify_submission(submission_id, key, value)
         console.print(f"[green]Updated {key} of submission '{submission_id}'[/green]")
 
     except SubmissionNotFoundError as e:

--- a/packages/grzctl/src/grzctl/commands/db.py
+++ b/packages/grzctl/src/grzctl/commands/db.py
@@ -407,11 +407,11 @@ def modify(ctx: click.Context, submission_id: str, key: str, value: str):
         submission = db_service.get_submission(submission_id)
         if not submission:
             raise SubmissionNotFoundError(submission_id)
-        tan_g, pseudonym = submission.tan_g, submission.pseudonym
+        _, _ = submission.tan_g, submission.pseudonym
         updated_submission = db_service.modify_submission(submission_id, key, value)
-        updated_tan_g, updated_pseudonym = updated_submission.tan_g, updated_submission.pseudonym
+        _, _ = updated_submission.tan_g, updated_submission.pseudonym
         console.print(
-            f"[green]Submission '{submission_id}' updated from tanG: {tan_g}, pseudonym: {pseudonym} to tanG: {updated_tan_g}, pseudonym: {updated_pseudonym} [/green]"
+            f"[green]Updated {key} of submission '{submission_id}'[/green]"
         )
 
     except SubmissionNotFoundError as e:

--- a/packages/grzctl/src/grzctl/commands/db.py
+++ b/packages/grzctl/src/grzctl/commands/db.py
@@ -405,6 +405,8 @@ def modify(ctx: click.Context, submission_id: str, key: str, value: str):
 
     try:
         submission = db_service.get_submission(submission_id)
+        if not submission:
+            raise SubmissionNotFoundError(submission_id)
         tan_g, pseudonym = submission.tan_g, submission.pseudonym
         updated_submission = db_service.modify_submission(submission_id, key, value)
         updated_tan_g, updated_pseudonym = updated_submission.tan_g, updated_submission.pseudonym

--- a/packages/grzctl/src/grzctl/commands/db.py
+++ b/packages/grzctl/src/grzctl/commands/db.py
@@ -335,19 +335,16 @@ def _build_submission_dict_from(
 
 @submission.command()
 @click.argument("submission_id", type=str)
-@click.option("--tan-g", "tan_g", type=str, default=None, help="The tanG for the submission.")
-@click.option("--pseudonym", type=str, default=None, help="The pseudonym for the submission.")
 @click.pass_context
-def add(ctx: click.Context, submission_id: str, tan_g: str | None, pseudonym: str | None):
+def add(ctx: click.Context, submission_id: str):
     """
     Add a submission to the database.
     """
     db = ctx.obj["db_url"]
     db_service = get_submission_db_instance(db)
     try:
-        db_submission = db_service.add_submission(submission_id, tan_g, pseudonym)
+        db_submission = db_service.add_submission(submission_id)
         console.print(f"[green]Submission '{db_submission.id}' added successfully.[/green]")
-        console.print(f"  tanG: {db_submission.tan_g}, Pseudonym: {db_submission.pseudonym}")
     except (DuplicateSubmissionError, DuplicateTanGError) as e:
         console.print(f"[red]Error: {e}[/red]")
         raise click.Abort() from e

--- a/packages/grzctl/src/grzctl/commands/db.py
+++ b/packages/grzctl/src/grzctl/commands/db.py
@@ -414,9 +414,7 @@ def modify(ctx: click.Context, submission_id: str, key: str, value: str):
         _, _ = submission.tan_g, submission.pseudonym
         updated_submission = db_service.modify_submission(submission_id, key, value)
         _, _ = updated_submission.tan_g, updated_submission.pseudonym
-        console.print(
-            f"[green]Updated {key} of submission '{submission_id}'[/green]"
-        )
+        console.print(f"[green]Updated {key} of submission '{submission_id}'[/green]")
 
     except SubmissionNotFoundError as e:
         console.print(f"[red]Error: {e}[/red]")

--- a/tests/cli/test_db.py
+++ b/tests/cli/test_db.py
@@ -24,8 +24,16 @@ def test_db(
     assert result.exit_code == 0, result.output
 
     # then add a submission
-    add_args = [*args_prefix, "submission", "add", "S01", "--tan-g", "foo", "--pseudonym", "bar"]
+    add_args = [*args_prefix, "submission", "add", "S01"]
     result = execute(add_args)
+    assert result.exit_code == 0, result.output
+
+    # then update the submission's tanG and/or pseudonym
+    modify_args = [*args_prefix, "submission", "modify", "S01", "tanG", "foo"]
+    result = execute(modify_args)
+    assert result.exit_code == 0, result.output
+    modify_args = [*args_prefix, "submission", "modify", "S01", "pseudonym", "bar"]
+    result = execute(modify_args)
     assert result.exit_code == 0, result.output
 
     # then update a submission


### PR DESCRIPTION
Previously, the `db submission add` command required knowing the tanG / pseudonym before knowing them. Therefore we introduce the `db submission modify SUBMISSION_ID tanG/pseudonym VALUE` command here.

Resolves #188 and #200