### PR TITLE
refactor(grz-pydantic-models,grz-cli,grzctl): Match multiple schema URLs

### DIFF
--- a/packages/grz-cli/src/grz_cli/cli.py
+++ b/packages/grz-cli/src/grz_cli/cli.py
@@ -41,7 +41,7 @@ def build_cli():
     @click.version_option(
         version=version("grz-cli"),
         prog_name="grz-cli",
-        message=f"%(prog)s v%(version)s (metadata schema versions: {', '.join(grz_pydantic_models.submission.metadata.get_supported_versions())})",
+        message=f"%(prog)s v%(version)s (currently accepted metadata schema versions: {', '.join(grz_pydantic_models.submission.metadata.get_accepted_versions())})",
     )
     @click.option("--log-file", metavar="FILE", type=str, help="Path to log file")
     @click.option(

--- a/packages/grz-common/src/grz_common/workers/submission.py
+++ b/packages/grz-common/src/grz_common/workers/submission.py
@@ -10,6 +10,7 @@ from itertools import groupby
 from os import PathLike
 from pathlib import Path
 
+from grz_pydantic_models.submission.metadata import get_accepted_versions
 from grz_pydantic_models.submission.metadata.v1 import (
     ChecksumType,
     File,
@@ -107,12 +108,17 @@ class SubmissionMetadata:
         self._files = submission_files
         return self._files
 
-    def validate(self) -> Generator[str]:
+    def validate(self) -> Generator[str]:  # noqa: C901
         """
         Validates this submission's metadata (content).
 
         :return: Generator of errors
         """
+        metadata_schema_version = self.content.get_schema_version()
+        accepted_versions = get_accepted_versions()
+        if metadata_schema_version not in accepted_versions:
+            yield f"Metadata schema version {metadata_schema_version} is outdated. Currently accepting the following versions: {', '.join(accepted_versions)}"
+
         submission_files: dict[str | PathLike, SubmissionFileMetadata] = {}
         for donor in self.content.donors:
             for lab_data in donor.lab_data:

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/__init__.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/__init__.py
@@ -1,5 +1,11 @@
+from ...std import deprecated
 from .v1 import *  # noqa: F403
 
 
+@deprecated(msg="get_supported_versions() is deprecated. Use get_accepted_versions() instead.")
 def get_supported_versions() -> set[str]:
     return {"1.1.1", "1.1.4"}
+
+
+def get_accepted_versions() -> set[str]:
+    return {"1.1.7", "1.1.8"}

--- a/packages/grzctl/src/grzctl/cli.py
+++ b/packages/grzctl/src/grzctl/cli.py
@@ -9,7 +9,6 @@ import logging.config
 from importlib.metadata import version
 
 import click
-import grz_pydantic_models.submission.metadata
 from grz_cli.commands.encrypt import encrypt
 from grz_cli.commands.submit import submit
 from grz_cli.commands.upload import upload
@@ -50,7 +49,7 @@ def build_cli():
     @click.version_option(
         version=version("grzctl"),
         prog_name="grzctl",
-        message=f"%(prog)s v%(version)s (metadata schema versions: {', '.join(grz_pydantic_models.submission.metadata.get_supported_versions())})",
+        message="%(prog)s v%(version)s",
     )
     @click.option("--log-file", metavar="FILE", type=str, help="Path to log file")
     @click.option(

--- a/tests/mock_files/submissions/valid_submission/metadata/metadata.json
+++ b/tests/mock_files/submissions/valid_submission/metadata/metadata.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq/refs/tags/v1.1.1/GRZ/grz-schema.json",
+  "$schema": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq/refs/tags/v1.1.8/GRZ/grz-schema.json",
   "submission": {
     "submissionDate": "2024-07-15",
     "submissionType": "initial",


### PR DESCRIPTION
* also remove supported metadata schema version display from grzctl as it will be all current and prior versions.

Resolves https://github.com/BfArM-MVH/grz-tools/issues/112

Will remove deprecated stuff in later PR. 