### PR TITLE
feat(grzctl,grz-common): use marker files while cleaning

### DIFF
--- a/packages/grzctl/src/grzctl/commands/clean.py
+++ b/packages/grzctl/src/grzctl/commands/clean.py
@@ -61,4 +61,4 @@ def clean(submission_id, config_file, yes_i_really_mean_it: bool):
         bucket.put_object(Body=b"", Key=f"{submission_id}/cleaned")
         bucket.Object(f"{submission_id}/cleaning").delete()
 
-        log.info(f"Cleaned '{prefix}' from '{bucket_name}' …")
+        log.info(f"Cleaned '{prefix}' from '{bucket_name}'.")

--- a/packages/grzctl/src/grzctl/commands/list_submissions.py
+++ b/packages/grzctl/src/grzctl/commands/list_submissions.py
@@ -9,7 +9,7 @@ import rich.console
 import rich.table
 import rich.text
 from grz_common.cli import config_file, output_json
-from grz_common.workers.download import query_submissions
+from grz_common.workers.download import InboxSubmissionState, query_submissions
 from pydantic_core import to_jsonable_python
 
 from ..models.config import ListConfig
@@ -20,12 +20,13 @@ log = logging.getLogger(__name__)
 @click.command()
 @config_file
 @output_json
-def list_submissions(config_file, output_json):
+@click.option("--show-cleaned/--hide-cleaned")
+def list_submissions(config_file, output_json, show_cleaned):
     """
     List submissions within an inbox from oldest to newest.
     """
     config = ListConfig.from_path(config_file)
-    submissions = query_submissions(config.s3)
+    submissions = query_submissions(config.s3, show_cleaned)
 
     if output_json:
         json.dump(to_jsonable_python(submissions), sys.stdout)
@@ -37,13 +38,22 @@ def list_submissions(config_file, output_json):
         table.add_column("Oldest Upload", overflow="fold")
         table.add_column("Newest Upload", overflow="fold")
         for submission in submissions:
-            status_text = rich.text.Text(
-                "Complete" if submission.complete else "Incomplete",
-                style="green" if submission.complete else "yellow",
-            )
+            match submission.state:
+                case InboxSubmissionState.INCOMPLETE:
+                    status_text = "[yellow]Incomplete[/yellow]"
+                case InboxSubmissionState.COMPLETE:
+                    status_text = "[green]Complete[/green]"
+                case InboxSubmissionState.CLEANING:
+                    status_text = "[yellow]Cleaning[/yellow]"
+                case InboxSubmissionState.CLEANED:
+                    status_text = "[sky_blue1]Cleaned[/sky_blue1]"
+                case InboxSubmissionState.ERROR:
+                    status_text = "[red]Error[/red]"
+                case _:
+                    status_text = "[red]Unknown[/red]"
             table.add_row(
                 submission.submission_id,
-                status_text,
+                rich.text.Text(status_text),
                 submission.oldest_upload.astimezone().strftime("%Y-%m-%d %H:%M:%S"),
                 submission.newest_upload.astimezone().strftime("%Y-%m-%d %H:%M:%S"),
             )

--- a/packages/grzctl/src/grzctl/commands/list_submissions.py
+++ b/packages/grzctl/src/grzctl/commands/list_submissions.py
@@ -40,17 +40,17 @@ def list_submissions(config_file, output_json, show_cleaned):
         for submission in submissions:
             match submission.state:
                 case InboxSubmissionState.INCOMPLETE:
-                    status_text = "[yellow]Incomplete[/yellow]"
+                    status_text = rich.text.Text("Incomplete", style="yellow")
                 case InboxSubmissionState.COMPLETE:
-                    status_text = "[green]Complete[/green]"
+                    status_text = rich.text.Text("Complete", style="green")
                 case InboxSubmissionState.CLEANING:
-                    status_text = "[yellow]Cleaning[/yellow]"
+                    status_text = rich.text.Text("Cleaning", style="yellow")
                 case InboxSubmissionState.CLEANED:
-                    status_text = "[sky_blue1]Cleaned[/sky_blue1]"
+                    status_text = rich.text.Text("Cleaned", style="sky_blue1")
                 case InboxSubmissionState.ERROR:
-                    status_text = "[red]Error[/red]"
+                    status_text = rich.text.Text("Error", style="red")
                 case _:
-                    status_text = "[red]Unknown[/red]"
+                    status_text = rich.text.Text("Unknown", style="red")
             table.add_row(
                 submission.submission_id,
                 rich.text.Text(status_text),

--- a/packages/grzctl/src/grzctl/commands/list_submissions.py
+++ b/packages/grzctl/src/grzctl/commands/list_submissions.py
@@ -53,7 +53,7 @@ def list_submissions(config_file, output_json, show_cleaned):
                     status_text = rich.text.Text("Unknown", style="red")
             table.add_row(
                 submission.submission_id,
-                rich.text.Text(status_text),
+                status_text,
                 submission.oldest_upload.astimezone().strftime("%Y-%m-%d %H:%M:%S"),
                 submission.newest_upload.astimezone().strftime("%Y-%m-%d %H:%M:%S"),
             )

--- a/packages/grzctl/src/grzctl/commands/list_submissions.py
+++ b/packages/grzctl/src/grzctl/commands/list_submissions.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 @click.command()
 @config_file
 @output_json
-@click.option("--show-cleaned/--hide-cleaned")
+@click.option("--show-cleaned/--hide-cleaned", help="Show cleaned submissions.")
 def list_submissions(config_file, output_json, show_cleaned):
     """
     List submissions within an inbox from oldest to newest.

--- a/packages/grzctl/src/grzctl/models/config.py
+++ b/packages/grzctl/src/grzctl/models/config.py
@@ -18,7 +18,7 @@ class DecryptConfig(KeyConfigModel):
     pass
 
 
-class CleanConfig(S3ConfigModel, KeyConfigModel):
+class CleanConfig(S3ConfigModel):
     pass
 
 

--- a/tests/cli/test_clean.py
+++ b/tests/cli/test_clean.py
@@ -1,0 +1,62 @@
+"""
+Tests for the Prüfbericht submission functionality.
+"""
+
+import importlib.resources
+import shutil
+from unittest import mock
+
+import click.testing
+import grzctl
+
+from .. import mock_files
+
+
+def test_clean(temp_s3_config_file_path, remote_bucket, working_dir_path, tmp_path):
+    submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
+    with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
+        shutil.copytree(submission_dir / "encrypted_files", working_dir_path / "encrypted_files", dirs_exist_ok=True)
+        shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+
+    with mock.patch(
+        "grz_common.models.s3.S3Options.__getattr__",
+        lambda self, name: None if name == "endpoint_url" else AttributeError,
+    ):
+        # upload encrypted submission
+        upload_args = [
+            "upload",
+            "--submission-dir",
+            str(working_dir_path),
+            "--config-file",
+            temp_s3_config_file_path,
+        ]
+
+        runner = click.testing.CliRunner()
+        cli = grzctl.cli.build_cli()
+        result_upload = runner.invoke(cli, upload_args, catch_exceptions=False)
+
+        assert result_upload.exit_code == 0, result_upload.output
+        assert len(result_upload.output) != 0, result_upload.stderr
+
+        submission_id = result_upload.stdout.strip()
+
+        clean_args = [
+            "clean",
+            "--submission-id",
+            submission_id,
+            "--config-file",
+            temp_s3_config_file_path,
+            "--yes-i-really-mean-it",
+        ]
+
+        result_clean = runner.invoke(cli, clean_args, catch_exceptions=False)
+
+        assert result_clean.exit_code == 0, result_clean.output
+
+        uploaded_keys = {o.key for o in remote_bucket.objects.all()}
+        assert len(uploaded_keys) == 2
+        assert f"{submission_id}/metadata/metadata.json" in uploaded_keys
+        assert f"{submission_id}/cleaned" in uploaded_keys
+        assert f"{submission_id}/cleaning" not in uploaded_keys
+        # ensure metadata is empty
+        assert remote_bucket.Object(f"{submission_id}/metadata/metadata.json").content_length == 0


### PR DESCRIPTION
Keeps an empty metadata.json in the inbox to prevent future re-uploads of the same submission. Also allows checking if the submission has been cleaned.

Resolves https://github.com/BfArM-MVH/grz-tools/issues/194