### PR TITLE
fix(grz-db): don't print the duplicate tanG

### DIFF
--- a/packages/grz-db/src/grz_db/errors.py
+++ b/packages/grz-db/src/grz_db/errors.py
@@ -15,8 +15,8 @@ class DuplicateSubmissionError(ValueError):
 class DuplicateTanGError(ValueError):
     """Exception for when a tanG is already in use."""
 
-    def __init__(self, tan_g: str):
-        super().__init__(f"Duplicate tanG {tan_g}")
+    def __init__(self):
+        super().__init__("Duplicate tanG")
 
 
 class DatabaseConfigurationError(Exception):

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -304,7 +304,7 @@ class SubmissionDb:
             except IntegrityError as e:
                 session.rollback()
                 if "UNIQUE constraint failed: submissions.tanG" in str(e) and key == "tan_g":
-                    raise DuplicateTanGError(value) from e
+                    raise DuplicateTanGError() from e
                 raise
             except Exception:
                 session.rollback()


### PR DESCRIPTION
Prevents accidentally writing to logs if running automated.