### PR TITLE
refactor(grzctl,grz-cli,grz-common): move tqdm defaults to constants

### DIFF
--- a/packages/grz-common/src/grz_common/constants.py
+++ b/packages/grz-common/src/grz_common/constants.py
@@ -36,4 +36,13 @@ LOGGING_CONFIG = {
     },
 }
 
-TQDM_SMOOTHING: float = 0.0001
+TQDM_SMOOTHING: float = 0.00001
+TQDM_BAR_FORMAT = "{desc} ▕{bar:50}▏ {n_fmt:>10}/{total_fmt:<10} ({rate_fmt:>12}, ETA: {remaining:>6}) {postfix}"
+TQDM_DEFAULTS = {
+    "bar_format": TQDM_BAR_FORMAT,
+    "unit": "iB",
+    "unit_scale": True,
+    "miniters": 1,
+    "smoothing": TQDM_SMOOTHING,
+    "colour": "cyan",
+}

--- a/packages/grz-common/src/grz_common/utils/checksums.py
+++ b/packages/grz-common/src/grz_common/utils/checksums.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from tqdm.auto import tqdm
 
-from ..constants import TQDM_SMOOTHING
+from ..constants import TQDM_DEFAULTS
 
 log = logging.getLogger(__name__)
 
@@ -27,13 +27,7 @@ def calculate_sha256(file_path: str | PathLike, chunk_size=2**16, progress=True)
     sha256_hash = hashlib.sha256()
     with open(file_path, "rb") as f:
         if progress and (total_size > chunk_size):
-            with tqdm(
-                total=total_size,
-                unit="B",
-                unit_scale=True,
-                desc=f"Calculating SHA256 {file_path.name}",
-                smoothing=TQDM_SMOOTHING,
-            ) as pbar:
+            with tqdm(total=total_size, desc="SHA256  ", postfix=f"{file_path.name}", **TQDM_DEFAULTS) as pbar:  # type: ignore[call-overload]
                 while chunk := f.read(chunk_size):
                     sha256_hash.update(chunk)
                     pbar.update(len(chunk))

--- a/packages/grz-common/src/grz_common/utils/crypt.py
+++ b/packages/grz-common/src/grz_common/utils/crypt.py
@@ -16,7 +16,7 @@ import crypt4gh.lib
 from nacl.public import PrivateKey
 from tqdm.auto import tqdm
 
-from ..constants import TQDM_SMOOTHING
+from ..constants import TQDM_DEFAULTS
 from .io import TqdmIOWrapper
 
 log = logging.getLogger(__name__)
@@ -76,15 +76,7 @@ class Crypt4GH:
             open(output_path, "wb") as out_fd,
             TqdmIOWrapper(
                 typing.cast(io.RawIOBase, in_fd),
-                tqdm(
-                    total=total_size,
-                    desc=f"Encrypting: '{input_path.name}'",
-                    unit="B",
-                    unit_scale=True,
-                    # unit_divisor=1024,  # make use of standard units e.g. KB, MB, etc.
-                    miniters=1,
-                    smoothing=TQDM_SMOOTHING,
-                ),
+                tqdm(total=total_size, desc="ENCRYPT ", postfix=f"{input_path.name}", **TQDM_DEFAULTS),  # type: ignore[call-overload]
             ) as pbar_in_fd,
         ):
             crypt4gh.lib.encrypt(
@@ -121,19 +113,13 @@ class Crypt4GH:
         :param private_key: The private key
         """
         total_size = getsize(input_path)
+        file_name = input_path.name
         with (
             open(input_path, "rb") as in_fd,
             open(output_path, "wb") as out_fd,
             TqdmIOWrapper(
                 typing.cast(io.RawIOBase, in_fd),
-                tqdm(
-                    total=total_size,
-                    desc=f"Decrypting: '{input_path.name}'",
-                    unit="B",
-                    unit_scale=True,
-                    # unit_divisor=1024,  # make use of standard units e.g. KB, MB, etc.
-                    miniters=1,
-                ),
+                tqdm(total=total_size, desc="DECRYPT ", postfix=f"{file_name}", **TQDM_DEFAULTS),  # type: ignore[call-overload]
             ) as pbar_in_fd,
         ):
             crypt4gh.lib.decrypt(

--- a/packages/grz-common/src/grz_common/validation/fastq.py
+++ b/packages/grz-common/src/grz_common/validation/fastq.py
@@ -9,11 +9,12 @@ from contextlib import contextmanager
 from gzip import GzipFile
 from io import RawIOBase
 from os import PathLike
+from pathlib import Path
 from typing import TextIO
 
 from tqdm.auto import tqdm
 
-from ..constants import TQDM_SMOOTHING
+from ..constants import TQDM_DEFAULTS
 from ..utils.io import TqdmIOWrapper
 
 log = logging.getLogger(__name__)
@@ -39,21 +40,14 @@ def open_fastq(file_path: str | PathLike, progress=True) -> Generator[TextIO, No
     :return: A file object opened in the appropriate mode (gzipped or plain text)
     """
     handle: TqdmIOWrapper | GzipFile | typing.BinaryIO | None = None
+    file_name = Path(file_path).name
     with open(file_path, "rb") as fd:
         # Open FASTQ
         total_size = os.stat(file_path).st_size
         if progress:
             handle = TqdmIOWrapper(
                 typing.cast(RawIOBase, fd),
-                tqdm(
-                    total=total_size,
-                    desc="Reading FASTQ: ",
-                    unit="B",
-                    unit_scale=True,
-                    # unit_divisor=1024,  # make use of standard units e.g. KB, MB, etc.
-                    miniters=1,
-                    smoothing=TQDM_SMOOTHING,
-                ),
+                tqdm(total=total_size, desc="FASTQ   ", postfix=f"{file_name}", **TQDM_DEFAULTS),  # type: ignore[call-overload]
             )
         else:
             handle = fd

--- a/packages/grz-common/src/grz_common/workers/download.py
+++ b/packages/grz-common/src/grz_common/workers/download.py
@@ -20,7 +20,7 @@ from grz_pydantic_models.submission.metadata.v1 import File as SubmissionFileMet
 from pydantic import BaseModel
 from tqdm.auto import tqdm
 
-from ..constants import TQDM_SMOOTHING
+from ..constants import TQDM_DEFAULTS
 from ..models.s3 import S3Options
 from ..progress import DownloadState, FileProgressLogger
 from ..transfer import init_s3_client
@@ -149,9 +149,7 @@ class S3BotoDownloadWorker:
         )
 
         transfer = S3Transfer(self._s3_client, config)  # type: ignore[arg-type]
-        with tqdm(
-            total=filesize, unit="B", unit_scale=True, unit_divisor=1024, smoothing=TQDM_SMOOTHING
-        ) as progress_bar:
+        with tqdm(total=filesize, postfix=f"{s3_object_id}", **TQDM_DEFAULTS) as progress_bar:  # type: ignore[call-overload]
             transfer.download_file(
                 self._s3_options.bucket,
                 s3_object_id,

--- a/packages/grz-common/src/grz_common/workers/upload.py
+++ b/packages/grz-common/src/grz_common/workers/upload.py
@@ -17,7 +17,7 @@ import botocore.handlers
 from boto3.s3.transfer import S3Transfer, TransferConfig  # type: ignore[import-untyped]
 from tqdm.auto import tqdm
 
-from ..constants import TQDM_SMOOTHING
+from ..constants import TQDM_DEFAULTS
 from ..models.s3 import S3Options
 from ..progress import FileProgressLogger, UploadState
 from ..transfer import init_s3_client
@@ -127,7 +127,7 @@ class S3BotoUploadWorker(UploadWorker):
         )
 
         transfer = S3Transfer(self._s3_client, config)  # type: ignore[arg-type]
-        progress_bar = tqdm(total=filesize, unit="B", unit_scale=True, unit_divisor=1024, smoothing=TQDM_SMOOTHING)
+        progress_bar = tqdm(total=filesize, desc="UPLOAD  ", **TQDM_DEFAULTS, postfix=f"{s3_object_id}")  # type: ignore[call-overload]
         transfer.upload_file(
             str(local_file_path),
             self._s3_options.bucket,


### PR DESCRIPTION
for code deduplication and mimicking progress bars from grz-check
(also decrypt didn't use the same smoothing value)