### PR TITLE
fix(grz-common): correctly fallback without grz-check

### DIFF
--- a/packages/grz-cli/src/grz_cli/commands/validate.py
+++ b/packages/grz-cli/src/grz_cli/commands/validate.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 @click.option(
     "--with-grz-check/--no-grz-check",
     "with_grz_check",
-    default=False,
+    default=True,
     hidden=True,
     help="Whether to use grz-check to perform validation",
 )

--- a/packages/grz-cli/src/grz_cli/commands/validate.py
+++ b/packages/grz-cli/src/grz_cli/commands/validate.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 @click.option(
     "--with-grz-check/--no-grz-check",
     "with_grz_check",
-    default=True,
+    default=False,
     hidden=True,
     help="Whether to use grz-check to perform validation",
 )

--- a/packages/grz-common/src/grz_common/workers/worker.py
+++ b/packages/grz-common/src/grz_common/workers/worker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from os import PathLike
 from pathlib import Path
+import shutil
 
 from ..models.identifiers import IdentifiersModel
 from ..models.s3 import S3Options
@@ -113,7 +114,8 @@ class Worker:
             self.progress_file_checksum_validation.unlink(missing_ok=True)
             self.progress_file_sequencing_data_validation.unlink(missing_ok=True)
 
-        if with_grz_check:
+        have_grz_check = shutil.which("grz-check") is not None
+        if with_grz_check and have_grz_check:
             try:
                 self.__log.info("Starting file validation with `grz-check`...")
                 errors = list(

--- a/packages/grz-common/src/grz_common/workers/worker.py
+++ b/packages/grz-common/src/grz_common/workers/worker.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
+import shutil
 from os import PathLike
 from pathlib import Path
-import shutil
 
 from ..models.identifiers import IdentifiersModel
 from ..models.s3 import S3Options

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -30,13 +30,14 @@ def test_validate_submission(
         grz_check_flag,
     ]
 
+    have_grz_check = shutil.which("grz-check") is not None
     runner = CliRunner()
     cli = grz_cli.cli.build_cli()
     with caplog.at_level(logging.INFO):
         result = runner.invoke(cli, testargs, catch_exceptions=False)
         assert result.exit_code == 0, result.output
 
-        if grz_check_flag == "--no-grz-check":
+        if grz_check_flag == "--no-grz-check" or not have_grz_check:
             assert "Starting checksum validation (fallback)..." in caplog.text
         else:
             assert "Starting file validation with `grz-check`..." in caplog.text
@@ -46,7 +47,7 @@ def test_validate_submission(
     with caplog.at_level(logging.INFO):
         result = runner.invoke(cli, testargs, catch_exceptions=False)
 
-        if grz_check_flag == "--no-grz-check":
+        if grz_check_flag == "--no-grz-check" or not have_grz_check:
             assert "Starting checksum validation (fallback)..." in caplog.text
         else:
             assert "Starting file validation with `grz-check`..." in caplog.text


### PR DESCRIPTION
This was an unintentional API break. Users shouldn't be required to pass `--no-grz-check` to continue working with `grz-cli` as before.