### PR TITLE
fix(grzctl,grz-cli): bump dependencies

### DIFF
--- a/packages/grz-cli/pyproject.toml
+++ b/packages/grz-cli/pyproject.toml
@@ -22,11 +22,11 @@ dependencies = [
     "pydantic >=2.9.2,<2.10",
     "pydantic-settings >=2.9.0,<2.10",
     "platformdirs >=4.3.6,<5",
-    "grz-pydantic-models >=2.1.1,<3",
+    "grz-pydantic-models >=2.1.2,<3",
     "pysam ==0.23.*",
     "rich ==13.*",
     "requests >=2.32.3,<3",
-    "grz-common >=1.0.3,<2",
+    "grz-common >=1.1.1,<2",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/packages/grzctl/pyproject.toml
+++ b/packages/grzctl/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "requests >=2.32.3,<3",
     "grz-db >=0.2.1",
     "grz-common >=1.1.1,<2",
-    "grz-cli >=1.1.1",
+    "grz-cli >=1.0.0",
     "grz-pydantic-models >=2.1.2,<3"
 ]
 classifiers = [

--- a/packages/grzctl/pyproject.toml
+++ b/packages/grzctl/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = [
     "rich ==13.*",
     "requests >=2.32.3,<3",
     "grz-db >=0.2.1",
-    "grz-common >=1.0.3,<2",
-    "grz-cli >=1.0.0",
-    "grz-pydantic-models >=2.1.1,<3"
+    "grz-common >=1.1.1,<2",
+    "grz-cli >=1.1.1",
+    "grz-pydantic-models >=2.1.2,<3"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
* bump grz-common to fallback without grz-check correctly
* bump grz-pydantic-models to allow non-index donors to fail thresholds