### PR TITLE
fix(grz-common): bump grz-pydanic-models version

### DIFF
--- a/packages/grz-common/pyproject.toml
+++ b/packages/grz-common/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pydantic >=2.9.2,<2.10",
     "pydantic-settings >=2.9.0,<2.10",
     "platformdirs >=4.3.6,<5",
-    "grz-pydantic-models >=2.0.0",
+    "grz-pydantic-models >=2.2.0",
     "pysam ==0.23.*",
     "rich ==13.*",
     "requests >=2.32.3,<3",


### PR DESCRIPTION
Uses the new submission_id property of GrzSubmissionMetadata