### PR TITLE
fix(grzctl,grz-cli): raise default log level to WARNING

### DIFF
--- a/packages/grz-cli/src/grz_cli/cli.py
+++ b/packages/grz-cli/src/grz_cli/cli.py
@@ -45,9 +45,9 @@ def build_cli():
     @click.option("--log-file", metavar="FILE", type=str, help="Path to log file")
     @click.option(
         "--log-level",
-        default="INFO",
+        default="WARNING",
         type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
-        help="Set the log level (default: INFO)",
+        help="Set the log level (default: WARNING)",
     )
     def cli(log_file: str | None = None, log_level: str = "INFO"):
         """

--- a/packages/grzctl/src/grzctl/cli.py
+++ b/packages/grzctl/src/grzctl/cli.py
@@ -53,9 +53,9 @@ def build_cli():
     @click.option("--log-file", metavar="FILE", type=str, help="Path to log file")
     @click.option(
         "--log-level",
-        default="INFO",
+        default="WARNING",
         type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
-        help="Set the log level (default: INFO)",
+        help="Set the log level (default: WARNING)",
     )
     def cli(log_file: str | None = None, log_level: str = "INFO"):
         """


### PR DESCRIPTION
Some of our dependencies are quite chatty (alembic) at the `INFO` level since it is not the default for Python. This raises the default level to `WARNING` to match Python's.