### PR TITLE
ci(repo): bump uv to 0.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  UV_VERSION: '0.7.21'
+  UV_VERSION: '0.8.5'
   GRZ_CHECK_WORKSPACE: "packages/grz-check"
 
 jobs:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - '*-v[0-9]+.[0-9]+.[0-9]+*'
 
+env:
+  UV_VERSION: '0.8.5'
+
 jobs:
   build-and-publish-package:
     name: Build & Publish Package from tag
@@ -45,7 +48,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          version: '0.7.9'
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
 
       - name: Set up Python


### PR DESCRIPTION
Resolves https://github.com/BfArM-MVH/grz-tools/issues/290

ci(repo): use env to define uv version for PyPI build