### PR TITLE
feat(grz-cli): also report grz library versions

### DIFF
--- a/packages/grz-cli/src/grz_cli/cli.py
+++ b/packages/grz-cli/src/grz_cli/cli.py
@@ -4,6 +4,8 @@ CLI module for handling command-line interface operations.
 
 import logging
 import logging.config
+import shutil
+import subprocess
 from importlib.metadata import version
 from textwrap import dedent
 
@@ -46,8 +48,13 @@ def build_cli():
         %(prog)s v%(version)s
         Currently accepted metadata schema versions: {", ".join(grz_pydantic_models.submission.metadata.get_accepted_versions())}
         grz-common v{version("grz-common")}
-        grz-pydantic-models v{version("grz-pydantic-models")}\
-        """),
+        grz-pydantic-models v{version("grz-pydantic-models")}
+        """)
+        + (
+            subprocess.run(["grz-check", "--version"], capture_output=True, text=True).stdout.strip()  # noqa: S603, S607
+            if shutil.which("grz-check") is not None
+            else ""
+        ),
     )
     @click.option("--log-file", metavar="FILE", type=str, help="Path to log file")
     @click.option(

--- a/packages/grz-cli/src/grz_cli/cli.py
+++ b/packages/grz-cli/src/grz_cli/cli.py
@@ -5,6 +5,7 @@ CLI module for handling command-line interface operations.
 import logging
 import logging.config
 from importlib.metadata import version
+from textwrap import dedent
 
 import click
 import grz_pydantic_models.submission.metadata
@@ -41,7 +42,12 @@ def build_cli():
     @click.version_option(
         version=version("grz-cli"),
         prog_name="grz-cli",
-        message=f"%(prog)s v%(version)s (currently accepted metadata schema versions: {', '.join(grz_pydantic_models.submission.metadata.get_accepted_versions())})",
+        message=dedent(f"""\
+        %(prog)s v%(version)s
+        Currently accepted metadata schema versions: {", ".join(grz_pydantic_models.submission.metadata.get_accepted_versions())}
+        grz-common v{version("grz-common")}
+        grz-pydantic-models v{version("grz-pydantic-models")}\
+        """),
     )
     @click.option("--log-file", metavar="FILE", type=str, help="Path to log file")
     @click.option(

--- a/packages/grzctl/src/grzctl/cli.py
+++ b/packages/grzctl/src/grzctl/cli.py
@@ -4,6 +4,8 @@ CLI module for handling command-line interface operations for GRZ administrators
 
 import logging
 import logging.config
+import shutil
+import subprocess
 from importlib.metadata import version
 from textwrap import dedent
 
@@ -54,8 +56,13 @@ def build_cli():
         grz-cli v{version("grz-cli")}
         grz-common v{version("grz-common")}
         grz-db v{version("grz-db")}
-        grz-pydantic-models v{version("grz-pydantic-models")}\
-        """),
+        grz-pydantic-models v{version("grz-pydantic-models")}
+        """)
+        + (
+            subprocess.run(["grz-check", "--version"], capture_output=True, text=True).stdout.strip()  # noqa: S603, S607
+            if shutil.which("grz-check") is not None
+            else ""
+        ),
     )
     @click.option("--log-file", metavar="FILE", type=str, help="Path to log file")
     @click.option(

--- a/packages/grzctl/src/grzctl/cli.py
+++ b/packages/grzctl/src/grzctl/cli.py
@@ -5,6 +5,7 @@ CLI module for handling command-line interface operations for GRZ administrators
 import logging
 import logging.config
 from importlib.metadata import version
+from textwrap import dedent
 
 import click
 from grz_cli.commands.encrypt import encrypt
@@ -48,7 +49,13 @@ def build_cli():
     @click.version_option(
         version=version("grzctl"),
         prog_name="grzctl",
-        message="%(prog)s v%(version)s",
+        message=dedent(f"""\
+        %(prog)s v%(version)s
+        grz-cli v{version("grz-cli")}
+        grz-common v{version("grz-common")}
+        grz-db v{version("grz-db")}
+        grz-pydantic-models v{version("grz-pydantic-models")}\
+        """),
     )
     @click.option("--log-file", metavar="FILE", type=str, help="Path to log file")
     @click.option(


### PR DESCRIPTION
Resolves https://github.com/BfArM-MVH/grz-tools/issues/283

Ignoring S603 because it's a [false positive](https://github.com/astral-sh/ruff/issues/4045) and S607 because we cannot use full paths to `grz-check` as it may be installed to a Conda/Pixi environment in any directory.

feat(grzctl): also report grz library versions