### PR TITLE
feat(grz-common): add extra warnings for BAM files

### DIFF
--- a/packages/grz-common/src/grz_common/validation/bam.py
+++ b/packages/grz-common/src/grz_common/validation/bam.py
@@ -30,4 +30,24 @@ def validate_bam(bam_path: str | PathLike) -> Generator[str]:
     if concerning_keys:
         log.warning(f"Detected a header in BAM file '{bam_path}', ensure it contains no private information!")
 
+    secondary_warned = False
+    hard_clipped_warned = False
+    # need until_eof since BAM won't have an index
+    for read in bam_file.fetch(until_eof=True):
+        if not secondary_warned and read.is_secondary:
+            log.warning(
+                f"Detected a secondary alignment in BAM file '{bam_path}'. "
+                "Please consider filtering them to save upload bandwidth and storage space."
+            )
+            secondary_warned = True
+
+        if not hard_clipped_warned and not read.is_secondary:
+            hard_clipped_count = read.get_cigar_stats()[0][5]
+            if hard_clipped_count:
+                log.warning(
+                    f"Detected hard-clipped base(s) in a primary alignment in BAM file '{bam_path}'. "
+                    "This is a loss of information from the raw reads."
+                )
+                hard_clipped_warned = True
+
     yield from errors

--- a/tests/resources/reads/hard_clipped_primary.bam
+++ b/tests/resources/reads/hard_clipped_primary.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b7da5a39e2371dffca3c10eea0c9616de7e84a266156c320bf1efebafecfbec
+size 218

--- a/tests/resources/reads/hard_clipped_primary.sam
+++ b/tests/resources/reads/hard_clipped_primary.sam
@@ -1,0 +1,2 @@
+@SQ	SN:ref	LN:10
+r001	0	ref	1	30	6H5M	*	0	0	TAGGC	*

--- a/tests/resources/reads/secondary.bam
+++ b/tests/resources/reads/secondary.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35f6017584a95f10c442872df34439b622c7b74e03274629246ce4212ba559b0
+size 220

--- a/tests/resources/reads/secondary.sam
+++ b/tests/resources/reads/secondary.sam
@@ -1,0 +1,2 @@
+@SQ	SN:ref	LN:10
+r001	256	ref	1	30	6H5M	*	0	0	TAGGC	*

--- a/tests/test_bam_validation.py
+++ b/tests/test_bam_validation.py
@@ -1,6 +1,7 @@
 """Tests for the bam_validation module."""
 
 import importlib.resources
+import logging
 
 from grz_common.validation.bam import validate_bam
 
@@ -12,4 +13,24 @@ def test_valid_hifi_bam():
     bam_ptr = importlib.resources.files(resources).joinpath("reads", "valid_HiFi.bam")
     with importlib.resources.as_file(bam_ptr) as bam_path:
         errors = list(validate_bam(bam_path))
+    assert len(errors) == 0
+
+
+def test_hard_clipped_primary(caplog):
+    """A warning should be logged if hard-clipped bases are detected in a primary alignment."""
+    bam_ptr = importlib.resources.files(resources).joinpath("reads", "hard_clipped_primary.bam")
+    with importlib.resources.as_file(bam_ptr) as bam_path, caplog.at_level(logging.WARNING):
+        errors = list(validate_bam(bam_path))
+    assert "Detected hard-clipped base(s) in a primary alignment" in caplog.text
+    assert len(errors) == 0
+
+
+def test_secondary(caplog):
+    """A warning should be logged if a secondary alignment is detected."""
+    bam_ptr = importlib.resources.files(resources).joinpath("reads", "secondary.bam")
+    with importlib.resources.as_file(bam_ptr) as bam_path, caplog.at_level(logging.WARNING):
+        errors = list(validate_bam(bam_path))
+    assert "Detected a secondary alignment in BAM" in caplog.text
+    # hard-clipped bases are fine in secondaries
+    assert "Detected hard-clipped base(s) in a primary alignment" not in caplog.text
     assert len(errors) == 0


### PR DESCRIPTION
Detect if hard-clipped bases in primary alignment or if secondary alignments present.

Resolves https://github.com/BfArM-MVH/grz-tools/issues/207