### PR TITLE
test(repo): drop os.environ usage from tests

### DIFF
--- a/tests/cli/test_db.py
+++ b/tests/cli/test_db.py
@@ -1,7 +1,6 @@
 """Tests for the db subcommand."""
 
 import json
-import os
 
 import grzctl.cli
 from click.testing import CliRunner
@@ -11,9 +10,8 @@ def test_db(
     temp_db_config_file_path,
 ):
     env = {"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test"}
-    os.environ.update(env)
 
-    runner = CliRunner(env={"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test"})
+    runner = CliRunner(env=env)
     cli = grzctl.cli.build_cli()
     execute = lambda args: runner.invoke(cli, args, catch_exceptions=False)
 

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -1,7 +1,6 @@
 """Tests for grzctl report."""
 
 import datetime
-import os
 
 import grzctl.cli
 from click.testing import CliRunner
@@ -9,7 +8,6 @@ from click.testing import CliRunner
 
 def test_report_processed(temp_db_config_file_path):
     env = {"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test"}
-    os.environ.update(env)
 
     runner = CliRunner(env=env)
     cli = grzctl.cli.build_cli()


### PR DESCRIPTION
This causes environment leakage across tests because os.environ is global to the whole process and these are unnecessary anyways.
