### PR TITLE
test(repo): change mock submission type to test

### DIFF
--- a/tests/cli/test_pruefbericht.py
+++ b/tests/cli/test_pruefbericht.py
@@ -56,7 +56,7 @@ def bfarm_submit_api(requests_mock):
                 {
                     "SubmittedCase": {
                         "submissionDate": "2024-07-15",
-                        "submissionType": "initial",
+                        "submissionType": "test",
                         "tan": "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000",
                         "submitterId": "260914050",
                         "dataNodeId": "GRZK00007",
@@ -80,7 +80,7 @@ def bfarm_submit_api(requests_mock):
                 {
                     "SubmittedCase": {
                         "submissionDate": "2024-07-15",
-                        "submissionType": "initial",
+                        "submissionType": "test",
                         "tan": "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000001",
                         "submitterId": "260914050",
                         "dataNodeId": "GRZK00007",
@@ -104,7 +104,7 @@ def bfarm_submit_api(requests_mock):
                 {
                     "SubmittedCase": {
                         "submissionDate": "2024-07-15",
-                        "submissionType": "initial",
+                        "submissionType": "test",
                         "tan": "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000",
                         "submitterId": "260914050",
                         "dataNodeId": "GRZK00007",

--- a/tests/mock_files/submissions/valid_submission/metadata/metadata.json
+++ b/tests/mock_files/submissions/valid_submission/metadata/metadata.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq/refs/tags/v1.2.1/GRZ/grz-schema.json",
   "submission": {
     "submissionDate": "2024-07-15",
-    "submissionType": "initial",
+    "submissionType": "test",
     "submitterId": "260914050",
     "labName": "Institute für Humangenetik am Klinikum rechts der Isar",
     "tanG": "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000",


### PR DESCRIPTION
An LE had the idea to set the mock submission type to "test" in case of accidental upload, or testing real uploads, and I agreed this was good now that we have the "test" submission type.