### PR TITLE
feat(grzctl)!: make pruefbericht submission a two step process

### DIFF
--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/__init__.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/__init__.py
@@ -2,4 +2,4 @@ from .v1 import *  # noqa: F403
 
 
 def get_accepted_versions() -> set[str]:
-    return {"1.2.1"}
+    return {"1.2.1", "1.3"}

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -143,12 +143,13 @@ def from_metadata(metadata_file, failed):
 @click.option(
     "--token", help="Access token to try instead of requesting a new one.", envvar="GRZ_PRUEFBERICHT_ACCESS_TOKEN"
 )
+@click.option("--print-token", is_flag=True, help="Print obtained access token to stdout.")
 @click.option(
     "--allow-redacted-tan-g",
     help="Allow submission of a Prüfbericht with a redacted TAN.",
     is_flag=True,
 )
-def submit(pruefbericht_file, config_file, token, allow_redacted_tan_g):
+def submit(pruefbericht_file, config_file, token, print_token, allow_redacted_tan_g):
     with open(pruefbericht_file) as f:
         pruefbericht = Pruefbericht.model_validate_json(f.read())
 
@@ -193,6 +194,6 @@ def submit(pruefbericht_file, config_file, token, allow_redacted_tan_g):
 
     log.info("Prüfbericht submitted successfully.")
 
-    if expiry:
+    if expiry and print_token:
         log.info(f"New token expires at {expiry.isoformat()}")
         click.echo(token)

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -7,7 +7,7 @@ import sys
 
 import click
 import requests
-from grz_common.cli import config_file, output_json, submission_dir
+from grz_common.cli import DIR_R_E, config_file, output_json
 from grz_common.constants import REDACTED_TAN
 from grz_common.workers.submission import Submission
 from grz_pydantic_models.pruefbericht import LibraryType as PruefberichtLibraryType
@@ -115,7 +115,12 @@ def generate():
 
 
 @generate.command("from-submission-dir")
-@submission_dir
+@click.argument(
+    "submission_dir",
+    metavar="PATH",
+    type=DIR_R_E,
+    required=True,
+)
 @output_json
 @fail_or_pass
 def from_submission_dir(submission_dir, output_json, failed):
@@ -130,7 +135,7 @@ def from_submission_dir(submission_dir, output_json, failed):
 
 
 @generate.command("from-metadata")
-@click.option("--metadata-file", type=click.Path(exists=True), required=True, help="Path to metadata file")
+@click.argument("metadata_file", type=click.Path(exists=True))
 @output_json
 @fail_or_pass
 def from_metadata(metadata_file, output_json, failed):

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -121,6 +121,10 @@ def generate():
 )
 @fail_or_pass
 def from_submission_dir(submission_dir, failed):
+    """Generate Prüfbericht from submission directory.
+
+    This is equivalent to `from-metadata ${submission_dir}/metadata/metadata.json`.
+    """
     submission = Submission(metadata_dir=f"{submission_dir}/metadata", files_dir=f"{submission_dir}/files")
     metadata = submission.metadata.content
     pruefbericht = _generate_pruefbericht_from_metadata(metadata, failed)
@@ -131,6 +135,7 @@ def from_submission_dir(submission_dir, failed):
 @click.argument("metadata_file", type=click.Path(exists=True))
 @fail_or_pass
 def from_metadata(metadata_file, failed):
+    """Generate Prüfbericht from metadata.json"""
     with open(metadata_file) as f:
         metadata = GrzSubmissionMetadata.model_validate_json(f.read())
     pruefbericht = _generate_pruefbericht_from_metadata(metadata, failed)

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -104,12 +104,12 @@ def _generate_pruefbericht_from_metadata(metadata: GrzSubmissionMetadata, failed
 
 @click.group()
 def pruefbericht():
-    """Submit a Prüfbericht to BfArM."""
+    """Generate and submit Prüfberichte."""
 
 
 @pruefbericht.group()
 def generate():
-    """Generate a Prüfbericht JSON."""
+    """Generate a Prüfbericht JSON from submission metadata."""
 
 
 @generate.command("from-submission-dir")
@@ -150,6 +150,7 @@ def from_metadata(metadata_file, failed):
     is_flag=True,
 )
 def submit(pruefbericht_file, config_file, token, print_token, allow_redacted_tan_g):
+    """Submit a Prüfbericht JSON to BfArM."""
     with open(pruefbericht_file) as f:
         pruefbericht = Pruefbericht.model_validate_json(f.read())
 

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -161,7 +161,7 @@ def from_metadata(metadata_file, output_json, failed):
     help="Allow submission of a Prüfbericht with a redacted TAN.",
     is_flag=True,
 )
-def submit(pruefbericht_file, config_file, output_json, token, allow_redacted_tan_g):  # noqa: PLR0913
+def submit(pruefbericht_file, config_file, output_json, token, allow_redacted_tan_g):
     with open(pruefbericht_file) as f:
         pruefbericht = Pruefbericht.model_validate_json(f.read())
 

--- a/tests/cli/test_pruefbericht.py
+++ b/tests/cli/test_pruefbericht.py
@@ -71,30 +71,6 @@ def bfarm_submit_api(requests_mock):
         ],
     )
 
-    # valid submission with multiple library types + valid token
-    requests_mock.post(
-        "https://bfarm.localhost/api/upload",
-        match=[
-            responses.matchers.header_matcher({"Authorization": "bearer my_token"}),
-            responses.matchers.json_params_matcher(
-                {
-                    "SubmittedCase": {
-                        "submissionDate": "2024-07-15",
-                        "submissionType": "test",
-                        "tan": "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000001",
-                        "submitterId": "260914050",
-                        "dataNodeId": "GRZK00007",
-                        "diseaseType": "oncological",
-                        "dataCategory": "genomic",
-                        "libraryType": "wgs",
-                        "coverageType": "GKV",
-                        "dataQualityCheckPassed": True,
-                    }
-                }
-            ),
-        ],
-    )
-
     # valid submission + expired token
     requests_mock.post(
         "https://bfarm.localhost/api/upload",

--- a/tests/cli/test_pruefbericht.py
+++ b/tests/cli/test_pruefbericht.py
@@ -123,17 +123,9 @@ def bfarm_submit_api(requests_mock):
     yield requests_mock
 
 
-def test_valid_submission(bfarm_auth_api, bfarm_submit_api, temp_pruefbericht_config_file_path):
+def test_valid_submission(bfarm_auth_api, bfarm_submit_api, temp_pruefbericht_config_file_path, tmp_path):
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
-        args = [
-            "pruefbericht",
-            "--config-file",
-            temp_pruefbericht_config_file_path,
-            "--submission-dir",
-            str(submission_dir),
-        ]
-
         runner = click.testing.CliRunner(
             env={
                 "GRZ_PRUEFBERICHT__AUTHORIZATION_URL": "https://bfarm.localhost/token",
@@ -143,54 +135,110 @@ def test_valid_submission(bfarm_auth_api, bfarm_submit_api, temp_pruefbericht_co
             }
         )
         cli = grzctl.cli.build_cli()
-        result = runner.invoke(cli, args, catch_exceptions=False)
 
-    assert result.exit_code == 0, result.output
+        # generate Prüfbericht JSON
+        pruefbericht_json_path = tmp_path / "pruefbericht.json"
+        generate_args = ["pruefbericht", "generate", "from-submission-dir", str(submission_dir)]
+        generate_result = runner.invoke(cli, generate_args, catch_exceptions=False)
+        assert generate_result.exit_code == 0, generate_result.output
+        pruefbericht_json_path.write_text(generate_result.output)
 
-
-def test_valid_submission_with_json_output(bfarm_auth_api, bfarm_submit_api, temp_pruefbericht_config_file_path):
-    submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
-    with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
-        args = [
+        # submit generated Prüfbericht
+        submit_args = [
             "pruefbericht",
+            "submit",
             "--config-file",
             temp_pruefbericht_config_file_path,
-            "--submission-dir",
-            str(submission_dir),
+            "--pruefbericht-file",
+            str(pruefbericht_json_path),
+        ]
+        submit_result = runner.invoke(cli, submit_args, catch_exceptions=False)
+
+    assert submit_result.exit_code == 0, submit_result.output
+
+
+def test_valid_submission_with_json_output(
+    bfarm_auth_api, bfarm_submit_api, temp_pruefbericht_config_file_path, tmp_path
+):
+    submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
+    with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
+        runner = click.testing.CliRunner(
+            env={
+                "GRZ_PRUEFBERICHT__AUTHORIZATION_URL": "https://bfarm.localhost/token",
+                "GRZ_PRUEFBERICHT__CLIENT_ID": "pytest",
+                "GRZ_PRUEFBERICHT__CLIENT_SECRET": "pysecret",
+                "GRZ_PRUEFBERICHT__API_BASE_URL": "https://bfarm.localhost/api",
+            }
+        )
+        cli = grzctl.cli.build_cli()
+
+        # generate Prüfbericht JSON
+        pruefbericht_json_path = tmp_path / "pruefbericht.json"
+        generate_args = ["pruefbericht", "generate", "from-submission-dir", str(submission_dir)]
+        generate_result = runner.invoke(cli, generate_args, catch_exceptions=False)
+        assert generate_result.exit_code == 0, generate_result.output
+        pruefbericht_json_path.write_text(generate_result.output)
+
+        # submit generated Prüfbericht and ask for JSON output (aka token)
+        submit_args = [
+            "pruefbericht",
+            "submit",
+            "--config-file",
+            temp_pruefbericht_config_file_path,
+            "--pruefbericht-file",
+            str(pruefbericht_json_path),
             "--json",
         ]
+        submit_result = runner.invoke(cli, submit_args, catch_exceptions=False)
 
-        runner = click.testing.CliRunner(
-            env={
-                "GRZ_PRUEFBERICHT__AUTHORIZATION_URL": "https://bfarm.localhost/token",
-                "GRZ_PRUEFBERICHT__CLIENT_ID": "pytest",
-                "GRZ_PRUEFBERICHT__CLIENT_SECRET": "pysecret",
-                "GRZ_PRUEFBERICHT__API_BASE_URL": "https://bfarm.localhost/api",
-            }
-        )
-        cli = grzctl.cli.build_cli()
-        result = runner.invoke(cli, args, catch_exceptions=False)
+    assert submit_result.exit_code == 0, submit_result.output
 
-    assert result.exit_code == 0, result.output
-
-    output = json.loads(result.output)
+    output = json.loads(submit_result.output)
     datetime.datetime.fromisoformat(output["expires"])
     assert output["token"] == "my_token"
 
 
-def test_valid_submission_with_token(bfarm_submit_api, temp_pruefbericht_config_file_path):
+def test_valid_submission_with_token(bfarm_submit_api, temp_pruefbericht_config_file_path, tmp_path):
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
-        args = [
+        runner = click.testing.CliRunner(
+            env={
+                "GRZ_PRUEFBERICHT__AUTHORIZATION_URL": "https://bfarm.localhost/token",
+                "GRZ_PRUEFBERICHT__CLIENT_ID": "pytest",
+                "GRZ_PRUEFBERICHT__CLIENT_SECRET": "pysecret",
+                "GRZ_PRUEFBERICHT__API_BASE_URL": "https://bfarm.localhost/api",
+            }
+        )
+        cli = grzctl.cli.build_cli()
+
+        # generate Prüfbericht JSON
+        pruefbericht_json_path = tmp_path / "pruefbericht.json"
+        generate_args = ["pruefbericht", "generate", "from-submission-dir", str(submission_dir)]
+        generate_result = runner.invoke(cli, generate_args, catch_exceptions=False)
+        assert generate_result.exit_code == 0, generate_result.output
+        pruefbericht_json_path.write_text(generate_result.output)
+
+        # submit generated Prüfbericht with a pre-provided token
+        submit_args = [
             "pruefbericht",
+            "submit",
             "--config-file",
             temp_pruefbericht_config_file_path,
-            "--submission-dir",
-            str(submission_dir),
+            "--pruefbericht-file",
+            str(pruefbericht_json_path),
             "--token",
             "my_token",
         ]
+        submit_result = runner.invoke(cli, submit_args, catch_exceptions=False)
 
+    assert submit_result.exit_code == 0, submit_result.output
+
+
+def test_valid_submission_with_expired_token(
+    bfarm_auth_api, bfarm_submit_api, temp_pruefbericht_config_file_path, tmp_path
+):
+    submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
+    with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
         runner = click.testing.CliRunner(
             env={
                 "GRZ_PRUEFBERICHT__AUTHORIZATION_URL": "https://bfarm.localhost/token",
@@ -200,41 +248,31 @@ def test_valid_submission_with_token(bfarm_submit_api, temp_pruefbericht_config_
             }
         )
         cli = grzctl.cli.build_cli()
-        result = runner.invoke(cli, args, catch_exceptions=False)
 
-    assert result.exit_code == 0, result.output
+        # generate Prüfbericht JSON
+        pruefbericht_json_path = tmp_path / "pruefbericht.json"
+        generate_args = ["pruefbericht", "generate", "from-submission-dir", str(submission_dir)]
+        generate_result = runner.invoke(cli, generate_args, catch_exceptions=False)
+        assert generate_result.exit_code == 0, generate_result.output
+        pruefbericht_json_path.write_text(generate_result.output)
 
-
-def test_valid_submission_with_expired_token(bfarm_auth_api, bfarm_submit_api, temp_pruefbericht_config_file_path):
-    submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
-    with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
-        args = [
+        # (try to) submit generated Prüfbericht with an expired token
+        submit_args = [
             "pruefbericht",
+            "submit",
             "--config-file",
             temp_pruefbericht_config_file_path,
-            "--submission-dir",
-            str(submission_dir),
+            "--pruefbericht-file",
+            str(pruefbericht_json_path),
             "--token",
             "expired_token",
         ]
+        submit_result = runner.invoke(cli, submit_args, catch_exceptions=False)
 
-        runner = click.testing.CliRunner(
-            env={
-                "GRZ_PRUEFBERICHT__AUTHORIZATION_URL": "https://bfarm.localhost/token",
-                "GRZ_PRUEFBERICHT__CLIENT_ID": "pytest",
-                "GRZ_PRUEFBERICHT__CLIENT_SECRET": "pysecret",
-                "GRZ_PRUEFBERICHT__API_BASE_URL": "https://bfarm.localhost/api",
-            }
-        )
-        cli = grzctl.cli.build_cli()
-        result = runner.invoke(cli, args, catch_exceptions=False)
-
-    assert result.exit_code == 0, result.output
+    assert submit_result.exit_code == 0, submit_result.output
 
 
-def test_valid_submission_multiple_library_types(
-    bfarm_auth_api, bfarm_submit_api, temp_pruefbericht_config_file_path, tmp_path
-):
+def test_generate_pruefbericht_multiple_library_types(temp_pruefbericht_config_file_path, tmp_path):
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
         # create and modify a temporary copy of the metadata JSON
@@ -255,29 +293,22 @@ def test_valid_submission_multiple_library_types(
 
         args = [
             "pruefbericht",
-            "--config-file",
-            temp_pruefbericht_config_file_path,
-            "--submission-dir",
+            "generate",
+            "from-submission-dir",
             str(tmp_path),
         ]
 
-        runner = click.testing.CliRunner(
-            env={
-                "GRZ_PRUEFBERICHT__AUTHORIZATION_URL": "https://bfarm.localhost/token",
-                "GRZ_PRUEFBERICHT__CLIENT_ID": "pytest",
-                "GRZ_PRUEFBERICHT__CLIENT_SECRET": "pysecret",
-                "GRZ_PRUEFBERICHT__API_BASE_URL": "https://bfarm.localhost/api",
-            }
-        )
+        runner = click.testing.CliRunner()
         cli = grzctl.cli.build_cli()
         result = runner.invoke(cli, args, catch_exceptions=False)
 
     assert result.exit_code == 0, result.output
+    # Check that the generated Pruefbericht correctly selected the most expensive library type
+    pruefbericht_data = json.loads(result.output)
+    assert pruefbericht_data["SubmittedCase"]["libraryType"] == "wgs"
 
 
-def test_invalid_submission_invalid_library_type(
-    bfarm_auth_api, bfarm_submit_api, temp_pruefbericht_config_file_path, tmp_path
-):
+def test_generate_fails_with_invalid_library_type(temp_pruefbericht_config_file_path, tmp_path):
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
         # create and modify a temporary copy of the metadata JSON
@@ -298,26 +329,18 @@ def test_invalid_submission_invalid_library_type(
 
         args = [
             "pruefbericht",
-            "--config-file",
-            temp_pruefbericht_config_file_path,
-            "--submission-dir",
+            "generate",
+            "from-submission-dir",
             str(tmp_path),
         ]
 
-        runner = click.testing.CliRunner(
-            env={
-                "GRZ_PRUEFBERICHT__AUTHORIZATION_URL": "https://bfarm.localhost/token",
-                "GRZ_PRUEFBERICHT__CLIENT_ID": "pytest",
-                "GRZ_PRUEFBERICHT__CLIENT_SECRET": "pysecret",
-                "GRZ_PRUEFBERICHT__API_BASE_URL": "https://bfarm.localhost/api",
-            }
-        )
+        runner = click.testing.CliRunner()
         cli = grzctl.cli.build_cli()
         result = runner.invoke(cli, args, catch_exceptions=False)
         assert result.exit_code != 0, result.output
 
 
-def test_refuse_redacted_tang(bfarm_auth_api, bfarm_submit_api, temp_pruefbericht_config_file_path, tmp_path):
+def test_refuse_redacted_tang(temp_pruefbericht_config_file_path, tmp_path):
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
         # create and modify a temporary copy of the metadata JSON
@@ -332,14 +355,6 @@ def test_refuse_redacted_tang(bfarm_auth_api, bfarm_submit_api, temp_pruefberich
             json.dump(metadata, metadata_file)
             metadata_file.truncate()
 
-        args = [
-            "pruefbericht",
-            "--config-file",
-            temp_pruefbericht_config_file_path,
-            "--submission-dir",
-            str(tmp_path),
-        ]
-
         runner = click.testing.CliRunner(
             env={
                 "GRZ_PRUEFBERICHT__AUTHORIZATION_URL": "https://bfarm.localhost/token",
@@ -349,5 +364,22 @@ def test_refuse_redacted_tang(bfarm_auth_api, bfarm_submit_api, temp_pruefberich
             }
         )
         cli = grzctl.cli.build_cli()
+
+        # generate Prüfbericht JSON
+        pruefbericht_json_path = tmp_path / "pruefbericht.json"
+        generate_args = ["pruefbericht", "generate", "from-submission-dir", str(tmp_path)]
+        generate_result = runner.invoke(cli, generate_args, catch_exceptions=False)
+        assert generate_result.exit_code == 0, generate_result.output
+        pruefbericht_json_path.write_text(generate_result.output)
+
+        # attempt to submit
+        submit_args = [
+            "pruefbericht",
+            "submit",
+            "--config-file",
+            temp_pruefbericht_config_file_path,
+            "--pruefbericht-file",
+            str(pruefbericht_json_path),
+        ]
         with pytest.raises(ValueError, match="Refusing to submit a Prüfbericht with a redacted TAN"):
-            runner.invoke(cli, args, catch_exceptions=False)
+            runner.invoke(cli, submit_args, catch_exceptions=False)


### PR DESCRIPTION
Resolves #392 

Introduces `grzctl pruefbericht generate` and `grzctl pruefbericht submit`:
```sh
# from submission dir
grzctl pruefbericht generate from-submission-dir $submission_dir > foo.json
# from metadata json
grzctl pruefbericht generate from-metadata $submittion_dir/metadata/metadata.json > foo.json
```
(perhaps we only need either one)
Initially I made use of options, but those were redundant with the subcommand naming, so changed to arguments. That, however, makes it a bit inconsistent with the `submit` subcommand:
```sh
grzctl pruefbericht submit --pruefbericht-file foo.json
```
which does still use the option style for explicitness.