### PR TITLE
fix(grz-pydantic-models): don't generate submission ID from redacted TAN

### DIFF
--- a/packages/grz-common/src/grz_common/constants.py
+++ b/packages/grz-common/src/grz_common/constants.py
@@ -9,5 +9,3 @@ TQDM_DEFAULTS = {
     "smoothing": 0.00001,
     "colour": "cyan",
 }
-
-REDACTED_TAN = "0" * 64

--- a/packages/grz-common/src/grz_common/workers/upload.py
+++ b/packages/grz-common/src/grz_common/workers/upload.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, override
 
 import botocore.handlers
 from boto3.s3.transfer import S3Transfer, TransferConfig  # type: ignore[import-untyped]
-from grz_common.constants import REDACTED_TAN
+from grz_pydantic_models.submission.metadata import REDACTED_TAN
 from tqdm.auto import tqdm
 
 from ..constants import TQDM_DEFAULTS

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -28,6 +28,7 @@ from ...mii.consent import Consent, ProvisionType
 from .versioning import Version
 
 SCHEMA_URL_PATTERN = r"https://raw\.githubusercontent\.com/BfArM-MVH/MVGenomseq/refs/tags/v([0-9]+)\.([0-9]+)(?:\.([0-9]+))?/GRZ/grz-schema\.json"
+REDACTED_TAN = "0" * 64
 
 log = logging.getLogger(__name__)
 
@@ -1072,6 +1073,9 @@ class GrzSubmissionMetadata(StrictBaseModel):
 
         Uses the first 8 characters of the SHA256 hash of the tanG to virtually prevent collisions.
         """
+        if self.submission.tan_g == REDACTED_TAN:
+            raise ValueError("Cannot compute submission ID from metadata with a redacted TAN.")
+
         return "_".join(
             (
                 self.submission.submitter_id,

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -20,7 +20,6 @@ import rich.table
 import rich.text
 import textual.logging
 from grz_common.cli import FILE_R_E, config_file, output_json
-from grz_common.constants import REDACTED_TAN
 from grz_common.logging import LOGGING_DATEFMT, LOGGING_FORMAT
 from grz_db.errors import (
     DatabaseConfigurationError,
@@ -41,6 +40,7 @@ from grz_db.models.submission import (
 )
 from grz_pydantic_models.common import StrictBaseModel
 from grz_pydantic_models.submission.metadata import (
+    REDACTED_TAN,
     GenomicStudySubtype,
     GrzSubmissionMetadata,
     LibraryType,

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -6,11 +6,10 @@ import logging
 import click
 import requests
 from grz_common.cli import DIR_R_E, config_file
-from grz_common.constants import REDACTED_TAN
 from grz_common.workers.submission import Submission
 from grz_pydantic_models.pruefbericht import LibraryType as PruefberichtLibraryType
 from grz_pydantic_models.pruefbericht import Pruefbericht, SubmittedCase
-from grz_pydantic_models.submission.metadata.v1 import GrzSubmissionMetadata
+from grz_pydantic_models.submission.metadata.v1 import REDACTED_TAN, GrzSubmissionMetadata
 from pydantic_core import to_jsonable_python
 
 from ..models.config import PruefberichtConfig

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -12,9 +12,8 @@ import click.testing
 import grzctl.cli
 import pytest
 import yaml
-from grz_common.constants import REDACTED_TAN
 from grz_db.models.submission import SubmissionDb
-from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
+from grz_pydantic_models.submission.metadata import REDACTED_TAN, GrzSubmissionMetadata
 from grzctl.models.config import DbConfig
 
 from .. import resources as test_resources

--- a/tests/cli/test_archive.py
+++ b/tests/cli/test_archive.py
@@ -8,8 +8,7 @@ import shutil
 
 import click.testing
 import grzctl
-from grz_common.constants import REDACTED_TAN
-from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
+from grz_pydantic_models.submission.metadata import REDACTED_TAN, GrzSubmissionMetadata
 
 from .. import mock_files
 

--- a/tests/cli/test_pruefbericht.py
+++ b/tests/cli/test_pruefbericht.py
@@ -10,7 +10,7 @@ import click.testing
 import grzctl.cli
 import pytest
 import responses
-from grz_common.constants import REDACTED_TAN
+from grz_pydantic_models.submission.metadata import REDACTED_TAN
 
 from .. import mock_files
 


### PR DESCRIPTION
Also refactors the REDACTED_TAN constant to be in grz-pydantic-models instead of grz-common.