### PR TITLE
fix(grz-pydantic-models): more conservative "deny" provisions for multiple codes

### DIFF
--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -347,11 +347,10 @@ class ResearchConsent(StrictBaseModel):
                     for codeable_concept in provision.code:
                         for coding in codeable_concept.coding:
                             if provision.type == ProvisionType.PERMIT:
-                                code2consent[coding.code] = True
+                                code2consent[coding.code] = code2consent.get(coding.code, True)  # propagate prior deny
                             else:
                                 # explicit deny overrides any prior/later permits for code
                                 code2consent[coding.code] = False
-                                break
         return code2consent
 
     @staticmethod


### PR DESCRIPTION
This change should be mostly moot. Only in the case where within the same Consent two provisions with identical codes show up (one with deny and one with permit) would the deny now count (regardless of order) (therefore the check on existing code2consent content for coding.code). Also if within a codeable concept different codings are listed - each should show up in case of a deny (therefore no break).

