### PR TITLE
fix(grz-pydantic-models): ignore optional fields in required consent scope/category

### DIFF
--- a/packages/grz-pydantic-models/tests/resources/example_research_consent/extra_consented.json
+++ b/packages/grz-pydantic-models/tests/resources/example_research_consent/extra_consented.json
@@ -1,0 +1,77 @@
+{
+  "status": "active",
+  "scope": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/consentscope",
+        "version": "0",
+        "code": "research",
+        "display": "Research",
+        "userSelected": false
+      }
+    ],
+    "text": "extra"
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "version": "0",
+          "code": "57016-8",
+          "display": "LOINC",
+          "userSelected": false
+        }
+      ],
+      "text": "extra"
+    },
+    {
+      "coding": [
+        {
+          "system": "https://www.medizininformatik-initiative.de/fhir/modul-consent/CodeSystem/mii-cs-consent-consent_category",
+          "version": "0",
+          "code": "2.16.840.1.113883.3.1937.777.24.2.184",
+          "display": "MII",
+          "userSelected": true
+        }
+      ],
+      "text": "extra"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/9b4a702d-162c-428a-8c5d-8b98af21b693"
+  },
+  "dateTime": "2020-09-01",
+  "policy": [
+    {
+      "uri": "urn:oid:2.16.840.1.113883.3.1937.777.24.2.1791"
+    }
+  ],
+  "provision": {
+    "type": "deny",
+    "period": {
+      "start": "2020-09-01",
+      "end": "2050-08-31"
+    },
+    "provision": [
+      {
+        "code": [
+          {
+            "coding": [
+              {
+                "system": "urn:oid:2.16.840.1.113883.3.1937.777.24.5.3",
+                "code": "2.16.840.1.113883.3.1937.777.24.5.3.1",
+                "display": "PATDAT_erheben_speichern_nutzen"
+              }
+            ]
+          }
+        ],
+        "type": "permit",
+        "period": {
+          "start": "2020-09-01",
+          "end": "2025-08-31"
+        }
+      }
+    ]
+  }
+}

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -177,6 +177,7 @@ def test_file_extensions():
     "case,valid",
     (
         ("minimal_consented", True),
+        ("extra_consented", True),
         ("minimal_nonconsented", True),
         ("minimal_consented_expired", True),
         ("mii_ig_consent_v2025_example1", True),


### PR DESCRIPTION
Consent profiles that have optional, but allowed, attributes like `display` set in the required scope/categories would fail validation before this fix.