### PR TITLE
fix(grz-common): resolve KeyError with long-read submissions

### DIFF
--- a/packages/grz-common/src/grz_common/workers/submission.py
+++ b/packages/grz-common/src/grz_common/workers/submission.py
@@ -244,7 +244,7 @@ class Submission:
                         lab_data.sequence_subtype,
                     )
                 ]
-                mean_read_length_threshold = thresholds["meanReadLength"]
+                mean_read_length_threshold = thresholds.get("meanReadLength", None)
 
                 sequence_data = lab_data.sequence_data
                 fastq_files = [f for f in sequence_data.files if f.file_type == FileType.fastq]


### PR DESCRIPTION
Long-read submissions don't have the minimum mean read length requirement defined so we need to handle that properly.