### PR TITLE
fix(grz-common): meanReadLength param None vs 0

### DIFF
--- a/packages/grz-common/src/grz_common/workers/submission.py
+++ b/packages/grz-common/src/grz_common/workers/submission.py
@@ -244,7 +244,7 @@ class Submission:
                         lab_data.sequence_subtype,
                     )
                 ]
-                mean_read_length_threshold = thresholds.get("meanReadLength", None)
+                mean_read_length_threshold = thresholds.get("meanReadLength", 0)
 
                 sequence_data = lab_data.sequence_data
                 fastq_files = [f for f in sequence_data.files if f.file_type == FileType.fastq]


### PR DESCRIPTION
For long read data, the mean read length check is ignored; the correct respective parameter for grz-check is `0`, not `None`.