### PR TITLE
fix(grzctl): bump grz-common dependency for new functionality

### DIFF
--- a/packages/grzctl/pyproject.toml
+++ b/packages/grzctl/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "rich ==13.*",
     "requests >=2.32.3,<3",
     "grz-db >=1.1.0,<2",
-    "grz-common >=1.4.0,<2",
+    "grz-common >=1.5.0,<2",
     "grz-cli >=1.3,<2",
     "grz-pydantic-models >=2.4,<3",
     "textual~=5.3"


### PR DESCRIPTION
grzctl relies on the new inbox summary API of grz-common 1.5.0 but forgot to bump.
