### PR TITLE
fix(grz-common,grz-cli): Do not resolve grz-check paths

### DIFF
--- a/packages/grz-common/src/grz_common/workers/submission.py
+++ b/packages/grz-common/src/grz_common/workers/submission.py
@@ -348,7 +348,7 @@ class Submission:
                 if not file_path_str:
                     continue
 
-                file_path = Path(file_path_str).resolve()
+                file_path = Path(file_path_str)
                 file_metadata = self.files.get(file_path)
 
                 if not file_metadata:

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -122,11 +122,7 @@ def test_validate_submission_incorrect_grz_id(
 
 @pytest.mark.parametrize("grz_check_flag", ["--with-grz-check", "--no-grz-check"])
 def test_validate_submission_with_symlink(
-    temp_identifiers_config_file_path,
-    working_dir_path,
-    grz_check_flag,
-    caplog,
-    chdir
+    temp_identifiers_config_file_path, working_dir_path, grz_check_flag, caplog, chdir
 ):
     """
     Tests that the validation can handle relative symlinked files correctly.

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -100,3 +100,110 @@ def test_validate_submission_incorrect_grz_id(
     assert "does not match genomic data center identifier" in str(exc)
 
     assert result.exit_code == 1, result.output
+
+
+@pytest.mark.parametrize("grz_check_flag", ["--with-grz-check", "--no-grz-check"])
+def test_validate_submission_with_symlink(
+    temp_identifiers_config_file_path,
+    working_dir_path,
+    grz_check_flag,
+    caplog,
+):
+    """
+    Tests that the validation can handle symlinked files correctly.
+    """
+    have_grz_check = shutil.which("grz-check") is not None
+
+    if (grz_check_flag == "--with-grz-check") and not have_grz_check:
+        pytest.skip(reason="grz-check not installed")
+
+    # setup dir for original files (with a name other than "files", just to make sure)
+    source_data_dir = working_dir_path / "source_data"
+    source_data_dir.mkdir()
+
+    submission_dir = Path("tests/mock_files/submissions/valid_submission")
+    mock_files_dir = submission_dir / "files"
+    submission_files_dir = working_dir_path / "files"
+
+    # copy mock files to _source_ directory
+    shutil.copytree(mock_files_dir, source_data_dir, dirs_exist_ok=True)
+
+    # create actual submission dir which should contain symlinks
+    submission_files_dir.mkdir()
+
+    # create symlinks (from submission 'files/' to 'source_data/')
+    for real_file in source_data_dir.iterdir():
+        link_path = submission_files_dir / real_file.name
+        link_path.symlink_to(real_file.resolve())
+
+    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+
+    testargs = [
+        "validate",
+        "--config-file",
+        temp_identifiers_config_file_path,
+        "--submission-dir",
+        str(working_dir_path),
+        grz_check_flag,
+    ]
+
+    runner = CliRunner()
+    cli = grz_cli.cli.build_cli()
+    with caplog.at_level(logging.INFO):
+        result = runner.invoke(cli, testargs, catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+
+        if grz_check_flag == "--no-grz-check":
+            assert "Starting checksum validation (fallback)..." in caplog.text
+        else:
+            assert "Starting file validation with `grz-check`..." in caplog.text
+
+
+@pytest.mark.parametrize("grz_check_flag", ["--with-grz-check", "--no-grz-check"])
+def test_validate_submission_with_broken_symlink(
+    grz_check_flag,
+    temp_identifiers_config_file_path,
+    working_dir_path,
+):
+    """
+    Tests that the validation fails with a broken symlink.
+    """
+    have_grz_check = shutil.which("grz-check") is not None
+
+    if (grz_check_flag == "--with-grz-check") and not have_grz_check:
+        pytest.skip(reason="grz-check not installed")
+
+    submission_dir = Path("tests/mock_files/submissions/valid_submission")
+    submission_files_dir = working_dir_path / "files"
+
+    submission_files_dir.mkdir()
+
+    broken_link_path = submission_files_dir / "broken_link.bed"
+    broken_link_path.symlink_to("non_existent.bed")
+
+    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+
+    metadata_path = working_dir_path / "metadata" / "metadata.json"
+    with open(metadata_path, "r+") as f:
+        metadata = json.load(f)
+        first = metadata["donors"][0]["labData"][0]["sequenceData"]["files"][0]
+        first["filePath"] = "broken_link.bed"
+        f.seek(0)
+        json.dump(metadata, f)
+        f.truncate()
+
+    testargs = [
+        "validate",
+        "--config-file",
+        temp_identifiers_config_file_path,
+        "--submission-dir",
+        str(working_dir_path),
+        grz_check_flag
+    ]
+
+    runner = CliRunner()
+    cli = grz_cli.cli.build_cli()
+    result = runner.invoke(cli, testargs, catch_exceptions=True)
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, SubmissionValidationError)


### PR DESCRIPTION
When using symlinks, paths may resolve to different locations, in which case the `self.files` mapping hasn't seen these keys before, as it expects paths to be relative to the `files/` dir.
