### PR TITLE
fix(grz-check): add minimum required rust version to package definition

### DIFF
--- a/packages/grz-check/Cargo.toml
+++ b/packages/grz-check/Cargo.toml
@@ -2,6 +2,7 @@
 name = "grz-check"
 version = "0.2.0"
 edition = "2024"
+rust-version = "1.88"
 license = "MIT"
 description = "grz-check is a tool for validating incoming files of Modellvorhaben §64e submissions to Genomrechenzentren (GRZ) in Germany."
 homepage = "https://github.com/BfArM-MVH/grz-tools/tree/main/packages/grz-check"


### PR DESCRIPTION
fix(grz-check): add minimum required rust version to pacakge definition

Resolves #456 