### PR TITLE
fix(grz-db): fix relation SQL Enum values

### DIFF
--- a/packages/grz-db/src/grz_db/migrations/versions/fb3df229a77b_initial_quartalsbericht_support.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/fb3df229a77b_initial_quartalsbericht_support.py
@@ -40,7 +40,7 @@ def upgrade() -> None:
         ),
         sa.Column(
             "relation",
-            sa.Enum("mother", "father", "brother", "sister", "child", "index", "other", name="relation"),
+            sa.Enum("mother", "father", "brother", "sister", "child", "index_", "other", name="relation"),
             nullable=False,
         ),
         sa.Column("library_types", AutoString(), nullable=False),

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -292,11 +292,11 @@ class Donor(SQLModel, table=True):
 
     submission_id: str = Field(foreign_key="submissions.id", primary_key=True)
     pseudonym: str = Field(primary_key=True)
-    # use values_callable so enum value is stored instead of name.
-    # SQLite stores string of value instead of name because it doesn't have
-    # native Enum support, so this keeps things consistent with other SQL
-    # server implementations.
-    relation: Relation = Field(sa_column=Column(Enum(Relation, values_callable=lambda e: [x.value for x in e])))
+    # use values_callable so enum name is explicitly stored across all
+    # dialects. SQLite stores string of member name without any enforcement on
+    # values because it doesn't have native Enum support, so this keeps things
+    # consistent with other SQL server implementations.
+    relation: Relation = Field(sa_column=Column(Enum(Relation, values_callable=lambda e: [x.name for x in e])))
     library_types: set[LibraryType] = Field(sa_column=Column(SemicolonSeparatedStringSet))
     sequence_types: set[SequenceType] = Field(sa_column=Column(SemicolonSeparatedStringSet))
     sequence_subtypes: set[SequenceSubtype] = Field(sa_column=Column(SemicolonSeparatedStringSet))


### PR DESCRIPTION
We have been storing the string "index_" in the SQLite database this entire time but SQLite doesn't support Enums so this wasn't caught until testing with Postgres. We need to use "index_" as the value now to ensure existing databases continue to work.