### PR TITLE
fix(grz-pydantic-models): quality_threshold type: should be an integer

### DIFF
--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/thresholds/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/thresholds/v1.py
@@ -16,7 +16,7 @@ __all__ = [
 class PercentBasesAboveQualityThreshold(StrictBaseModel):
     """Fraction of bases above a given base quality threshold."""
 
-    quality_threshold: Annotated[float, Field(strict=True, ge=0.0)]
+    quality_threshold: Annotated[int, Field(strict=True, ge=0)]
     percent_bases_above: Annotated[float, Field(strict=True, ge=0.0, le=100.0)]
 
 


### PR DESCRIPTION
Currently, `quality_threshold` is defined as a float. Should be an integer, however.