### PR TITLE
feat(grzctl): Make 'identifiers.le' config optional for 'grzctl report' command

### DIFF
--- a/packages/grzctl/src/grzctl/models/config.py
+++ b/packages/grzctl/src/grzctl/models/config.py
@@ -1,9 +1,9 @@
 from typing import Annotated
 
-from grz_common.models.base import IgnoringBaseSettings
-from grz_common.models.identifiers import IdentifiersConfigModel
+from grz_common.models.base import IgnoringBaseModel, IgnoringBaseSettings
 from grz_common.models.keys import KeyConfigModel
 from grz_common.models.s3 import S3ConfigModel
+from grz_pydantic_models.submission.metadata import GenomicDataCenterId
 from pydantic import Field
 
 from .db import DbModel
@@ -34,8 +34,13 @@ class DbConfig(IgnoringBaseSettings):
     db: DbModel
 
 
-class ReportConfig(DbConfig, IdentifiersConfigModel):
-    pass
+class ReportIdentifiersConfigModel(IgnoringBaseModel):
+    grz: GenomicDataCenterId
+    """Id of the GRZ."""
+
+
+class ReportConfig(DbConfig):
+    identifiers: ReportIdentifiersConfigModel
 
 
 class ListConfig(S3ConfigModel):

--- a/packages/grzctl/tests/cli/test_report.py
+++ b/packages/grzctl/tests/cli/test_report.py
@@ -44,7 +44,6 @@ def test_quarterly_empty(blank_database_config_path: Path, tmp_path: Path):
     env = {
         "GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test",
         "GRZ_IDENTIFIERS__GRZ": "GRZX00000",
-        "GRZ_IDENTIFIERS__LE": "999999999",
     }
 
     runner = CliRunner(env=env)
@@ -68,7 +67,6 @@ def test_quarterly(blank_database_config_path: Path, tmp_path: Path):
     env = {
         "GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test",
         "GRZ_IDENTIFIERS__GRZ": "GRZX00000",
-        "GRZ_IDENTIFIERS__LE": "999999999",
     }
 
     runner = CliRunner(env=env)
@@ -423,7 +421,6 @@ def test_quarterly_migrated_database(blank_database_config_path: Path, tmp_path:
     env = {
         "GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test",
         "GRZ_IDENTIFIERS__GRZ": "GRZX00000",
-        "GRZ_IDENTIFIERS__LE": "999999999",
     }
 
     runner = CliRunner(env=env)


### PR DESCRIPTION
`grzctl report` is not LE-specific. Therefore, remove it from required keys.