### PR TITLE
feat(grz-check): Generalize from `File` to `impl Read`

### DIFF
--- a/packages/grz-check/src/checker.rs
+++ b/packages/grz-check/src/checker.rs
@@ -175,7 +175,7 @@ impl DataSource {
 
 fn filename(path: impl AsRef<Path>) -> String {
     path.as_ref()
-        .file_name()
+        .canonicalize()
         .unwrap_or_default()
         .to_string_lossy()
         .to_string()

--- a/packages/grz-check/src/checker.rs
+++ b/packages/grz-check/src/checker.rs
@@ -13,7 +13,7 @@ use std::fmt;
 use std::fs;
 use std::io::{BufWriter, Write};
 use std::os::unix::fs::MetadataExt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -692,6 +692,7 @@ mod tests {
     use noodles::sam::{Header, header::record::value::Map};
     use serde::Deserialize;
     use std::io::{BufRead, BufReader, Write};
+    use std::path::PathBuf;
     use tempfile::tempdir;
 
     fn create_gzipped_fastq(path: &Path, content: &str) -> Result<()> {

--- a/packages/grz-check/src/checker.rs
+++ b/packages/grz-check/src/checker.rs
@@ -343,7 +343,7 @@ fn add_progress_bar(
     style: &mut ProgressStyle,
     input: &DataSource,
 ) -> ProgressBar {
-    let pb = if let Some(size) = input.size {
+    if let Some(size) = input.size {
         let pb = m.add(ProgressBar::new(size));
         pb.set_style(style.clone());
         pb
@@ -352,8 +352,7 @@ fn add_progress_bar(
         let spinner_style = ProgressStyle::default_spinner();
         pb.set_style(spinner_style);
         pb
-    };
-    pb
+    }
 }
 
 fn finish_pb(pb: ProgressBar, name: &str, report: &FileReport) {

--- a/packages/grz-check/src/checks/bam.rs
+++ b/packages/grz-check/src/checks/bam.rs
@@ -1,13 +1,12 @@
-use crate::checker::{FileReport, Stats};
-use crate::checks::common::{CheckOutcome, check_file};
+use crate::checker::{DataSource, FileReport, Stats};
+use crate::checks::common::{CheckOutcome, check_data};
 use indicatif::ProgressBar;
 use noodles::bam;
 use noodles::sam::alignment::record::cigar::op::Kind;
 use std::io::BufReader;
-use std::path::{Path, PathBuf};
 
-pub fn check_bam(path: &Path, file_pb: &ProgressBar, global_pb: &ProgressBar) -> FileReport {
-    check_file(path, file_pb, global_pb, false, |reader| {
+pub fn check_bam(input: DataSource, file_pb: &ProgressBar, global_pb: &ProgressBar) -> FileReport {
+    check_data(input, file_pb, global_pb, false, |reader| {
         let mut bam_reader = bam::io::Reader::new(BufReader::new(reader));
         let header = match bam_reader.read_header() {
             Ok(h) => h,
@@ -97,6 +96,5 @@ pub fn check_bam(path: &Path, file_pb: &ProgressBar, global_pb: &ProgressBar) ->
 
 #[derive(Debug)]
 pub struct BamCheckJob {
-    pub path: PathBuf,
-    pub size: u64,
+    pub input: DataSource,
 }

--- a/packages/grz-check/src/checks/fastq.rs
+++ b/packages/grz-check/src/checks/fastq.rs
@@ -1,11 +1,10 @@
-use crate::checker::{FileReport, Stats};
-use crate::checks::common::{CheckOutcome, check_file};
+use crate::checker::{DataSource, FileReport, Stats};
+use crate::checks::common::{CheckOutcome, check_data};
 use indicatif::ProgressBar;
 use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::Itertools;
 use noodles::fastq;
 use std::io::{BufReader, Read};
-use std::path::{Path, PathBuf};
 
 #[derive(Debug, Copy, Clone)]
 pub enum ReadLengthCheck {
@@ -15,18 +14,15 @@ pub enum ReadLengthCheck {
 
 #[derive(Debug)]
 pub struct SingleFastqJob {
-    pub path: PathBuf,
+    pub input: DataSource,
     pub length_check: ReadLengthCheck,
-    pub size: u64,
 }
 
 #[derive(Debug)]
 pub struct PairedFastqJob {
-    pub fq1_path: PathBuf,
-    pub fq2_path: PathBuf,
+    pub input1: DataSource,
+    pub input2: DataSource,
     pub length_check: ReadLengthCheck,
-    pub fq1_size: u64,
-    pub fq2_size: u64,
 }
 
 struct FastqCheckProcessor {
@@ -114,12 +110,12 @@ impl FastqCheckProcessor {
 }
 
 pub fn check_single_fastq(
-    path: &Path,
+    input: DataSource,
     length_check: ReadLengthCheck,
     file_pb: &ProgressBar,
     global_pb: &ProgressBar,
 ) -> FileReport {
-    check_file(path, file_pb, global_pb, true, |reader| {
+    check_data(input, file_pb, global_pb, true, |reader| {
         let mut fastq_reader = fastq::io::Reader::new(BufReader::new(reader));
         let mut processor = FastqCheckProcessor::new(length_check);
 

--- a/packages/grz-check/src/checks/raw.rs
+++ b/packages/grz-check/src/checks/raw.rs
@@ -1,11 +1,10 @@
-use crate::checker::FileReport;
-use crate::checks::common::{CheckOutcome, check_file};
+use crate::checker::{DataSource, FileReport};
+use crate::checks::common::{CheckOutcome, check_data};
 use indicatif::ProgressBar;
 use std::io;
-use std::path::{Path, PathBuf};
 
-pub fn check_raw(path: &Path, file_pb: &ProgressBar, global_pb: &ProgressBar) -> FileReport {
-    check_file(path, file_pb, global_pb, false, |reader| {
+pub fn check_raw(input: DataSource, file_pb: &ProgressBar, global_pb: &ProgressBar) -> FileReport {
+    check_data(input, file_pb, global_pb, false, |reader| {
         match io::copy(reader, &mut io::sink()) {
             Ok(_) => Ok(CheckOutcome::default()),
             Err(e) => Err(format!("Failed to read file: {e}")),
@@ -15,6 +14,5 @@ pub fn check_raw(path: &Path, file_pb: &ProgressBar, global_pb: &ProgressBar) ->
 
 #[derive(Debug)]
 pub struct RawJob {
-    pub path: PathBuf,
-    pub size: u64,
+    pub input: DataSource,
 }


### PR DESCRIPTION
This PR adapts grz-check to operate on anything that implements `Read`.
i.e., "path" changes to "name" (and downstream users such as `grz-cli`/`grzctl` that parse the report will have to check for "name" instead of "path").
Should make upcoming pyO3 bindings more convenient.