### PR TITLE
chore(repo): allow deps scope

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -26,6 +26,7 @@ jobs:
             grz-check
             repo
             release
+            deps
             other
           requireScope: true
         env:


### PR DESCRIPTION
… so that dependabot updates don't fail PR title format check