### PR TITLE
feat(grzctl): implement Prüfbericht generation using submission ID from database

### DIFF
--- a/packages/grz-pydantic-models/src/grz_pydantic_models/pruefbericht/v0.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/pruefbericht/v0.py
@@ -26,6 +26,9 @@ class DataCategory(enum.StrEnum):
     genomic = "genomic"
 
 
+import enum
+
+
 class LibraryType(enum.StrEnum):
     """Sequencing method, if applicable."""
 
@@ -34,6 +37,42 @@ class LibraryType(enum.StrEnum):
     wgs = "wgs"
     wgs_lr = "wgs_lr"
     none = "none"
+
+    @property
+    def reimbursement_priority(self) -> int:
+        """Reimbursement priority — higher value = more expensive."""
+        priorities = {
+            LibraryType.none: 0,
+            LibraryType.panel: 1,
+            LibraryType.wes: 2,
+            LibraryType.wgs: 3,
+            LibraryType.wgs_lr: 4,
+        }
+        return priorities[self]
+
+    @classmethod
+    def most_expensive(cls, library_types: set[str]) -> "LibraryType":
+        """
+        Return the LibraryType with the highest reimbursement value from a set of strings.
+
+        Args:
+            library_types: Set of library type strings.
+
+        Returns:
+            The LibraryType with the highest reimbursement priority.
+
+        Raises:
+            ValueError: If no valid LibraryType values are found in the input set.
+        """
+        valid_types = {cls(lt) for lt in library_types if lt in cls._value2member_map_}
+
+        if not valid_types:
+            raise ValueError(
+                f"Submission contained ONLY library types ({', '.join(library_types)}) that cannot be "
+                f"submitted in the Prüfbericht. Valid types are: {', '.join(cls._value2member_map_)}."
+            )
+
+        return max(valid_types, key=lambda lt: lt.reimbursement_priority)
 
 
 class SubmittedCase(StrictBaseModel):

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -63,30 +63,7 @@ def _submit_pruefbericht(base_url: str, token: str, pruefbericht: Pruefbericht):
 
 
 def _get_most_expensive_library_type(library_types: set[str]) -> PruefberichtLibraryType:
-    """
-    Determine the library type with the highest reimbursement value from a set of library type strings.
-
-    Args:
-        library_types: Set of library type strings
-
-    Returns:
-        The PruefberichtLibraryType with the highest reimbursement value
-    """
-    pruefbericht_library_types = {
-        str(PruefberichtLibraryType(library_type))
-        for library_type in library_types
-        if library_type in PruefberichtLibraryType
-    }
-
-    if not pruefbericht_library_types:
-        raise ValueError(
-            f"Submission contained ONLY library types ({', '.join(library_types)}) that cannot be submitted in the Prüfbericht. "
-            f"Valid types are {', '.join(PruefberichtLibraryType)}."
-        )
-
-    # enums sort by their definition order
-    most_expensive_library_type = sorted(pruefbericht_library_types)[-1]
-    return PruefberichtLibraryType(most_expensive_library_type)
+    return PruefberichtLibraryType.most_expensive(library_types)
 
 
 def get_pruefbericht_library_type(metadata: GrzSubmissionMetadata) -> PruefberichtLibraryType:

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -62,10 +62,6 @@ def _submit_pruefbericht(base_url: str, token: str, pruefbericht: Pruefbericht):
         response.raise_for_status()
 
 
-def _get_most_expensive_library_type(library_types: set[str]) -> PruefberichtLibraryType:
-    return PruefberichtLibraryType.most_expensive(library_types)
-
-
 def get_pruefbericht_library_type(metadata: GrzSubmissionMetadata) -> PruefberichtLibraryType:
     """
     Determine the singular representative library type of a submission to submit with the Prüfbericht.
@@ -73,7 +69,7 @@ def get_pruefbericht_library_type(metadata: GrzSubmissionMetadata) -> Pruefberic
     """
     index_patient = metadata.index_donor
     index_patient_submission_library_types = {str(datum.library_type) for datum in index_patient.lab_data}
-    return _get_most_expensive_library_type(index_patient_submission_library_types)
+    return PruefberichtLibraryType.most_expensive(index_patient_submission_library_types)
 
 
 def _generate_pruefbericht_from_metadata(metadata: GrzSubmissionMetadata, failed: bool) -> Pruefbericht:
@@ -136,7 +132,7 @@ def _generate_pruefbericht_from_database(
     # Convert database library_types to strings and determine most expensive type
     index_donor_library_types = {str(lt.value if hasattr(lt, "value") else lt) for lt in index_donor.library_types}
 
-    library_type = _get_most_expensive_library_type(index_donor_library_types)
+    library_type = PruefberichtLibraryType.most_expensive(index_donor_library_types)
 
     # Generate the Prüfbericht
     return Pruefbericht(

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -8,14 +8,14 @@ import click
 import grz_common.cli as grzcli
 import requests
 from grz_common.workers.submission import Submission
-from grz_db.models.submission import SubmissionStateEnum
-from grz_pydantic_models.pruefbericht import LibraryType as PruefberichtLibraryType
-from grz_pydantic_models.pruefbericht import Pruefbericht, SubmittedCase
-from grz_pydantic_models.submission.metadata.v1 import REDACTED_TAN, GrzSubmissionMetadata
+from grz_db.models.submission import SubmissionDb, SubmissionStateEnum
+from grz_pydantic_models.pruefbericht.v0 import LibraryType as PruefberichtLibraryType
+from grz_pydantic_models.pruefbericht.v0 import Pruefbericht, SubmittedCase
+from grz_pydantic_models.submission.metadata.v1 import REDACTED_TAN, GrzSubmissionMetadata, Relation
 from pydantic_core import to_jsonable_python
 
 from ..dbcontext import DbContext
-from ..models.config import PruefberichtConfig
+from ..models.config import DbConfig, PruefberichtConfig
 
 log = logging.getLogger(__name__)
 fail_or_pass = click.option(
@@ -62,29 +62,41 @@ def _submit_pruefbericht(base_url: str, token: str, pruefbericht: Pruefbericht):
         response.raise_for_status()
 
 
+def _get_most_expensive_library_type(library_types: set[str]) -> PruefberichtLibraryType:
+    """
+    Determine the library type with the highest reimbursement value from a set of library type strings.
+
+    Args:
+        library_types: Set of library type strings
+
+    Returns:
+        The PruefberichtLibraryType with the highest reimbursement value
+    """
+    pruefbericht_library_types = {
+        str(PruefberichtLibraryType(library_type))
+        for library_type in library_types
+        if library_type in PruefberichtLibraryType
+    }
+
+    if not pruefbericht_library_types:
+        raise ValueError(
+            f"Submission contained ONLY library types ({', '.join(library_types)}) that cannot be submitted in the Prüfbericht. "
+            f"Valid types are {', '.join(PruefberichtLibraryType)}."
+        )
+
+    # enums sort by their definition order
+    most_expensive_library_type = sorted(pruefbericht_library_types)[-1]
+    return PruefberichtLibraryType(most_expensive_library_type)
+
+
 def get_pruefbericht_library_type(metadata: GrzSubmissionMetadata) -> PruefberichtLibraryType:
     """
     Determine the singular representative library type of a submission to submit with the Prüfbericht.
     This should be library type of the index patient with the highest reimbursement value.
     """
     index_patient = metadata.index_donor
-
     index_patient_submission_library_types = {str(datum.library_type) for datum in index_patient.lab_data}
-
-    index_patient_pruefbericht_library_types = {
-        str(PruefberichtLibraryType(library_type))
-        for library_type in index_patient_submission_library_types
-        if library_type in PruefberichtLibraryType
-    }
-    if not index_patient_pruefbericht_library_types:
-        raise ValueError(
-            f"Submission contained ONLY library types ({', '.join(index_patient_submission_library_types)}) that cannot be submitted in the Prüfbericht. "
-            f"Valid types are {', '.join(PruefberichtLibraryType)}."
-        )
-    # enums sort by their definition order
-    most_expensive_library_type = sorted(index_patient_pruefbericht_library_types)[-1]
-
-    return PruefberichtLibraryType(most_expensive_library_type)
+    return _get_most_expensive_library_type(index_patient_submission_library_types)
 
 
 def _generate_pruefbericht_from_metadata(metadata: GrzSubmissionMetadata, failed: bool) -> Pruefbericht:
@@ -99,6 +111,68 @@ def _generate_pruefbericht_from_metadata(metadata: GrzSubmissionMetadata, failed
             dataCategory="genomic",
             libraryType=get_pruefbericht_library_type(metadata),
             coverageType=metadata.submission.coverage_type,
+            dataQualityCheckPassed=not failed,
+        )
+    )
+
+
+def _generate_pruefbericht_from_database(
+    submission_id: str, configuration: dict[str, Any], failed: bool
+) -> Pruefbericht:
+    """Generate Prüfbericht by fetching submission data from the database."""
+    config = DbConfig.model_validate(configuration)
+
+    if not config.db.database_url:
+        raise ValueError("database_url must be provided in configuration to fetch from database")
+
+    db = SubmissionDb(db_url=str(config.db.database_url), author=None, debug=False)
+    submission = db.get_submission(submission_id)
+
+    if submission is None:
+        raise ValueError(f"Submission with ID '{submission_id}' not found in database")
+
+    # Check if submission has the required fields populated
+    required_fields = [
+        "submission_date",
+        "submission_type",
+        "tan_g",
+        "submitter_id",
+        "data_node_id",
+        "disease_type",
+        "coverage_type",
+    ]
+
+    missing_fields = [field for field in required_fields if getattr(submission, field) is None]
+    if missing_fields:
+        raise ValueError(f"Submission {submission_id} is missing required fields: {', '.join(missing_fields)}")
+
+    # Get donors to determine library types
+    donors = db.get_donors(submission_id)
+    if not donors:
+        raise ValueError(f"No donors found for submission {submission_id}")
+
+    # Find index donor
+    index_donor = next((d for d in donors if d.relation == Relation.index_), None)
+    if index_donor is None:
+        raise ValueError(f"No index donor found for submission {submission_id}")
+
+    # Convert database library_types to strings and determine most expensive type
+    index_donor_library_types = {str(lt.value if hasattr(lt, "value") else lt) for lt in index_donor.library_types}
+
+    library_type = _get_most_expensive_library_type(index_donor_library_types)
+
+    # Generate the Prüfbericht
+    return Pruefbericht(
+        SubmittedCase=SubmittedCase(
+            submissionDate=submission.submission_date,
+            submissionType=submission.submission_type,
+            tan=submission.tan_g,
+            submitterId=submission.submitter_id,
+            dataNodeId=submission.data_node_id,
+            diseaseType=submission.disease_type,
+            dataCategory="genomic",
+            libraryType=library_type,
+            coverageType=submission.coverage_type,
             dataQualityCheckPassed=not failed,
         )
     )
@@ -142,6 +216,19 @@ def from_metadata(metadata_file, failed):
         metadata = GrzSubmissionMetadata.model_validate_json(f.read())
     pruefbericht = _generate_pruefbericht_from_metadata(metadata, failed)
     click.echo(pruefbericht.model_dump_json(indent=None, by_alias=True))
+
+
+@generate.command("from-database")
+@grzcli.submission_id
+@grzcli.configuration
+@fail_or_pass
+def from_database(submission_id, configuration, failed, config_file=None):
+    """Generate Prüfbericht from database using submission ID."""
+    try:
+        pruefbericht = _generate_pruefbericht_from_database(submission_id, configuration, failed)
+        click.echo(pruefbericht.model_dump_json(indent=None, by_alias=True))
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
 
 
 @pruefbericht.command()

--- a/tests/cli/test_pruefbericht.py
+++ b/tests/cli/test_pruefbericht.py
@@ -10,6 +10,7 @@ import click.testing
 import grzctl.cli
 import pytest
 import responses
+from grz_pydantic_models.pruefbericht.v0 import LibraryType
 from grz_pydantic_models.submission.metadata import REDACTED_TAN
 
 from .. import mock_files
@@ -415,17 +416,18 @@ def test_generate_from_database(temp_pruefbericht_config_file_path, pruefbericht
 
     # Verify the generated Prüfbericht matches expected values
     pruefbericht_data = json.loads(result.output)
-    assert pruefbericht_data["SubmittedCase"]["submissionDate"] == "2024-07-15"
-    assert pruefbericht_data["SubmittedCase"]["submissionType"] == "test"
-    assert (
-        pruefbericht_data["SubmittedCase"]["tan"] == "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000"
-    )
-    assert pruefbericht_data["SubmittedCase"]["submitterId"] == "260914050"
-    assert pruefbericht_data["SubmittedCase"]["dataNodeId"] == "GRZK00007"
-    assert pruefbericht_data["SubmittedCase"]["diseaseType"] == "oncological"
-    assert pruefbericht_data["SubmittedCase"]["libraryType"] == "wes"  # Most expensive
-    assert pruefbericht_data["SubmittedCase"]["coverageType"] == "GKV"
-    assert pruefbericht_data["SubmittedCase"]["dataQualityCheckPassed"] is True
+    assert pruefbericht_data["SubmittedCase"] == {
+        "submissionDate": "2024-07-15",
+        "submissionType": "test",
+        "tan": "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000",
+        "submitterId": "260914050",
+        "dataNodeId": "GRZK00007",
+        "diseaseType": "oncological",
+        "dataCategory": "genomic",
+        "libraryType": "wes",  # Most expensive
+        "coverageType": "GKV",
+        "dataQualityCheckPassed": True,
+    }
 
 
 def test_generate_from_database_missing_submission(pruefbericht_db_config):
@@ -557,3 +559,36 @@ def test_generate_from_database_no_index_donor(pruefbericht_db_config):
 
     assert result.exit_code != 0
     assert "No index donor found" in result.output
+
+
+class TestLibraryTypeMostExpensive:
+    def test_single_type_returned(self):
+        assert LibraryType.most_expensive({"wes"}) == LibraryType.wes
+
+    def test_most_expensive_is_wgs_lr(self):
+        assert LibraryType.most_expensive({"panel", "wes", "wgs", "wgs_lr"}) == LibraryType.wgs_lr
+
+    def test_most_expensive_excludes_none(self):
+        """'none' must never win over a real sequencing type."""
+        assert LibraryType.most_expensive({"panel", "none"}) == LibraryType.panel
+
+    def test_none_alone_is_valid(self):
+        assert LibraryType.most_expensive({"none"}) == LibraryType.none
+
+    def test_invalid_types_are_ignored(self):
+        assert LibraryType.most_expensive({"wgs", "invalid_type"}) == LibraryType.wgs
+
+    def test_all_invalid_raises(self):
+        with pytest.raises(ValueError, match="cannot be submitted"):
+            LibraryType.most_expensive({"invalid_type", "another_bad_one"})
+
+    def test_priority_ordering(self):
+        """Verify the full priority ladder explicitly."""
+        ordered = sorted(LibraryType, key=lambda lt: lt.reimbursement_priority)
+        assert ordered == [
+            LibraryType.none,
+            LibraryType.panel,
+            LibraryType.wes,
+            LibraryType.wgs,
+            LibraryType.wgs_lr,
+        ]

--- a/tests/cli/test_pruefbericht.py
+++ b/tests/cli/test_pruefbericht.py
@@ -327,3 +327,233 @@ def test_refuse_redacted_tang(temp_pruefbericht_config_file_path, tmp_path):
         ]
         with pytest.raises(ValueError, match="Refusing to submit a Prüfbericht with a redacted TAN"):
             runner.invoke(cli, submit_args, catch_exceptions=False)
+
+
+@pytest.fixture
+def pruefbericht_db_config(tmp_path):
+    """Create a test database config for pruefbericht tests."""
+    import json
+
+    db_path = tmp_path / "test.db"
+    db_url = f"sqlite:///{db_path}"
+
+    config = {"db": {"database_url": db_url, "author": {"name": "test_author"}}}
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+
+    return {"db_path": db_path, "db_url": db_url, "config": config, "config_path": config_path}
+
+
+def test_generate_from_database(temp_pruefbericht_config_file_path, pruefbericht_db_config):
+    """Test generating Prüfbericht from database."""
+    import datetime
+    import json
+
+    from grz_db.models.submission import Donor, SubmissionDb
+    from grz_pydantic_models.submission.metadata import (
+        LibraryType,
+        Relation,
+        SequenceSubtype,
+        SequenceType,
+    )
+    from grz_pydantic_models.submission.metadata.v1 import (
+        CoverageType,
+        DiseaseType,
+        SubmissionType,
+    )
+
+    # Use the fixture
+    db_url = pruefbericht_db_config["db_url"]
+    config_path = pruefbericht_db_config["config_path"]
+
+    db = SubmissionDb(db_url=db_url, author=None, debug=False)
+    db.initialize_schema()
+
+    db.add_submission(TEST_SUBMISSION_ID)
+    # Populate submission fields to match the mock data used in other tests
+    db.modify_submission(TEST_SUBMISSION_ID, "submission_date", datetime.date(2024, 7, 15))
+    db.modify_submission(TEST_SUBMISSION_ID, "submission_type", SubmissionType.test)
+    db.modify_submission(
+        TEST_SUBMISSION_ID, "tan_g", "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000"
+    )
+    db.modify_submission(TEST_SUBMISSION_ID, "submitter_id", "260914050")
+    db.modify_submission(TEST_SUBMISSION_ID, "data_node_id", "GRZK00007")
+    db.modify_submission(TEST_SUBMISSION_ID, "disease_type", DiseaseType.oncological)
+    db.modify_submission(TEST_SUBMISSION_ID, "coverage_type", CoverageType.GKV)
+
+    # Add index donor with library types
+    index_donor = Donor(
+        submission_id=TEST_SUBMISSION_ID,
+        pseudonym="test_donor",
+        relation=Relation.index_,
+        library_types={LibraryType.wes, LibraryType.panel},
+        sequence_types={SequenceType.dna},
+        sequence_subtypes={SequenceSubtype.germline},
+        mv_consented=True,
+        research_consented=True,
+    )
+    db.add_donor(index_donor)
+
+    # Test the from-database command
+    runner = click.testing.CliRunner()
+    cli = grzctl.cli.build_cli()
+
+    args = [
+        "pruefbericht",
+        "generate",
+        "from-database",
+        "--submission-id",
+        TEST_SUBMISSION_ID,
+        "--config-file",
+        str(config_path),
+    ]
+
+    result = runner.invoke(cli, args, catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+
+    # Verify the generated Prüfbericht matches expected values
+    pruefbericht_data = json.loads(result.output)
+    assert pruefbericht_data["SubmittedCase"]["submissionDate"] == "2024-07-15"
+    assert pruefbericht_data["SubmittedCase"]["submissionType"] == "test"
+    assert (
+        pruefbericht_data["SubmittedCase"]["tan"] == "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000"
+    )
+    assert pruefbericht_data["SubmittedCase"]["submitterId"] == "260914050"
+    assert pruefbericht_data["SubmittedCase"]["dataNodeId"] == "GRZK00007"
+    assert pruefbericht_data["SubmittedCase"]["diseaseType"] == "oncological"
+    assert pruefbericht_data["SubmittedCase"]["libraryType"] == "wes"  # Most expensive
+    assert pruefbericht_data["SubmittedCase"]["coverageType"] == "GKV"
+    assert pruefbericht_data["SubmittedCase"]["dataQualityCheckPassed"] is True
+
+
+def test_generate_from_database_missing_submission(pruefbericht_db_config):
+    """Test error when submission doesn't exist in database."""
+    from grz_db.models.submission import SubmissionDb
+
+    # Use the fixture
+    db_url = pruefbericht_db_config["db_url"]
+    config_path = pruefbericht_db_config["config_path"]
+
+    db = SubmissionDb(db_url=db_url, author=None, debug=False)
+    db.initialize_schema()
+
+    runner = click.testing.CliRunner()
+    cli = grzctl.cli.build_cli()
+
+    args = [
+        "pruefbericht",
+        "generate",
+        "from-database",
+        "--submission-id",
+        "nonexistent_id",
+        "--config-file",
+        str(config_path),
+    ]
+
+    result = runner.invoke(cli, args, catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert "not found in database" in result.output
+
+
+def test_generate_from_database_missing_fields(pruefbericht_db_config):
+    """Test error when submission has missing required fields."""
+    from grz_db.models.submission import SubmissionDb
+
+    # Use the fixture
+    db_url = pruefbericht_db_config["db_url"]
+    config_path = pruefbericht_db_config["config_path"]
+
+    db = SubmissionDb(db_url=db_url, author=None, debug=False)
+    db.initialize_schema()
+
+    # Add submission without populating required fields
+    db.add_submission(TEST_SUBMISSION_ID)
+
+    runner = click.testing.CliRunner()
+    cli = grzctl.cli.build_cli()
+
+    args = [
+        "pruefbericht",
+        "generate",
+        "from-database",
+        "--submission-id",
+        TEST_SUBMISSION_ID,
+        "--config-file",
+        str(config_path),
+    ]
+
+    result = runner.invoke(cli, args, catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert "missing required fields" in result.output
+
+
+def test_generate_from_database_no_index_donor(pruefbericht_db_config):
+    """Test error when no index donor exists."""
+    import datetime
+
+    from grz_db.models.submission import Donor, SubmissionDb
+    from grz_pydantic_models.submission.metadata import (
+        LibraryType,
+        Relation,
+        SequenceSubtype,
+        SequenceType,
+    )
+    from grz_pydantic_models.submission.metadata.v1 import (
+        CoverageType,
+        DiseaseType,
+        SubmissionType,
+    )
+
+    # Use the fixture
+    db_url = pruefbericht_db_config["db_url"]
+    config_path = pruefbericht_db_config["config_path"]
+
+    db = SubmissionDb(db_url=db_url, author=None, debug=False)
+    db.initialize_schema()
+    db.add_submission(TEST_SUBMISSION_ID)
+
+    # Populate all required fields (matching the pattern from test_generate_from_database)
+    db.modify_submission(TEST_SUBMISSION_ID, "submission_date", datetime.date(2024, 7, 15))
+    db.modify_submission(TEST_SUBMISSION_ID, "submission_type", SubmissionType.test)
+    db.modify_submission(
+        TEST_SUBMISSION_ID, "tan_g", "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000"
+    )
+    db.modify_submission(TEST_SUBMISSION_ID, "submitter_id", "260914050")
+    db.modify_submission(TEST_SUBMISSION_ID, "data_node_id", "GRZK00007")
+    db.modify_submission(TEST_SUBMISSION_ID, "disease_type", DiseaseType.oncological)
+    db.modify_submission(TEST_SUBMISSION_ID, "coverage_type", CoverageType.GKV)
+
+    # Add a non-index donor such as mother
+    donor = Donor(
+        submission_id=TEST_SUBMISSION_ID,
+        pseudonym="test_donor",
+        relation=Relation.mother,  # NOT index
+        library_types={LibraryType.wes},
+        sequence_types={SequenceType.dna},
+        sequence_subtypes={SequenceSubtype.germline},
+        mv_consented=True,
+        research_consented=True,
+    )
+    db.add_donor(donor)
+
+    runner = click.testing.CliRunner()
+    cli = grzctl.cli.build_cli()
+
+    args = [
+        "pruefbericht",
+        "generate",
+        "from-database",
+        "--submission-id",
+        TEST_SUBMISSION_ID,
+        "--config-file",
+        str(config_path),
+    ]
+
+    result = runner.invoke(cli, args, catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert "No index donor found" in result.output


### PR DESCRIPTION
## Description
Implements Prüfbericht generation from database using submission ID.

## Related Issue
Closes #486 

## Changes
- Added `from-database` command to generate Pruefbericht from DB
- Created tests for database-based Pruefbericht generation

## Testing
- All existing tests pass
- Added 4 new tests for database functionality