### PR TITLE
fix(grzctl, grz-pydantic-models): automatically set correct submission date

### DIFF
--- a/packages/grz-common/src/grz_common/workers/worker.py
+++ b/packages/grz-common/src/grz_common/workers/worker.py
@@ -4,12 +4,43 @@ from __future__ import annotations
 
 import logging
 import shutil
+import json
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, ROUND_HALF_UP
 from os import PathLike
 from pathlib import Path
+from typing import Any
+
+
+from grz_db.errors import SubmissionNotFoundError
+from grz_db.models.author import Author
+from grz_db.models.submission import Donor
+from grz_pydantic_models.submission.metadata import (
+    GrzSubmissionMetadata,
+    Relation,
+    REDACTED_TAN
+)
+from grzctl.commands.db.cli import (
+    get_submission_db_instance,
+    redact_metadata,
+    diff_metadata,
+    diff_donor,
+    SubmissionData,
+    DonorDiff,
+    DonorData
+)
+
+from grzctl.models.config import (
+    DbConfig,
+    ListConfig,
+    DownloadConfig
+)
 
 from ..models.identifiers import IdentifiersModel
 from ..models.s3 import S3Options
 from ..progress import EncryptionState, FileProgressLogger, ValidationState
+from ..transfer import init_s3_client
 from ..validation import UserInterruptException
 from .download import S3BotoDownloadWorker
 from .submission import EncryptedSubmission, Submission, SubmissionValidationError
@@ -17,6 +48,20 @@ from .upload import S3BotoUploadWorker
 
 log = logging.getLogger(__name__)
 
+# TODO: move to grz_db.models.author?
+def _initialise_author_from_dbconfig(db_config: DbConfig) -> Author:
+    author = None
+    if db_config.author:
+        key_path = Path(db_config.author.private_key_path)
+        if not key_path.exists():
+            raise FileNotFoundError(f"Author private key not found at: {key_path}")
+
+        author = Author(
+            name=db_config.author.name,
+            private_key_bytes=key_path.read_bytes(),
+            private_key_passphrase=db_config.author.private_key_passphrase,
+        )
+    return Author
 
 class Worker:
     """Worker class for handling submission processing"""
@@ -317,3 +362,97 @@ class Worker:
 
         self.__log.info("Downloading encrypted files...")
         download_worker.download(submission_id, EncryptedSubmission(self.metadata_dir, self.encrypted_files_dir))
+
+
+    def populate(self, configuration,  submission_id: str, force: bool):
+        updates = False
+        # establish connection to s3; no check because connection established during download
+        s3_config = DownloadConfig.model_validate(configuration).s3
+        s3_client = init_s3_client(s3_config)
+
+        # get the metadata file object and extract the date
+        object_key = f"{submission_id}/metadata/metadata.json"
+        response = s3_client.head_object(Bucket= s3_config.bucket, Key= object_key)
+        submission_date = response["LastModified"].date()
+
+        # establish connection to database; no check because connection established via DbContext
+        db_config = DbConfig.model_validate(configuration).db
+        author = _initialise_author_from_dbconfig(db_config)
+        db = get_submission_db_instance(db_config.database_url, author=author)
+        submission = db.get_submission(submission_id)
+
+        # store entries of donors in database
+        donors_in_db_submission = {donor.pseudonym : donor for donor in db.get_donors(submission_id=submission_id)}
+
+        # parse metadata
+        metadata_file_path = self.metadata_dir / "metadata.json"
+        with open(metadata_file_path, encoding="utf-8") as metadata_file:
+            metadata = GrzSubmissionMetadata.model_validate_json(metadata_file.read())
+
+            metadata_file.seek(0)
+            metadata_content = json.load(metadata_file)
+            # redact tanG, local case id and potential tanG in the patient information
+            metadata_content = redact_metadata(metadata_content)
+            metadata_string = json.dumps(metadata_content)
+
+
+        # add the filesize; would be better with SubmissionMetadata but then without validation
+        # submission_size: int = sum([i.file_size_in_bytes for i in submission_metadata.files.values()])
+        submission_size: int = 0
+        for donor in metadata.donors:
+            for lab_datum in donor.lab_data:
+                if sequence_data := lab_datum.sequence_data:
+                    for file in sequence_data.files:
+                        submission_size += file.file_size_in_bytes
+
+        # populate submission metadata
+        submission_information = diff_metadata(submission, metadata, submission_size, submission_date, metadata_string)
+        if submission_information.change: updates = True
+
+        donors_in_metadata: list[str] = []
+        donor_diff = DonorDiff([], [], [], [], [])
+        for donor in metadata.donors:
+            donor_data = diff_donor(donor, donors_in_db_submission, submission_id)
+            donors_in_metadata.append(donor_data.name)
+            if donor_data.status != "unchanged":
+                updates = True
+                if donor_data.status == "new":
+                    donor_diff.added.append(donor_data.donor)
+                else:
+                    donor_diff.updated.append(donor_data.donor)
+            else:
+                donor_diff.unchanged.append(donor_data.donor)
+
+        donor_diff.deleted = [db_donor for db_donor in donors_in_db_submission.values() if db_donor.pseudonym not in donors_in_metadata]
+
+        if updates and not force:
+            raise RuntimeError(f"Changes in {object_key} detected. Re-run with --populate to commit them.")
+
+        if updates:
+            # goes below
+            if submission_information.update:
+                self.__log.info(f"Submission: {submission_id} - Updating fields: {', '.join(submission_information.update)} in database")
+            if submission_information.unchanged:
+                self.__log.info(f"Submission: {submission_id} - Not updating fields: {', '.join(submission_information.unchanged)} in database")
+            if donor_diff.unchanged:
+                self.__log.info(f"Submission: {submission_id} - Keep existing donor(s) in database: {','.join([i.pseudonym for i in donor_diff.unchanged])}")
+            if donor_diff.added:
+                self.__log.info(f"Submission: {submission_id} - Adding new donor(s) to database: {','.join([i.pseudonym for i in donor_diff.added])} from metadata.json")
+            if donor_diff.updated:
+                self.__log.info(f"Submission: {submission_id} - Modify existing donor(s) in database: {','.join([i.pseudonym for i in donor_diff.updated])} from metadata.json")
+            if donor_diff.deleted:
+                self.__log.info(f"Submission: {submission_id} - Drop existing donor(s) in db: {','.join([i.pseudonym for i in donor_diff.deleted])}")
+
+            # push to database
+            for key, unused, value in submission_information.db_ingest:
+                db.modify_submission(submission_id, key, value)
+            for donor in donor_diff.added:
+                db.add_donor(donor)
+            for donor in donor_diff.updated:
+                db.update_donor(donor)
+            for donor in donor_diff.deleted:
+                db.delete_donor(donor)
+        else:
+            self.__log.info(f"Submission: {submission_id} - No updates from metadata.json necessary")
+
+

--- a/packages/grz-common/src/grz_common/workers/worker.py
+++ b/packages/grz-common/src/grz_common/workers/worker.py
@@ -8,10 +8,9 @@ import shutil
 from os import PathLike
 from pathlib import Path
 
-from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
-from grzctl.commands.db.cli import DonorDiff, diff_donor, diff_metadata, get_submission_db_instance
-from grzctl.dbcontext import DbContext
-from grzctl.models.config import DbConfig
+from grz_db.models.submission import SubmissionDb
+from grz_pydantic_models.submission.metadata import REDACTED_TAN, GrzSubmissionMetadata
+from grzctl.commands.db.cli import DonorDiff, DonorStatus, diff_donor, diff_metadata
 
 from ..models.identifiers import IdentifiersModel
 from ..models.s3 import S3Options
@@ -326,7 +325,7 @@ class Worker:
         download_worker.download(submission_id, EncryptedSubmission(self.metadata_dir, self.encrypted_files_dir))
 
 
-    def populate(self, s3_options: S3Options, db_context: DbContext, submission_id: str, force_populate: bool): # noqa: PLR0915, PLR0912, C901
+    def populate(self, s3_options: S3Options, db: SubmissionDb, submission_id: str, force_populate: bool): # noqa: PLR0915, PLR0912, C901
         updates: bool = False
         updates_notnull: bool = False
         # establish connection to s3; no check because connection established during download
@@ -338,8 +337,8 @@ class Worker:
         submission_date = response["LastModified"].date()
 
         # establish connection to database; no check because connection established via DbContext
-        db_config = DbConfig.model_validate(db_context.configuration).db
-        db = get_submission_db_instance(db_config.database_url, author=db_context.author)
+        # db_config = DbConfig.model_validate(db_context.configuration).db
+        # db = get_submission_db_instance(db_config.database_url, author=db_context.author)
         # that part is not necessary because it is called in context with DBcontext and that requires an added submission_id to the database
         submission = db.get_submission(submission_id)
         if not submission:
@@ -358,12 +357,17 @@ class Worker:
             metadata_content = metadata.to_redacted_dict(False)
             metadata_string = json.dumps(metadata_content)
 
-        submission_size = metadata.get_submission_size() + 1
+        if metadata.submission.tan_g == REDACTED_TAN:
+            raise ValueError(f"Submission {submission_id} has redacted tan_g in metadata.json ({metadata_file_path}).")
+        if not metadata.submission.local_case_id or metadata.submission.local_case_id == "REDACTED_LOCAL_CASE_ID":
+            raise ValueError(f"Submission {submission_id} has missing or redacted local_case_id in metadata.json ({metadata_file_path}).")
+
+        submission_size = metadata.get_submission_size()
 
         # populate submission metadata
         submission_information = diff_metadata(submission, metadata, submission_size, submission_date, metadata_string)
         if submission_information.new:
-            self.__log.info(f"Submission {submission_id} metadata fields were set to default None: Indicates first time populate. Force populate")
+            self.__log.warning(f"Submission {submission_id} has some fields in the db that were set to default None. Indicates first time populate. Force populate")
             force_populate = True
         if submission_information.change:
             updates = True
@@ -372,21 +376,29 @@ class Worker:
 
         donors_in_metadata: list[str] = []
         donor_diff = DonorDiff([], [], [], [], [])
+        first_time = False
         for donor in metadata.donors:
             donor_data = diff_donor(donor, donors_in_db_submission, submission_id)
-            donors_in_metadata.append(donor_data.name)
-            if donor_data.status != "unchanged":
+            donors_in_metadata.append(donor_data.donor.pseudonym)
+            if donor_data.status in (DonorStatus.NEW, DonorStatus.UPDATE, DonorStatus.NEW_RESUB):
                 updates = True
-                if donor_data.status == "new":
+                if donor_data.status == DonorStatus.NEW:
                     donor_diff.added.append(donor_data.donor)
+                    if not first_time:
+                        self.__log.warning(f"Submission {submission_id} has donors that do not exist in db. Indicates first time populate. Force populate")
+                        first_time = True
+                    force_populate = True # new donor, first time populate is required
+                elif donor_data.status == DonorStatus.NEW_RESUB:
+                    updates_notnull = True
                 else:
                     donor_diff.updated.append(donor_data.donor)
             else:
                 donor_diff.unchanged.append(donor_data.donor)
 
         donor_diff.deleted = [db_donor for db_donor in donors_in_db_submission.values() if db_donor.pseudonym not in donors_in_metadata]
+        if len(donor_diff.deleted) > 0:
+            updates_notnull = True
 
-        print(updates_notnull)
         if updates_notnull and not force_populate:
             raise RuntimeError(f"Changes after initial populate in {object_key} detected and --force not set. Re-run download with --force and --populate to commit them.")
         if updates and not force_populate:
@@ -395,17 +407,17 @@ class Worker:
         if updates and force_populate:
             # goes below
             if submission_information.update:
-                self.__log.info(f"Submission: {submission_id} - Updating fields: {', '.join(submission_information.update)} in database")
+                self.__log.info(f"Submission: {submission_id} - Updating fields: {', '.join([f'"{i}"' for i in submission_information.update])} in database")
             if submission_information.unchanged:
-                self.__log.info(f"Submission: {submission_id} - Not updating fields: {', '.join(submission_information.unchanged)} in database")
+                self.__log.info(f"Submission: {submission_id} - Not updating fields: {', '.join([f'"{i}"' for i in submission_information.unchanged])} in database")
             if donor_diff.unchanged:
-                self.__log.info(f"Submission: {submission_id} - Keep existing donor(s) in database: {','.join([i.pseudonym for i in donor_diff.unchanged])}")
+                self.__log.info(f"Submission: {submission_id} - Keep existing donor(s) in database: {','.join([f'"{i.pseudonym}"' for i in donor_diff.unchanged])}")
             if donor_diff.added:
-                self.__log.info(f"Submission: {submission_id} - Adding new donor(s) to database: {','.join([i.pseudonym for i in donor_diff.added])} from metadata.json")
+                self.__log.info(f"Submission: {submission_id} - Adding new donor(s) to database: {','.join([f'"{i.pseudonym}"' for i in donor_diff.added])} from metadata.json ({metadata_file_path}).")
             if donor_diff.updated:
-                self.__log.info(f"Submission: {submission_id} - Modify existing donor(s) in database: {','.join([i.pseudonym for i in donor_diff.updated])} from metadata.json")
+                self.__log.info(f"Submission: {submission_id} - Modify existing donor(s) in database: {','.join([f'"{i.pseudonym}"' for i in donor_diff.updated])} from metadata.json ({metadata_file_path}).")
             if donor_diff.deleted:
-                self.__log.info(f"Submission: {submission_id} - Drop existing donor(s) in db: {','.join([i.pseudonym for i in donor_diff.deleted])}")
+                self.__log.info(f"Submission: {submission_id} - Drop existing donor(s) in db: {','.join([f'"{i.pseudonym}"' for i in donor_diff.deleted])}")
 
             # push to database
             for key, _, value in submission_information.db_ingest:
@@ -417,6 +429,6 @@ class Worker:
             for deleted_donor in donor_diff.deleted:
                 db.delete_donor(deleted_donor)
         else:
-            self.__log.info(f"Submission: {submission_id} - No updates from metadata.json necessary")
+            self.__log.info(f"Submission: {submission_id} - No updates from metadata.json ({metadata_file_path}) necessary.")
 
 

--- a/packages/grz-common/src/grz_common/workers/worker.py
+++ b/packages/grz-common/src/grz_common/workers/worker.py
@@ -326,7 +326,9 @@ class Worker:
         download_worker.download(submission_id, EncryptedSubmission(self.metadata_dir, self.encrypted_files_dir))
 
 
-    def populate(self, s3_options: S3Options, db_context: DbContext,  submission_id: str, force: bool): # noqa: PLR0915, PLR0912, C901
+    def populate(self, s3_options: S3Options, db_context: DbContext, submission_id: str, force_populate: bool): # noqa: PLR0915, PLR0912, C901
+        updates: bool = False
+        updates_notnull: bool = False
         # establish connection to s3; no check because connection established during download
         s3_client = init_s3_client(s3_options)
 
@@ -338,7 +340,13 @@ class Worker:
         # establish connection to database; no check because connection established via DbContext
         db_config = DbConfig.model_validate(db_context.configuration).db
         db = get_submission_db_instance(db_config.database_url, author=db_context.author)
+        # that part is not necessary because it is called in context with DBcontext and that requires an added submission_id to the database
         submission = db.get_submission(submission_id)
+        if not submission:
+            self.__log.warning(f"Submission {submission_id} does not exist. Creating ...")
+            submission = db.add_submission(submission_id)
+            self.__log.info(f"Submission {submission_id} added to database. Force populate")
+            force_populate = True # Submission does not exist, first time populate is required
 
         # store entries of donors in database
         donors_in_db_submission = {donor.pseudonym : donor for donor in db.get_donors(submission_id=submission_id)}
@@ -350,11 +358,17 @@ class Worker:
             metadata_content = metadata.to_redacted_dict(False)
             metadata_string = json.dumps(metadata_content)
 
-        submission_size = metadata.get_submission_size()
+        submission_size = metadata.get_submission_size() + 1
 
         # populate submission metadata
         submission_information = diff_metadata(submission, metadata, submission_size, submission_date, metadata_string)
-        if submission_information.change: updates = True
+        if submission_information.new:
+            self.__log.info(f"Submission {submission_id} metadata fields were set to default None: Indicates first time populate. Force populate")
+            force_populate = True
+        if submission_information.change:
+            updates = True
+        if submission_information.change_notnull:
+            updates_notnull = True
 
         donors_in_metadata: list[str] = []
         donor_diff = DonorDiff([], [], [], [], [])
@@ -372,10 +386,13 @@ class Worker:
 
         donor_diff.deleted = [db_donor for db_donor in donors_in_db_submission.values() if db_donor.pseudonym not in donors_in_metadata]
 
-        if updates and not force:
-            raise RuntimeError(f"Changes in {object_key} detected. Re-run with --populate to commit them.")
+        print(updates_notnull)
+        if updates_notnull and not force_populate:
+            raise RuntimeError(f"Changes after initial populate in {object_key} detected and --force not set. Re-run download with --force and --populate to commit them.")
+        if updates and not force_populate:
+            raise RuntimeError(f"Changes in {object_key} detected. Re-run download with --force and --populate to commit them.")
 
-        if updates:
+        if updates and force_populate:
             # goes below
             if submission_information.update:
                 self.__log.info(f"Submission: {submission_id} - Updating fields: {', '.join(submission_information.update)} in database")
@@ -393,12 +410,12 @@ class Worker:
             # push to database
             for key, _, value in submission_information.db_ingest:
                 db.modify_submission(submission_id, key, value)
-            for donor in donor_diff.added:
-                db.add_donor(donor)
-            for donor in donor_diff.updated:
-                db.update_donor(donor)
-            for donor in donor_diff.deleted:
-                db.delete_donor(donor)
+            for added_donor in donor_diff.added:
+                db.add_donor(added_donor)
+            for updated_donor in donor_diff.updated:
+                db.update_donor(updated_donor)
+            for deleted_donor in donor_diff.deleted:
+                db.delete_donor(deleted_donor)
         else:
             self.__log.info(f"Submission: {submission_id} - No updates from metadata.json necessary")
 

--- a/packages/grz-common/src/grz_common/workers/worker.py
+++ b/packages/grz-common/src/grz_common/workers/worker.py
@@ -2,40 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import shutil
-import json
-from dataclasses import dataclass
-from datetime import date, datetime
-from decimal import Decimal, ROUND_HALF_UP
 from os import PathLike
 from pathlib import Path
-from typing import Any
 
-
-from grz_db.errors import SubmissionNotFoundError
-from grz_db.models.author import Author
-from grz_db.models.submission import Donor
-from grz_pydantic_models.submission.metadata import (
-    GrzSubmissionMetadata,
-    Relation,
-    REDACTED_TAN
-)
-from grzctl.commands.db.cli import (
-    get_submission_db_instance,
-    redact_metadata,
-    diff_metadata,
-    diff_donor,
-    SubmissionData,
-    DonorDiff,
-    DonorData
-)
-
-from grzctl.models.config import (
-    DbConfig,
-    ListConfig,
-    DownloadConfig
-)
+from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
+from grzctl.commands.db.cli import DonorDiff, diff_donor, diff_metadata, get_submission_db_instance
+from grzctl.dbcontext import DbContext
+from grzctl.models.config import DbConfig
 
 from ..models.identifiers import IdentifiersModel
 from ..models.s3 import S3Options
@@ -48,20 +24,6 @@ from .upload import S3BotoUploadWorker
 
 log = logging.getLogger(__name__)
 
-# TODO: move to grz_db.models.author?
-def _initialise_author_from_dbconfig(db_config: DbConfig) -> Author:
-    author = None
-    if db_config.author:
-        key_path = Path(db_config.author.private_key_path)
-        if not key_path.exists():
-            raise FileNotFoundError(f"Author private key not found at: {key_path}")
-
-        author = Author(
-            name=db_config.author.name,
-            private_key_bytes=key_path.read_bytes(),
-            private_key_passphrase=db_config.author.private_key_passphrase,
-        )
-    return Author
 
 class Worker:
     """Worker class for handling submission processing"""
@@ -364,21 +326,18 @@ class Worker:
         download_worker.download(submission_id, EncryptedSubmission(self.metadata_dir, self.encrypted_files_dir))
 
 
-    def populate(self, configuration,  submission_id: str, force: bool):
-        updates = False
+    def populate(self, s3_options: S3Options, db_context: DbContext,  submission_id: str, force: bool): # noqa: PLR0915, PLR0912, C901
         # establish connection to s3; no check because connection established during download
-        s3_config = DownloadConfig.model_validate(configuration).s3
-        s3_client = init_s3_client(s3_config)
+        s3_client = init_s3_client(s3_options)
 
         # get the metadata file object and extract the date
         object_key = f"{submission_id}/metadata/metadata.json"
-        response = s3_client.head_object(Bucket= s3_config.bucket, Key= object_key)
+        response = s3_client.head_object(Bucket= s3_options.bucket, Key= object_key)
         submission_date = response["LastModified"].date()
 
         # establish connection to database; no check because connection established via DbContext
-        db_config = DbConfig.model_validate(configuration).db
-        author = _initialise_author_from_dbconfig(db_config)
-        db = get_submission_db_instance(db_config.database_url, author=author)
+        db_config = DbConfig.model_validate(db_context.configuration).db
+        db = get_submission_db_instance(db_config.database_url, author=db_context.author)
         submission = db.get_submission(submission_id)
 
         # store entries of donors in database
@@ -388,26 +347,10 @@ class Worker:
         metadata_file_path = self.metadata_dir / "metadata.json"
         with open(metadata_file_path, encoding="utf-8") as metadata_file:
             metadata = GrzSubmissionMetadata.model_validate_json(metadata_file.read())
-
-            # metadata_file.seek(0)
-            # metadata_content = json.load(metadata_file)
-            # redact tanG, local case id and potential tanG in the patient information
-            # metadata_content = redact_metadata(metadata_content)
-            # metadata_string = json.dumps(metadata_content)
-
             metadata_content = metadata.to_redacted_dict(False)
             metadata_string = json.dumps(metadata_content)
-            print(metadata_string)
-            exit()
 
-        # add the filesize; would be better with SubmissionMetadata but then without validation
-        # submission_size: int = sum([i.file_size_in_bytes for i in submission_metadata.files.values()])
-        submission_size: int = 0
-        for donor in metadata.donors:
-            for lab_datum in donor.lab_data:
-                if sequence_data := lab_datum.sequence_data:
-                    for file in sequence_data.files:
-                        submission_size += file.file_size_in_bytes
+        submission_size = metadata.get_submission_size()
 
         # populate submission metadata
         submission_information = diff_metadata(submission, metadata, submission_size, submission_date, metadata_string)
@@ -448,7 +391,7 @@ class Worker:
                 self.__log.info(f"Submission: {submission_id} - Drop existing donor(s) in db: {','.join([i.pseudonym for i in donor_diff.deleted])}")
 
             # push to database
-            for key, unused, value in submission_information.db_ingest:
+            for key, _, value in submission_information.db_ingest:
                 db.modify_submission(submission_id, key, value)
             for donor in donor_diff.added:
                 db.add_donor(donor)

--- a/packages/grz-common/src/grz_common/workers/worker.py
+++ b/packages/grz-common/src/grz_common/workers/worker.py
@@ -389,12 +389,16 @@ class Worker:
         with open(metadata_file_path, encoding="utf-8") as metadata_file:
             metadata = GrzSubmissionMetadata.model_validate_json(metadata_file.read())
 
-            metadata_file.seek(0)
-            metadata_content = json.load(metadata_file)
+            # metadata_file.seek(0)
+            # metadata_content = json.load(metadata_file)
             # redact tanG, local case id and potential tanG in the patient information
-            metadata_content = redact_metadata(metadata_content)
-            metadata_string = json.dumps(metadata_content)
+            # metadata_content = redact_metadata(metadata_content)
+            # metadata_string = json.dumps(metadata_content)
 
+            metadata_content = metadata.to_redacted_dict(False)
+            metadata_string = json.dumps(metadata_content)
+            print(metadata_string)
+            exit()
 
         # add the filesize; would be better with SubmissionMetadata but then without validation
         # submission_size: int = sum([i.file_size_in_bytes for i in submission_metadata.files.values()])

--- a/packages/grz-db/src/grz_db/migrations/README.md
+++ b/packages/grz-db/src/grz_db/migrations/README.md
@@ -15,6 +15,69 @@ The available operations can be browsed in the [Alembic documentation](https://a
 You may also find the other migration scripts under `versions/` useful as a reference.
 Finally, Alembic's migration script [tutorial](https://alembic.sqlalchemy.org/en/latest/tutorial.html#create-a-migration-script) may also be useful as a guide.
 
+## Run a migration
+
+From `packages/grz-db`:
+
+```
+uv run alembic -c /PATH/TO/alembic.ini upgrade head
+```
+
+### Basic alembic.ini
+
+```
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = .../grz-tools/packages/grz-db/src/grz_db/migrations
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+# See notes in "escaping characters in ini files" for guidelines on
+# passwords
+sqlalchemy.url = postgresql+psycopg://DBUSER@DBSERVER/DB_NAME
+# sqlalchemy.url = sqlite:////PATH/TO/submission.db.sqlite
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+propagate = 0
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+```
+
+
 ## General Tips
 
 To easily find the appropriate SQLAlchemy column type for a migration operation, try the following in a REPL after adding the new fields to the particular object:

--- a/packages/grz-db/src/grz_db/migrations/README.md
+++ b/packages/grz-db/src/grz_db/migrations/README.md
@@ -17,66 +17,9 @@ Finally, Alembic's migration script [tutorial](https://alembic.sqlalchemy.org/en
 
 ## Run a migration
 
-From `packages/grz-db`:
-
 ```
-uv run alembic -c /PATH/TO/alembic.ini upgrade head
+grzctl db upgrade --revision TEXT
 ```
-
-### Basic alembic.ini
-
-```
-[alembic]
-# path to migration scripts.
-# this is typically a path given in POSIX (e.g. forward slashes)
-# format, relative to the token %(here)s which refers to the location of this
-# ini file
-script_location = .../grz-tools/packages/grz-db/src/grz_db/migrations
-
-# database URL.  This is consumed by the user-maintained env.py script only.
-# other means of configuring database URLs may be customized within the env.py
-# file.
-# See notes in "escaping characters in ini files" for guidelines on
-# passwords
-sqlalchemy.url = postgresql+psycopg://DBUSER@DBSERVER/DB_NAME
-# sqlalchemy.url = sqlite:////PATH/TO/submission.db.sqlite
-
-[loggers]
-keys = root,sqlalchemy,alembic
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = WARN
-handlers = console
-qualname =
-
-[logger_sqlalchemy]
-level = WARN
-handlers =
-qualname = sqlalchemy.engine
-propagate = 0
-
-[logger_alembic]
-level = INFO
-handlers =
-qualname = alembic
-propagate = 0
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(levelname)-5.5s [%(name)s] %(message)s
-```
-
 
 ## General Tips
 

--- a/packages/grz-db/src/grz_db/migrations/versions/834bd50b8734_modify_submissions_with_new_column_size_.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/834bd50b8734_modify_submissions_with_new_column_size_.py
@@ -1,0 +1,31 @@
+"""modify submissions with new column size and metadata
+
+Revision ID: 834bd50b8734
+Revises: 8aa6fc8d118a
+Create Date: 2026-02-12 14:58:52.096841+00:00
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '834bd50b8734'
+down_revision: str | Sequence[str] | None = '8aa6fc8d118a'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("submissions", sa.Column("submission_size", sa.Numeric(10, 2), nullable=True))
+    op.add_column("submissions", sa.Column("submission_metadata", sa.Text(), nullable=True))
+
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    raise RuntimeError("Downgrades not supported.")

--- a/packages/grz-db/src/grz_db/migrations/versions/834bd50b8734_modify_submissions_with_new_column_size_.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/834bd50b8734_modify_submissions_with_new_column_size_.py
@@ -11,7 +11,6 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
 revision: str = '834bd50b8734'
 down_revision: str | Sequence[str] | None = '8aa6fc8d118a'
@@ -21,7 +20,7 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    op.add_column("submissions", sa.Column("submission_size", sa.Numeric(10, 2), nullable=True))
+    op.add_column("submissions", sa.Column("submission_size", sa.Integer(), nullable=True))
     op.add_column("submissions", sa.Column("submission_metadata", sa.Text(), nullable=True))
 
 

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -6,7 +6,6 @@ import random
 import re
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
-from decimal import Decimal
 from operator import attrgetter
 from typing import Any, ClassVar, Optional
 
@@ -139,8 +138,8 @@ class SubmissionBase(SQLModel):
     genomic_study_subtype: GenomicStudySubtype | None = None
 
     # extra fields
-    submission_size: Optional[int] = Field(default=None)
-    submission_metadata: Optional[str] = Field(default=None)
+    submission_size: int | None = Field(default=None)
+    submission_metadata: str | None = Field(default=None)
 
 class Submission(SubmissionBase, table=True):
     """Submission table model."""

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -31,7 +31,7 @@ from grz_pydantic_models.submission.metadata import (
     Tan,
 )
 from pydantic import ConfigDict, field_serializer, field_validator
-from sqlalchemy import JSON, Column, Enum
+from sqlalchemy import JSON, BigInteger, Column, Enum
 from sqlalchemy import func as sqlfn
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
@@ -138,7 +138,7 @@ class SubmissionBase(SQLModel):
     genomic_study_subtype: GenomicStudySubtype | None = None
 
     # extra fields
-    submission_size: int | None = Field(default=None)
+    submission_size: int | None = Field(default=None, sa_type=BigInteger)
     submission_metadata: str | None = Field(default=None)
 
 class Submission(SubmissionBase, table=True):

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -6,6 +6,7 @@ import random
 import re
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
+from decimal import Decimal
 from operator import attrgetter
 from typing import Any, ClassVar, Optional
 
@@ -137,6 +138,9 @@ class SubmissionBase(SQLModel):
     genomic_study_type: GenomicStudyType | None = None
     genomic_study_subtype: GenomicStudySubtype | None = None
 
+    # extra fields
+    submission_size: Optional[int] = Field(default=None)
+    submission_metadata: Optional[str] = Field(default=None)
 
 class Submission(SubmissionBase, table=True):
     """Submission table model."""
@@ -489,6 +493,20 @@ class SubmissionDb:
             except Exception:
                 session.rollback()
                 raise
+
+    def update_submission_size(self, session: Session, submission_id: str, value: int) -> None:
+        submission = session.get(Submission, submission_id)
+        if submission is None:
+            raise SubmissionNotFoundError(submission_id)
+
+        submission.submission_size = value
+
+    def update_submission_date(self, session: Session, submission_id: str, value: datetime.date) -> None:
+        submission = session.get(Submission, submission_id)
+        if submission is None:
+            raise SubmissionNotFoundError(submission_id)
+
+        submission.submission_date = value
 
     def update_submission_state(
         self,

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -1392,6 +1392,15 @@ class GrzSubmissionMetadata(StrictBaseModel):
 
         return thresholds
 
+    def get_submission_size(self) -> int:
+        submission_size: int = 0
+        for donor in self.donors:
+            for lab_datum in donor.lab_data:
+                if sequence_data := lab_datum.sequence_data:
+                    for datafile in sequence_data.files:
+                        submission_size += datafile.file_size_in_bytes
+        return submission_size
+
     def get_thresholds(self) -> dict[tuple[str, str], thresholds_model.Thresholds | None]:
         """
         Get the thresholds for all lab data in the submission.

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -36,13 +36,13 @@ from grz_db.models.submission import (
     ChangeRequestEnum,
     ChangeRequestLog,
     DetailedQCResult,
-    Donor,
     Submission,
     SubmissionDb,
     SubmissionStateEnum,
     SubmissionStateFilterModeEnum,
     SubmissionStateLog,
 )
+from grz_db.models.submission import Donor as DBDonor
 from grz_pydantic_models.common import StrictBaseModel
 from grz_pydantic_models.submission.metadata import (
     REDACTED_TAN,
@@ -53,6 +53,7 @@ from grz_pydantic_models.submission.metadata import (
     SequenceSubtype,
     SequenceType,
 )
+from grz_pydantic_models.submission.metadata import Donor as MetadataDonor
 from pydantic import Field
 
 from ...models.config import DbConfig, ListConfig
@@ -560,6 +561,8 @@ class SubmissionData:
     unchanged: list[str]
     db_ingest: list[tuple[str, Any, Any]]
     change: bool = False
+    change_notnull: bool = False
+    new: bool = False
 
 def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submission_size: int, submission_date: date | None, metadata_content: str, ignore_fields: set[str] | None = None) -> SubmissionData: # noqa: PLR0913
     submission_data = SubmissionData([], [], [])
@@ -570,14 +573,14 @@ def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submi
         submission_date = metadata.submission.submission_date
 
     # refuse to ingest metadata when tan_g is redacted
-    if metadata.submission.tan_g == REDACTED_TAN:
+    if metadata.submission.tan_g == REDACTED_TAN and "tan_g" not in ignore_fields:
         raise ValueError(
             "Refusing to populate a seemingly-redacted TAN (all zeros). "
             "Use 'grzctl db submission modify' directly."
         )
 
     # refuse to ingest metadata when local case ID is empty
-    if submission.pseudonym != metadata.submission.local_case_id and not metadata.submission.local_case_id:
+    if submission.pseudonym != metadata.submission.local_case_id and not metadata.submission.local_case_id and "pseudonym" not in ignore_fields:
         raise ValueError(
             "Refusing to populate a seemingly-redacted local case ID (empty). "
             "Use 'grzctl db submission modify' directly."
@@ -589,12 +592,17 @@ def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submi
     for key in simple_fields - ignore_fields:
         submission_info = getattr(submission, key)
         metadata_info = getattr(metadata.submission, key)
+        if submission_info is None:
+            submission_data.new = True # indicator for a new submission because a field is still None
+        log.info(f"FUBAR {submission_info} {type(submission_info)} {metadata_info} {type(metadata_info)}")
         if submission_info != metadata_info:
             submission_data.db_ingest.append((key, submission_info, metadata_info))
             submission_data.update.append(key)
-            submission_data.change = True
+            submission_data.change = True # tracking changes in general
+            if submission_info is not None: # tracking changes when the database field was Null
+                submission_data.change_notnull = True
         else:
-            submission_data.unchanged.append(key)
+            submission_data.unchanged.append(key) # no change of existing data in database
 
     complex_fields = (
         ("pseudonym", metadata.submission.local_case_id),
@@ -608,34 +616,36 @@ def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submi
     for key, value in complex_fields:
         if key in ignore_fields: continue
         submission_info = getattr(submission, key)
+        if submission_info is None:
+            submission_data.new = True # indicator for a new submission because a field is still None
         if submission_info != value:
             submission_data.db_ingest.append((key, submission_info, value))
             submission_data.update.append(key)
-            submission_data.change = True
+            submission_data.change = True # tracking changes in general
+            if submission_info is not None: # tracking changes when the database field was Null
+                submission_data.change_notnull = True
         else:
-            submission_data.unchanged.append(key)
+            submission_data.unchanged.append(key) # no change of existing data in database
 
     return submission_data
 
 @dataclass
 class DonorDiff:
-    added: list[Donor]
-    updated: list[Donor]
-    deleted: list[Donor]
-    unchanged: list[Donor]
+    added: list[DBDonor]
+    updated: list[DBDonor]
+    deleted: list[DBDonor]
+    unchanged: list[DBDonor]
     diff_tables: list[rich.console.RenderableType]
 
 @dataclass
 class DonorData:
+    donor: DBDonor
     changes: list[tuple[str, Any, Any]] = field(default_factory=list)
     name: str = ""
     status: str = ""
-    donor: Donor | None = None
 
-def diff_donor(donor: Donor, donors_in_db_submission: dict[str, Donor], submission_id: str) -> DonorData:
-    donor_data = DonorData([])
-
-    donor_metadata = Donor.model_validate(
+def diff_donor(donor: MetadataDonor, donors_in_db_submission: dict[str, DBDonor], submission_id: str) -> DonorData:
+    donor_metadata = DBDonor.model_validate(
         {
             "submission_id": submission_id,
             "pseudonym": "index" if donor.relation == Relation.index_ else donor.donor_pseudonym,
@@ -654,8 +664,9 @@ def diff_donor(donor: Donor, donors_in_db_submission: dict[str, Donor], submissi
             else None,
         }
     )
+
+    donor_data = DonorData(donor = donor_metadata)
     donor_data.name = donor_metadata.pseudonym
-    donor_data.donor = donor_metadata
     donor_before = donors_in_db_submission.get(donor_metadata.pseudonym)
     if donor_before == donor_metadata:
         donor_data.status = "unchanged"
@@ -665,7 +676,7 @@ def diff_donor(donor: Donor, donors_in_db_submission: dict[str, Donor], submissi
         donor_data.status = "update"
 
     if donor_data.status != "unchanged":
-        for field in sorted(Donor.model_fields.keys() - {"submission_id", "pseudonym"}):
+        for field in sorted(DBDonor.model_fields.keys() - {"submission_id", "pseudonym"}):
             before = getattr(donor_before, field, None)
             after = getattr(donor_metadata, field)
             donor_data.changes.append((field, before, after))
@@ -694,18 +705,17 @@ def diff_donor(donor: Donor, donors_in_db_submission: dict[str, Donor], submissi
 @click.pass_context
 def populate(ctx: click.Context, submission_id: str, metadata_path: str, submission_date: datetime | None, confirm: bool, ignore_field: tuple[str]):  # noqa: PLR0913, PLR0915, PLR0912, C901
     updates: bool = False
-    ignore_field = set(ignore_field)
+    ignore_fields: set[str] = set(ignore_field)
 
     if submission_date is not None:
-        submission_date = submission_date.date()
         log.info("Submission date from provided option is used")
-        if submission_date >= date.today() + timedelta(days = 1):
+        if submission_date.date() >= date.today() + timedelta(days = 1):
             raise RuntimeError(f"Submission date ({submission_date.date()}) is set to a future date (today: {date.today()}) which is not allowed") 
     else:
         log.warning("Submission date from metadata.json is used")
 
     """Populate the submission database from a metadata JSON file."""
-    log.debug("Ignored fields for populate: %s", ignore_field)
+    log.debug("Ignored fields for populate: %s", ignore_fields)
 
     db = ctx.obj["db_url"]
     db_service = get_submission_db_instance(db, author=ctx.obj["author"])
@@ -734,7 +744,7 @@ def populate(ctx: click.Context, submission_id: str, metadata_path: str, submiss
     # add the filesize; would be better with SubmissionMetadata but then without validation
     submission_size = metadata.get_submission_size()
 
-    submission_information = diff_metadata(submission, metadata, submission_size, submission_date, metadata_string, ignore_field)
+    submission_information = diff_metadata(submission, metadata, submission_size, submission_date, metadata_string, ignore_fields)
     diff_table_submission = _prepare_submission_console_table(submission_information.db_ingest)
     if submission_information.change: updates = True
 
@@ -979,6 +989,7 @@ def show(ctx: click.Context, submission_id: str, output_json: bool):
         ("tanG", "tan_g"),
         ("Pseudonym", "pseudonym"),
         ("Submission Date", "submission_date"),
+        ("Submission Size", "submission_size"),
         ("Submission Type", "submission_type"),
         ("Submitter ID", "submitter_id"),
         ("Data Node ID", "data_node_id"),

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -564,7 +564,7 @@ class SubmissionData:
     change_notnull: bool = False
     new: bool = False
 
-def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submission_size: int, submission_date: date | None, metadata_content: str, ignore_fields: set[str] | None = None) -> SubmissionData: # noqa: PLR0913
+def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submission_size: int, submission_date: date | None, metadata_content: str, ignore_fields: set[str] | None = None) -> SubmissionData: # noqa: PLR0913, C901, PLR0912
     submission_data = SubmissionData([], [], [])
     if ignore_fields is None:
         ignore_fields = set()
@@ -572,35 +572,22 @@ def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submi
     if submission_date is None:
         submission_date = metadata.submission.submission_date
 
-    # refuse to ingest metadata when tan_g is redacted
-    if metadata.submission.tan_g == REDACTED_TAN and "tan_g" not in ignore_fields:
-        raise ValueError(
-            "Refusing to populate a seemingly-redacted TAN (all zeros). "
-            "Use 'grzctl db submission modify' directly."
-        )
-
-    # refuse to ingest metadata when local case ID is empty
-    if submission.pseudonym != metadata.submission.local_case_id and not metadata.submission.local_case_id and "pseudonym" not in ignore_fields:
-        raise ValueError(
-            "Refusing to populate a seemingly-redacted local case ID (empty). "
-            "Use 'grzctl db submission modify' directly."
-        )
-
-    # taken from grzctl.commands.db.cli.popuplate; they have the same name in database and metadata.json
     simple_fields = {"tan_g", "submission_type", "submitter_id", "coverage_type", "disease_type", "genomic_study_type","genomic_study_subtype"}
 
     for key in simple_fields - ignore_fields:
         submission_info = getattr(submission, key)
         metadata_info = getattr(metadata.submission, key)
         if submission_info is None:
-            submission_data.new = True # indicator for a new submission because a field is still None
-        log.info(f"FUBAR {submission_info} {type(submission_info)} {metadata_info} {type(metadata_info)}")
-        if submission_info != metadata_info:
+            submission_data.new = True  # indicator for a new submission because a field is still None
+            if metadata_info is not None:  # None vs non-None is a change
+                submission_data.db_ingest.append((key, submission_info, metadata_info))
+                submission_data.update.append(key)
+                submission_data.change = True  # tracking changes in general
+        elif submission_info != metadata_info:
             submission_data.db_ingest.append((key, submission_info, metadata_info))
             submission_data.update.append(key)
             submission_data.change = True # tracking changes in general
-            if submission_info is not None: # tracking changes when the database field was Null
-                submission_data.change_notnull = True
+            submission_data.change_notnull = True
         else:
             submission_data.unchanged.append(key) # no change of existing data in database
 
@@ -618,33 +605,43 @@ def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submi
         submission_info = getattr(submission, key)
         if submission_info is None:
             submission_data.new = True # indicator for a new submission because a field is still None
-        if submission_info != value:
+            if value is not None:  # None vs non-None is a change
+                submission_data.db_ingest.append((key, submission_info, value))
+                submission_data.update.append(key)
+                submission_data.change = True # tracking changes in general
+        elif submission_info != value:
             submission_data.db_ingest.append((key, submission_info, value))
             submission_data.update.append(key)
             submission_data.change = True # tracking changes in general
-            if submission_info is not None: # tracking changes when the database field was Null
-                submission_data.change_notnull = True
+            submission_data.change_notnull = True
         else:
             submission_data.unchanged.append(key) # no change of existing data in database
 
     return submission_data
 
+class DonorStatus(StrEnum):
+    NEW = "new"
+    NEW_RESUB = "new (resubmission)"
+    UPDATE = "update"
+    UNCHANGED = "unchanged"
+
 @dataclass
 class DonorDiff:
-    added: list[DBDonor]
-    updated: list[DBDonor]
-    deleted: list[DBDonor]
-    unchanged: list[DBDonor]
-    diff_tables: list[rich.console.RenderableType]
+    added: list[DBDonor] = field(default_factory=list)
+    updated: list[DBDonor] = field(default_factory=list)
+    deleted: list[DBDonor] = field(default_factory=list)
+    unchanged: list[DBDonor] = field(default_factory=list)
+    diff_tables: list[rich.console.RenderableType] = field(default_factory=list)
 
 @dataclass
 class DonorData:
     donor: DBDonor
     changes: list[tuple[str, Any, Any]] = field(default_factory=list)
-    name: str = ""
-    status: str = ""
+    status: DonorStatus = DonorStatus.UNCHANGED
 
 def diff_donor(donor: MetadataDonor, donors_in_db_submission: dict[str, DBDonor], submission_id: str) -> DonorData:
+    new_submission = len(donors_in_db_submission) == 0
+
     donor_metadata = DBDonor.model_validate(
         {
             "submission_id": submission_id,
@@ -665,17 +662,16 @@ def diff_donor(donor: MetadataDonor, donors_in_db_submission: dict[str, DBDonor]
         }
     )
 
-    donor_data = DonorData(donor = donor_metadata)
-    donor_data.name = donor_metadata.pseudonym
+    donor_data = DonorData(donor=donor_metadata)
     donor_before = donors_in_db_submission.get(donor_metadata.pseudonym)
     if donor_before == donor_metadata:
-        donor_data.status = "unchanged"
+        donor_data.status = DonorStatus.UNCHANGED
     elif donor_before is None:
-        donor_data.status = "new"
+        donor_data.status = DonorStatus.NEW if new_submission else DonorStatus.NEW_RESUB
     else:
-        donor_data.status = "update"
+        donor_data.status = DonorStatus.UPDATE
 
-    if donor_data.status != "unchanged":
+    if donor_data.status != DonorStatus.UNCHANGED:
         for field in sorted(DBDonor.model_fields.keys() - {"submission_id", "pseudonym"}):
             before = getattr(donor_before, field, None)
             after = getattr(donor_metadata, field)
@@ -703,9 +699,8 @@ def diff_donor(donor: MetadataDonor, donors_in_db_submission: dict[str, DBDonor]
     multiple=True,
 )
 @click.pass_context
-def populate(ctx: click.Context, submission_id: str, metadata_path: str, submission_date: datetime | None, confirm: bool, ignore_field: tuple[str]):  # noqa: PLR0913, PLR0915, PLR0912, C901
+def populate(ctx: click.Context, submission_id: str, metadata_path: str, submission_date: datetime | None, confirm: bool, ignore_field: tuple[str, ...]):  # noqa: PLR0913, PLR0915, PLR0912, C901
     updates: bool = False
-    ignore_fields: set[str] = set(ignore_field)
 
     if submission_date is not None:
         log.info("Submission date from provided option is used")
@@ -715,7 +710,7 @@ def populate(ctx: click.Context, submission_id: str, metadata_path: str, submiss
         log.warning("Submission date from metadata.json is used")
 
     """Populate the submission database from a metadata JSON file."""
-    log.debug("Ignored fields for populate: %s", ignore_fields)
+    log.debug("Ignored fields for populate: %s", ignore_field)
 
     db = ctx.obj["db_url"]
     db_service = get_submission_db_instance(db, author=ctx.obj["author"])
@@ -741,32 +736,49 @@ def populate(ctx: click.Context, submission_id: str, metadata_path: str, submiss
         metadata_content = metadata.to_redacted_dict(False)
         metadata_string = json.dumps(metadata_content)
 
+    # refuse to ingest metadata when tan_g is redacted
+    if metadata.submission.tan_g == REDACTED_TAN and "tan_g" not in ignore_field:
+        raise ValueError(
+            f"Submission {submission_id} has redacted tan_g in metadata.json: {metadata_path}."
+            "Use 'grzctl db submission modify' directly."
+        )
+
+    # refuse to ingest metadata when local case ID is empty
+    # submission.pseudonym != metadata.submission.local_case_id and 
+    if (not metadata.submission.local_case_id or metadata.submission.local_case_id == "REDACTED_LOCAL_CASE_ID") and "pseudonym" not in ignore_field:
+        raise ValueError(
+            f"Submission {submission_id} has missing or redacted local_case_id in metadata.json: {metadata_path}."
+            "Use 'grzctl db submission modify' directly."
+        )
+
     # add the filesize; would be better with SubmissionMetadata but then without validation
     submission_size = metadata.get_submission_size()
 
-    submission_information = diff_metadata(submission, metadata, submission_size, submission_date, metadata_string, ignore_fields)
+    submission_information = diff_metadata(submission, metadata, submission_size, submission_date, metadata_string, set(ignore_field))
     diff_table_submission = _prepare_submission_console_table(submission_information.db_ingest)
-    if submission_information.change: updates = True
 
     donors_in_metadata: list[str] = []
     donor_diff = DonorDiff([], [], [], [], [])
     for donor in metadata.donors:
         donor_data = diff_donor(donor, donors_in_db_submission, submission_id)
-        donors_in_metadata.append(donor_data.name)
-        if donor_data.status != "unchanged":
+        donors_in_metadata.append(donor_data.donor.pseudonym)
+        if donor_data.status in (DonorStatus.NEW, DonorStatus.UPDATE, DonorStatus.NEW_RESUB):
             updates = True
-            diff_table_donor = _prepare_donor_console_table(donor_data.changes, donor_data.name, donor_data.status)
+            diff_table_donor = _prepare_donor_console_table(donor_data.changes, donor_data.donor.pseudonym, donor_data.status)
             donor_diff.diff_tables.append(diff_table_donor)
-            if donor_data.status == "new":
+            if donor_data.status in (DonorStatus.NEW, DonorStatus.NEW_RESUB):
                 donor_diff.added.append(donor_data.donor)
             else:
                 donor_diff.updated.append(donor_data.donor)
         else:
             donor_diff.unchanged.append(donor_data.donor)
 
-    donor_diff.deleted = [db_donor for db_donor in donors_in_db_submission.values() if db_donor.pseudonym not in donors_in_metadata]
-    for deleted_donor in donor_diff.deleted :
-        donor_diff.diff_tables.append(rich.text.Text(f"Donor {deleted_donor.pseudonym} deleted", style="red"))
+    # Handle deleted donors
+    for db_donor in donors_in_db_submission.values():
+        if db_donor.pseudonym not in donors_in_metadata:
+            updates = True
+            donor_diff.deleted.append(db_donor)
+            donor_diff.diff_tables.append(rich.text.Text(f"Donor {db_donor.pseudonym} deleted", style="red"))
 
     if not updates:
         console_err.print("[green]Database is already up to date with the provided metadata![/green]")
@@ -782,7 +794,7 @@ def populate(ctx: click.Context, submission_id: str, metadata_path: str, submiss
         default=False,
         show_default=True,
     ):
-        for key, _before, after in submission_information.db_ingest:
+        for key, _, after in submission_information.db_ingest:
             db_service.modify_submission(submission_id, key=key, value=after)
         for added_donor in donor_diff.added:
             db_service.add_donor(added_donor)
@@ -791,7 +803,6 @@ def populate(ctx: click.Context, submission_id: str, metadata_path: str, submiss
         for deleted_donor in donor_diff.deleted:
             db_service.delete_donor(deleted_donor)
         console_err.print("[green]Database populated successfully.[/green]")
-
 
 class QCStatus(StrEnum):
     PASS = "PASS"  # noqa: S105

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -561,10 +561,13 @@ class SubmissionData:
     db_ingest: list[tuple[str, Any, Any]]
     change: bool = False
 
-def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submission_size: int, submission_date: date | None, metadata_content: str, ignore_fields: set[str] = set()) -> SubmissionData:
+def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submission_size: int, submission_date: date | None, metadata_content: str, ignore_fields: set[str] | None = None) -> SubmissionData: # noqa: PLR0913
     submission_data = SubmissionData([], [], [])
+    if ignore_fields is None:
+        ignore_fields = set()
     # if date is not provided, fallback to metadata submission_date
-    if submission_date is None: metadata.submission.submission_date
+    if submission_date is None:
+        submission_date = metadata.submission.submission_date
 
     # refuse to ingest metadata when tan_g is redacted
     if metadata.submission.tan_g == REDACTED_TAN:
@@ -574,25 +577,24 @@ def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submi
         )
 
     # refuse to ingest metadata when local case ID is empty
-    if submission.pseudonym != metadata.submission.local_case_id:
-        if not metadata.submission.local_case_id:
-            raise ValueError(
-                "Refusing to populate a seemingly-redacted local case ID (empty). "
-                "Use 'grzctl db submission modify' directly."
-            )
+    if submission.pseudonym != metadata.submission.local_case_id and not metadata.submission.local_case_id:
+        raise ValueError(
+            "Refusing to populate a seemingly-redacted local case ID (empty). "
+            "Use 'grzctl db submission modify' directly."
+        )
 
     # taken from grzctl.commands.db.cli.popuplate; they have the same name in database and metadata.json
     simple_fields = {"tan_g", "submission_type", "submitter_id", "coverage_type", "disease_type", "genomic_study_type","genomic_study_subtype"}
 
-    for field in simple_fields - ignore_fields:
-        submission_info = getattr(submission, field)
-        metadata_info = getattr(metadata.submission, field)
+    for key in simple_fields - ignore_fields:
+        submission_info = getattr(submission, key)
+        metadata_info = getattr(metadata.submission, key)
         if submission_info != metadata_info:
-            submission_data.db_ingest.append((field, submission_info, metadata_info))
-            submission_data.update.append(field)
+            submission_data.db_ingest.append((key, submission_info, metadata_info))
+            submission_data.update.append(key)
             submission_data.change = True
         else:
-            submission_data.unchanged.append(field)
+            submission_data.unchanged.append(key)
 
     complex_fields = (
         ("pseudonym", metadata.submission.local_case_id),
@@ -603,15 +605,15 @@ def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submi
         ("submission_metadata", metadata_content)
     )
 
-    for field, value in complex_fields:
-        if field in ignore_fields: continue
-        submission_info = getattr(submission, field)
+    for key, value in complex_fields:
+        if key in ignore_fields: continue
+        submission_info = getattr(submission, key)
         if submission_info != value:
-            submission_data.db_ingest.append((field, submission_info, value))
-            submission_data.update.append(field)
+            submission_data.db_ingest.append((key, submission_info, value))
+            submission_data.update.append(key)
             submission_data.change = True
         else:
-            submission_data.unchanged.append(field)
+            submission_data.unchanged.append(key)
 
     return submission_data
 
@@ -654,7 +656,7 @@ def diff_donor(donor: Donor, donors_in_db_submission: dict[str, Donor], submissi
     )
     donor_data.name = donor_metadata.pseudonym
     donor_data.donor = donor_metadata
-    donor_before = donors_in_db_submission.get(donor_metadata.pseudonym, None)
+    donor_before = donors_in_db_submission.get(donor_metadata.pseudonym)
     if donor_before == donor_metadata:
         donor_data.status = "unchanged"
     elif donor_before is None:
@@ -690,7 +692,7 @@ def diff_donor(donor: Donor, donors_in_db_submission: dict[str, Donor], submissi
     multiple=True,
 )
 @click.pass_context
-def populate(ctx: click.Context, submission_id: str, metadata_path: str, submission_date: datetime | None, confirm: bool, ignore_field: tuple[str]):  # noqa: C901
+def populate(ctx: click.Context, submission_id: str, metadata_path: str, submission_date: datetime | None, confirm: bool, ignore_field: tuple[str]):  # noqa: PLR0913, PLR0915, PLR0912, C901
     updates: bool = False
     ignore_field = set(ignore_field)
 
@@ -730,12 +732,7 @@ def populate(ctx: click.Context, submission_id: str, metadata_path: str, submiss
         metadata_string = json.dumps(metadata_content)
 
     # add the filesize; would be better with SubmissionMetadata but then without validation
-    submission_size: int = 0  
-    for donor in metadata.donors:
-        for lab_datum in donor.lab_data:
-            if sequence_data := lab_datum.sequence_data:
-                for file in sequence_data.files:
-                    submission_size += file.file_size_in_bytes
+    submission_size = metadata.get_submission_size()
 
     submission_information = diff_metadata(submission, metadata, submission_size, submission_date, metadata_string, ignore_field)
     diff_table_submission = _prepare_submission_console_table(submission_information.db_ingest)
@@ -784,105 +781,6 @@ def populate(ctx: click.Context, submission_id: str, metadata_path: str, submiss
         for deleted_donor in donor_diff.deleted:
             db_service.delete_donor(deleted_donor)
         console_err.print("[green]Database populated successfully.[/green]")
-
-
-# @submission.command()
-# @click.argument("submission_id", type=str)
-# @click.argument("metadata_path", metavar="path/to/metadata.json", type=str)
-# # @click.argument("submission_date", metavar="submission_date (YYYY-MM-DD)", type=click.DateTime(formats=["%Y-%m-%d"]), default = None)
-# @click.option(
-#     "--submission_date",
-#     type=click.DateTime(formats=["%Y-%m-%d"]),
-#     default=None,
-#     help="Submission date of the submission; overwrites submissionDate in metadata.json",
-# )
-# @click.option(
-#     "--confirm/--no-confirm",
-#     default=True,
-#     help="Whether to confirm changes before committing to database. (Default: confirm)",
-# )
-# @click.option(
-#     "--ignore-field",
-#     help="Do not populate the given key from the metadata to the database. Can be specified multiple times to ignore multiple keys.",
-#     multiple=True,
-# )
-# @click.pass_context
-# def populate(ctx: click.Context, submission_id: str, metadata_path: str, submission_date: datetime | None, confirm: bool, ignore_field: tuple[str]):  # noqa: C901
-#     # TODO: add submission_size
-#     ignore_field = set(ignore_field)
-#     if submission_date is not None:
-#         ignore_field.add("submission_date")
-#     """Populate the submission database from a metadata JSON file."""
-#     log.debug("Ignored fields for populate: %s", ignore_field)
-
-#     db = ctx.obj["db_url"]
-#     db_service = get_submission_db_instance(db, author=ctx.obj["author"])
-
-#     try:
-#         submission = db_service.get_submission(submission_id)
-#         if not submission:
-#             raise SubmissionNotFoundError(submission_id)
-#     except SubmissionNotFoundError as e:
-#         console_err.print(f"[red]Error: {e}[/red]")
-#         console_err.print(f"You might need to add it first: grz-cli db submission add {submission_id}")
-#         raise click.Abort() from e
-#     except Exception as e:
-#         console_err.print(f"[red]An unexpected error occurred: {e}[/red]")
-#         traceback.print_exc()
-#         raise click.ClickException(f"Failed to update submission state: {e}") from e
-
-#     with open(metadata_path, encoding="utf-8") as metadata_file:
-#         metadata = GrzSubmissionMetadata.model_validate_json(metadata_file.read())
-
-#         metadata_file.seek(0)
-#         metadata_content = json.load(metadata_file)
-#         # redact tanG, local case id and potential tanG in the patient information
-#         metadata_content = _redact_metadata(metadata_content)
-#         metadata_string = json.dumps(metadata_content)
-
-#     changes = _diff_metadata(submission, metadata, submission_date, metadata_string, ignore_field)
-
-#     # consent records
-#     donor_diff = _diff_donors(
-#         donors_in_submission=db_service.get_donors(submission_id=submission_id),
-#         submission_id=submission_id,
-#         metadata=metadata,
-#     )
-
-#     if not any(dataclasses.astuple(donor_diff)):
-#         console_err.print("[green]Database is already up to date with the provided metadata![/green]")
-#         ctx.exit()
-
-#     diff_table: rich.console.RenderableType
-#     if changes:
-#         diff_table = rich.table.Table(title="Submission Metadata")
-#         diff_table.add_column("Key")
-#         diff_table.add_column("Before")
-#         diff_table.add_column("After")
-#         for key, before, after in sorted(changes, key=itemgetter(0)):
-#             diff_table.add_row(key, str(before) if before is not None else _TEXT_MISSING, str(after))
-#     else:
-#         diff_table = rich.padding.Padding(rich.text.Text("No changes to submission-level metadata."), pad=(0, 0, 1, 0))
-
-#     panel = rich.panel.Panel.fit(
-#         rich.console.Group(diff_table, *donor_diff.diff_tables, fit=True), title="Pending Changes"
-#     )
-#     console.print(panel)
-
-#     if not confirm or click.confirm(
-#         "Are you sure you want to commit these changes to the database?",
-#         default=False,
-#         show_default=True,
-#     ):
-#         for key, _before, after in changes:
-#             _ = db_service.modify_submission(submission_id, key=key, value=after)
-#         for added_donor in donor_diff.added:
-#             _ = db_service.add_donor(added_donor)
-#         for updated_donor in donor_diff.updated:
-#             _ = db_service.update_donor(updated_donor)
-#         for deleted_donor in donor_diff.deleted:
-#             db_service.delete_donor(deleted_donor)
-#         console_err.print("[green]Database populated successfully.[/green]")
 
 
 class QCStatus(StrEnum):

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -523,20 +523,6 @@ def modify(ctx: click.Context, submission_id: str, key: str, value: str):
         traceback.print_exc()
         raise click.ClickException(f"Failed to update submission state: {e}") from e
 
-# TODO: identical part in to grz_common.workers.upload.py : S3BotoUploadWorker.archive()
-# TODO: identical function in grz_common.workers.worker.py; just here due to circular import because of get_submission_db_instance
-def redact_metadata(metadata_content: dict[str, Any]) -> dict[str, Any]:
-    # redact tanG as all zeros
-    metadata_content["submission"]["tanG"] = REDACTED_TAN
-    # redact local case ID
-    metadata_content["submission"]["localCaseId"] = ""
-
-    for donor in metadata_content["donors"]:
-        if donor["relation"] == "index":
-            # redact index donorPseudonym (which can be the tanG)
-            donor["donorPseudonym"] = "index"
-    return metadata_content
-
 def _prepare_submission_console_table(submission_data: list[tuple[str, Any, Any]]) -> rich.console.RenderableType:
     diff_table: rich.console.RenderableType
 
@@ -629,72 +615,6 @@ def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submi
 
     return submission_data
 
-# def _diff_metadata(
-#     submission: Submission, metadata: GrzSubmissionMetadata, submission_date: datetime, metadata_content: str, ignore_fields: set[str]
-# ) -> list[tuple[str, Any, Any]]:
-#     """Given a database submission and a metadata.json file, report changed fields and their before/after values if they are not in ignore_fields."""
-#     changes = []
-
-#     simple_fields = {
-#         "tan_g",
-#         "submission_date",
-#         "submission_type",
-#         "submitter_id",
-#         "coverage_type",
-#         "disease_type",
-#         "genomic_study_type",
-#         "genomic_study_subtype",
-#     }
-#     # submission_date is substracted from simple_fields when it is in ignore_fields
-#     for field in simple_fields - ignore_fields:
-#         if field == "tan_g" and metadata.submission.tan_g == REDACTED_TAN:
-#             raise ValueError(
-#                 "Refusing to populate a seemingly-redacted TAN (all zeros). "
-#                 "Add 'tan_g' to --ignore-field or use 'grzctl db submission modify' directly."
-#             )
-#         submission_attr = getattr(submission, field)
-#         metadata_attr = getattr(metadata.submission, field)
-#         if submission_attr != metadata_attr:
-#             changes.append((field, submission_attr, metadata_attr))
-    
-#     # when it's in ignore_fields, then it was provided and should be added
-#     if "submission_date" in ignore_fields:
-#         changes.append(("submission_date", getattr(submission, "submission_date"), submission_date))
-
-#     #  add the filesize
-#     submission_size: int = 0  
-#     for donor in metadata.donors:
-#         for lab_datum in donor.lab_data:
-#             if sequence_data := lab_datum.sequence_data:
-#                 for file in sequence_data.files:
-#                     submission_size += file.file_size_in_bytes
-#     if "submission_size" not in ignore_fields and submission.submission_size != submission_size:
-#         changes.append(("submission_size", submission.submission_size, submission_size))
-
-#     if "submission_metadata" not in ignore_fields and submission.submission_metadata != metadata_content:
-#         changes.append(("submission_metadata", submission.submission_metadata, metadata_content))
-
-#     # pseudonym (TODO: change after phase 0)
-#     if "pseudonym" not in ignore_fields and (submission.pseudonym != metadata.submission.local_case_id):
-#         if not metadata.submission.local_case_id:
-#             raise ValueError(
-#                 "Refusing to populate a seemingly-redacted local case ID (empty). "
-#                 "Add 'pseudonym' to --ignore-field or use 'grzctl db submission modify' directly."
-#             )
-#         changes.append(("pseudonym", submission.pseudonym, metadata.submission.local_case_id))
-
-#     # data node id
-#     if "data_node_id" not in ignore_fields and (submission.data_node_id != metadata.submission.genomic_data_center_id):
-#         changes.append(("data_node_id", submission.data_node_id, metadata.submission.genomic_data_center_id))
-
-#     # consent state
-#     consented = metadata.consents_to_research(date=date.today())
-#     if submission.consented != consented:
-#         changes.append(("consented", submission.consented, consented))
-
-#     return changes
-
-
 @dataclass
 class DonorDiff:
     added: list[Donor]
@@ -749,123 +669,6 @@ def diff_donor(donor: Donor, donors_in_db_submission: dict[str, Donor], submissi
             donor_data.changes.append((field, before, after))
 
     return donor_data
-
-# def _diff_donors(metadata: SubmissionMetadata, donors_in_db_submission: dict[str, Donor], submission_id: str):
-#     donor_data = SubmissionDonorData([], [], [], [])
-#     donors_pseudonym_metadata: list[str] = []
-
-#     for donor in metadata.content.donors:
-#         donor_metadata = Donor.model_validate(
-#             {
-#                 "submission_id": submission_id,
-#                 "pseudonym": "index" if donor.relation == Relation.index_ else donor.donor_pseudonym,
-#                 "relation": Relation(donor.relation),
-#                 "library_types": {datum.library_type for datum in donor.lab_data},
-#                 "sequence_types": {datum.sequence_type for datum in donor.lab_data},
-#                 "sequence_subtypes": {datum.sequence_subtype for datum in donor.lab_data},
-#                 "mv_consented": donor.consents_to_mv(),
-#                 "research_consented": donor.consents_to_research(date=date.today()),
-#                 "research_consent_missing_justifications": {
-#                     consent.no_scope_justification
-#                     for consent in donor.research_consents
-#                     if consent.no_scope_justification is not None
-#                 }
-#                 if donor.research_consents
-#                 else None,
-#             }
-#         )
-#         donors_pseudonym_metadata.append(donor_metadata.pseudonym)
-#         donor_before = donors_in_db_submission.get(donor_metadata.pseudonym, None)
-#         if donor_before == donor_metadata:
-#             donor_data.unchanged.append(donor_metadata)
-#         elif donor_before is None:
-#             donor_data.db_ingest.append(donor_metadata)
-#             donor_data.change = True
-#         else:
-#             donor_data.update.append(donor_metadata)
-#             donor_data.change = True
-#     # build list of donors which are to be dropped from database because they are not in the downloaded sumbission anymore
-#     donor_data.delete = [db_donor for db_donor in donors_in_db_submission.values() if db_donor.pseudonym not in donors_pseudonym_metadata]
-#     if donor_data.delete: donor_data.change = True
-
-#     return donor_data
-
-# def _diff_donors(
-#     donors_in_submission: tuple[Donor, ...], submission_id: str, metadata: GrzSubmissionMetadata
-# ) -> _DonorDiff:
-#     pseudonym2before = {donor.pseudonym: donor for donor in donors_in_submission}
-
-#     added_donors = []
-#     updated_donors = []
-#     type Pseudonym = str
-#     pending_pseudonyms: set[Pseudonym] = set()
-#     donor_diff_tables: list[rich.console.RenderableType] = []
-#     for donor in metadata.donors:
-#         # we use submission ID passed to this function instead of metadata
-#         # because the tanG might be redacted and therefore the
-#         # metadata-calculated submission ID would change.
-#         # Also, we use model_validate here instead of __init__ because of:
-#         # https://github.com/fastapi/sqlmodel/issues/453
-#         donor_after = Donor.model_validate(
-#             {
-#                 "submission_id": submission_id,
-#                 "pseudonym": "index" if donor.relation == Relation.index_ else donor.donor_pseudonym,
-#                 "relation": Relation(donor.relation),
-#                 "library_types": {datum.library_type for datum in donor.lab_data},
-#                 "sequence_types": {datum.sequence_type for datum in donor.lab_data},
-#                 "sequence_subtypes": {datum.sequence_subtype for datum in donor.lab_data},
-#                 "mv_consented": donor.consents_to_mv(),
-#                 "research_consented": donor.consents_to_research(date=date.today()),
-#                 "research_consent_missing_justifications": {
-#                     consent.no_scope_justification
-#                     for consent in donor.research_consents
-#                     if consent.no_scope_justification is not None
-#                 }
-#                 if donor.research_consents
-#                 else None,
-#             }
-#         )
-#         donor_before = pseudonym2before.get(donor_after.pseudonym, None)
-#         pending_pseudonyms.add(donor_after.pseudonym)
-#         change = "added"
-#         if donor_before == donor_after:
-#             continue
-#         if donor_before is None:
-#             added_donors.append(donor_after)
-#         else:
-#             updated_donors.append(donor_after)
-#             change = "updated"
-
-#         table_title = f"[green]Donor '{donor_after.pseudonym}' {change}[/green]"
-#         diff_table = rich.table.Table(title=table_title, min_width=len(table_title), title_justify="left")
-#         diff_table.add_column("Key")
-#         diff_table.add_column("Before")
-#         diff_table.add_column("After")
-#         for field in sorted(Donor.model_fields.keys() - {"submission_id", "pseudonym"}):
-#             before = getattr(donor_before, field, None)
-#             after = getattr(donor_after, field)
-#             if before != after:
-#                 diff_table.add_row(
-#                     field, _TEXT_MISSING if before is None else rich.pretty.Pretty(before), rich.pretty.Pretty(after)
-#                 )
-#         if diff_table.row_count:
-#             donor_diff_tables.append(diff_table)
-
-#     deleted_donors = tuple(
-#         filter(
-#             lambda donor: donor.pseudonym not in pending_pseudonyms,
-#             pseudonym2before.values(),
-#         )
-#     )
-#     for deleted_donor in deleted_donors:
-#         donor_diff_tables.append(rich.text.Text(f"Donor {deleted_donor.pseudonym} deleted", style="red"))
-
-#     return _DonorDiff(
-#         added=tuple(added_donors),
-#         updated=tuple(updated_donors),
-#         deleted=deleted_donors,
-#         diff_tables=tuple(donor_diff_tables),
-#     )
 
 @submission.command()
 @click.argument("submission_id", type=str)
@@ -923,11 +726,7 @@ def populate(ctx: click.Context, submission_id: str, metadata_path: str, submiss
 
     with open(metadata_path, encoding="utf-8") as metadata_file:
         metadata = GrzSubmissionMetadata.model_validate_json(metadata_file.read())
-
-        metadata_file.seek(0)
-        metadata_content = json.load(metadata_file)
-        # redact tanG, local case id and potential tanG in the patient information
-        metadata_content = redact_metadata(metadata_content)
+        metadata_content = metadata.to_redacted_dict(False)
         metadata_string = json.dumps(metadata_content)
 
     # add the filesize; would be better with SubmissionMetadata but then without validation

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -1,13 +1,13 @@
 """Command for managing a submission database"""
 
 import csv
-import dataclasses
 import json
 import logging
 import sys
 import traceback
 from collections import namedtuple
-from datetime import UTC, date, datetime
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
 from operator import itemgetter
 from pathlib import Path
@@ -523,145 +523,359 @@ def modify(ctx: click.Context, submission_id: str, key: str, value: str):
         traceback.print_exc()
         raise click.ClickException(f"Failed to update submission state: {e}") from e
 
+# TODO: identical part in to grz_common.workers.upload.py : S3BotoUploadWorker.archive()
+# TODO: identical function in grz_common.workers.worker.py; just here due to circular import because of get_submission_db_instance
+def redact_metadata(metadata_content: dict[str, Any]) -> dict[str, Any]:
+    # redact tanG as all zeros
+    metadata_content["submission"]["tanG"] = REDACTED_TAN
+    # redact local case ID
+    metadata_content["submission"]["localCaseId"] = ""
 
-def _diff_metadata(
-    submission: Submission, metadata: GrzSubmissionMetadata, ignore_fields: set[str]
-) -> list[tuple[str, Any, Any]]:
-    """Given a database submission and a metadata.json file, report changed fields and their before/after values if they are not in ignore_fields."""
-    changes = []
+    for donor in metadata_content["donors"]:
+        if donor["relation"] == "index":
+            # redact index donorPseudonym (which can be the tanG)
+            donor["donorPseudonym"] = "index"
+    return metadata_content
 
-    simple_fields = {
-        "tan_g",
-        "submission_date",
-        "submission_type",
-        "submitter_id",
-        "coverage_type",
-        "disease_type",
-        "genomic_study_type",
-        "genomic_study_subtype",
-    }
+def _prepare_submission_console_table(submission_data: list[tuple[str, Any, Any]]) -> rich.console.RenderableType:
+    diff_table: rich.console.RenderableType
 
-    for field in simple_fields - ignore_fields:
-        if field == "tan_g" and metadata.submission.tan_g == REDACTED_TAN:
-            raise ValueError(
-                "Refusing to populate a seemingly-redacted TAN (all zeros). "
-                "Add 'tan_g' to --ignore-field or use 'grzctl db submission modify' directly."
-            )
-        submission_attr = getattr(submission, field)
-        metadata_attr = getattr(metadata.submission, field)
-        if submission_attr != metadata_attr:
-            changes.append((field, submission_attr, metadata_attr))
-
-    # pseudonym (TODO: change after phase 0)
-    if "pseudonym" not in ignore_fields and (submission.pseudonym != metadata.submission.local_case_id):
-        if not metadata.submission.local_case_id:
-            raise ValueError(
-                "Refusing to populate a seemingly-redacted local case ID (empty). "
-                "Add 'pseudonym' to --ignore-field or use 'grzctl db submission modify' directly."
-            )
-        changes.append(("pseudonym", submission.pseudonym, metadata.submission.local_case_id))
-
-    # data node id
-    if "data_node_id" not in ignore_fields and (submission.data_node_id != metadata.submission.genomic_data_center_id):
-        changes.append(("data_node_id", submission.data_node_id, metadata.submission.genomic_data_center_id))
-
-    # consent state
-    consented = metadata.consents_to_research(date=date.today())
-    if submission.consented != consented:
-        changes.append(("consented", submission.consented, consented))
-
-    return changes
-
-
-@dataclasses.dataclass
-class _DonorDiff:
-    added: tuple[Donor, ...]
-    updated: tuple[Donor, ...]
-    deleted: tuple[Donor, ...]
-    diff_tables: tuple[rich.console.RenderableType, ...]
-
-
-def _diff_donors(
-    donors_in_submission: tuple[Donor, ...], submission_id: str, metadata: GrzSubmissionMetadata
-) -> _DonorDiff:
-    pseudonym2before = {donor.pseudonym: donor for donor in donors_in_submission}
-
-    added_donors = []
-    updated_donors = []
-    type Pseudonym = str
-    pending_pseudonyms: set[Pseudonym] = set()
-    donor_diff_tables: list[rich.console.RenderableType] = []
-    for donor in metadata.donors:
-        # we use submission ID passed to this function instead of metadata
-        # because the tanG might be redacted and therefore the
-        # metadata-calculated submission ID would change.
-        # Also, we use model_validate here instead of __init__ because of:
-        # https://github.com/fastapi/sqlmodel/issues/453
-        donor_after = Donor.model_validate(
-            {
-                "submission_id": submission_id,
-                "pseudonym": "index" if donor.relation == Relation.index_ else donor.donor_pseudonym,
-                "relation": Relation(donor.relation),
-                "library_types": {datum.library_type for datum in donor.lab_data},
-                "sequence_types": {datum.sequence_type for datum in donor.lab_data},
-                "sequence_subtypes": {datum.sequence_subtype for datum in donor.lab_data},
-                "mv_consented": donor.consents_to_mv(),
-                "research_consented": donor.consents_to_research(date=date.today()),
-                "research_consent_missing_justifications": {
-                    consent.no_scope_justification
-                    for consent in donor.research_consents
-                    if consent.no_scope_justification is not None
-                }
-                if donor.research_consents
-                else None,
-            }
-        )
-        donor_before = pseudonym2before.get(donor_after.pseudonym)
-        pending_pseudonyms.add(donor_after.pseudonym)
-        change = "added"
-        if donor_before == donor_after:
-            continue
-        if donor_before is None:
-            added_donors.append(donor_after)
-        else:
-            updated_donors.append(donor_after)
-            change = "updated"
-
-        table_title = f"[green]Donor '{donor_after.pseudonym}' {change}[/green]"
-        diff_table = rich.table.Table(title=table_title, min_width=len(table_title), title_justify="left")
+    if submission_data:
+        diff_table = rich.table.Table(title="Submission Metadata")
         diff_table.add_column("Key")
         diff_table.add_column("Before")
         diff_table.add_column("After")
+        for key, before, after in sorted(submission_data, key=itemgetter(0)):
+            # metadata is quite large; should it be visualised?
+            if key == "submission_metadata": continue
+            diff_table.add_row(key, str(before) if before is not None else _TEXT_MISSING, str(after))
+    else:
+        diff_table = rich.padding.Padding(rich.text.Text("No changes to submission-level metadata."), pad=(0, 0, 0, 0))
+    return diff_table
+
+def _prepare_donor_console_table(donor_data: list[tuple[str, Any, Any]], donor_id: str, status: str) -> rich.console.RenderableType:
+    diff_table: rich.console.RenderableType
+
+    table_title = f"[green]Donor '{donor_id}' database status: {status}[/green]"
+    diff_table = rich.table.Table(title=table_title, min_width=len(table_title), title_justify="left")
+    diff_table.add_column("Key")
+    diff_table.add_column("Before")
+    diff_table.add_column("After")
+    for key, before, after in sorted(donor_data, key=itemgetter(0)):
+        if before != after:
+            diff_table.add_row(
+                key, _TEXT_MISSING if before is None else rich.pretty.Pretty(before), rich.pretty.Pretty(after)
+            )
+    return diff_table
+
+@dataclass
+class SubmissionData:
+    update: list[str]
+    unchanged: list[str]
+    db_ingest: list[tuple[str, Any, Any]]
+    change: bool = False
+
+def diff_metadata(submission: Submission, metadata: GrzSubmissionMetadata, submission_size: int, submission_date: date | None, metadata_content: str, ignore_fields: set[str] = set()) -> SubmissionData:
+    submission_data = SubmissionData([], [], [])
+    # if date is not provided, fallback to metadata submission_date
+    if submission_date is None: metadata.submission.submission_date
+
+    # refuse to ingest metadata when tan_g is redacted
+    if metadata.submission.tan_g == REDACTED_TAN:
+        raise ValueError(
+            "Refusing to populate a seemingly-redacted TAN (all zeros). "
+            "Use 'grzctl db submission modify' directly."
+        )
+
+    # refuse to ingest metadata when local case ID is empty
+    if submission.pseudonym != metadata.submission.local_case_id:
+        if not metadata.submission.local_case_id:
+            raise ValueError(
+                "Refusing to populate a seemingly-redacted local case ID (empty). "
+                "Use 'grzctl db submission modify' directly."
+            )
+
+    # taken from grzctl.commands.db.cli.popuplate; they have the same name in database and metadata.json
+    simple_fields = {"tan_g", "submission_type", "submitter_id", "coverage_type", "disease_type", "genomic_study_type","genomic_study_subtype"}
+
+    for field in simple_fields - ignore_fields:
+        submission_info = getattr(submission, field)
+        metadata_info = getattr(metadata.submission, field)
+        if submission_info != metadata_info:
+            submission_data.db_ingest.append((field, submission_info, metadata_info))
+            submission_data.update.append(field)
+            submission_data.change = True
+        else:
+            submission_data.unchanged.append(field)
+
+    complex_fields = (
+        ("pseudonym", metadata.submission.local_case_id),
+        ("data_node_id", metadata.submission.genomic_data_center_id),
+        ("consented", metadata.consents_to_research(date=date.today())),
+        ("submission_size", submission_size),
+        ("submission_date", submission_date),
+        ("submission_metadata", metadata_content)
+    )
+
+    for field, value in complex_fields:
+        if field in ignore_fields: continue
+        submission_info = getattr(submission, field)
+        if submission_info != value:
+            submission_data.db_ingest.append((field, submission_info, value))
+            submission_data.update.append(field)
+            submission_data.change = True
+        else:
+            submission_data.unchanged.append(field)
+
+    return submission_data
+
+# def _diff_metadata(
+#     submission: Submission, metadata: GrzSubmissionMetadata, submission_date: datetime, metadata_content: str, ignore_fields: set[str]
+# ) -> list[tuple[str, Any, Any]]:
+#     """Given a database submission and a metadata.json file, report changed fields and their before/after values if they are not in ignore_fields."""
+#     changes = []
+
+#     simple_fields = {
+#         "tan_g",
+#         "submission_date",
+#         "submission_type",
+#         "submitter_id",
+#         "coverage_type",
+#         "disease_type",
+#         "genomic_study_type",
+#         "genomic_study_subtype",
+#     }
+#     # submission_date is substracted from simple_fields when it is in ignore_fields
+#     for field in simple_fields - ignore_fields:
+#         if field == "tan_g" and metadata.submission.tan_g == REDACTED_TAN:
+#             raise ValueError(
+#                 "Refusing to populate a seemingly-redacted TAN (all zeros). "
+#                 "Add 'tan_g' to --ignore-field or use 'grzctl db submission modify' directly."
+#             )
+#         submission_attr = getattr(submission, field)
+#         metadata_attr = getattr(metadata.submission, field)
+#         if submission_attr != metadata_attr:
+#             changes.append((field, submission_attr, metadata_attr))
+    
+#     # when it's in ignore_fields, then it was provided and should be added
+#     if "submission_date" in ignore_fields:
+#         changes.append(("submission_date", getattr(submission, "submission_date"), submission_date))
+
+#     #  add the filesize
+#     submission_size: int = 0  
+#     for donor in metadata.donors:
+#         for lab_datum in donor.lab_data:
+#             if sequence_data := lab_datum.sequence_data:
+#                 for file in sequence_data.files:
+#                     submission_size += file.file_size_in_bytes
+#     if "submission_size" not in ignore_fields and submission.submission_size != submission_size:
+#         changes.append(("submission_size", submission.submission_size, submission_size))
+
+#     if "submission_metadata" not in ignore_fields and submission.submission_metadata != metadata_content:
+#         changes.append(("submission_metadata", submission.submission_metadata, metadata_content))
+
+#     # pseudonym (TODO: change after phase 0)
+#     if "pseudonym" not in ignore_fields and (submission.pseudonym != metadata.submission.local_case_id):
+#         if not metadata.submission.local_case_id:
+#             raise ValueError(
+#                 "Refusing to populate a seemingly-redacted local case ID (empty). "
+#                 "Add 'pseudonym' to --ignore-field or use 'grzctl db submission modify' directly."
+#             )
+#         changes.append(("pseudonym", submission.pseudonym, metadata.submission.local_case_id))
+
+#     # data node id
+#     if "data_node_id" not in ignore_fields and (submission.data_node_id != metadata.submission.genomic_data_center_id):
+#         changes.append(("data_node_id", submission.data_node_id, metadata.submission.genomic_data_center_id))
+
+#     # consent state
+#     consented = metadata.consents_to_research(date=date.today())
+#     if submission.consented != consented:
+#         changes.append(("consented", submission.consented, consented))
+
+#     return changes
+
+
+@dataclass
+class DonorDiff:
+    added: list[Donor]
+    updated: list[Donor]
+    deleted: list[Donor]
+    unchanged: list[Donor]
+    diff_tables: list[rich.console.RenderableType]
+
+@dataclass
+class DonorData:
+    changes: list[tuple[str, Any, Any]] = field(default_factory=list)
+    name: str = ""
+    status: str = ""
+    donor: Donor | None = None
+
+def diff_donor(donor: Donor, donors_in_db_submission: dict[str, Donor], submission_id: str) -> DonorData:
+    donor_data = DonorData([])
+
+    donor_metadata = Donor.model_validate(
+        {
+            "submission_id": submission_id,
+            "pseudonym": "index" if donor.relation == Relation.index_ else donor.donor_pseudonym,
+            "relation": Relation(donor.relation),
+            "library_types": {datum.library_type for datum in donor.lab_data},
+            "sequence_types": {datum.sequence_type for datum in donor.lab_data},
+            "sequence_subtypes": {datum.sequence_subtype for datum in donor.lab_data},
+            "mv_consented": donor.consents_to_mv(),
+            "research_consented": donor.consents_to_research(date=date.today()),
+            "research_consent_missing_justifications": {
+                consent.no_scope_justification
+                for consent in donor.research_consents
+                if consent.no_scope_justification is not None
+            }
+            if donor.research_consents
+            else None,
+        }
+    )
+    donor_data.name = donor_metadata.pseudonym
+    donor_data.donor = donor_metadata
+    donor_before = donors_in_db_submission.get(donor_metadata.pseudonym, None)
+    if donor_before == donor_metadata:
+        donor_data.status = "unchanged"
+    elif donor_before is None:
+        donor_data.status = "new"
+    else:
+        donor_data.status = "update"
+
+    if donor_data.status != "unchanged":
         for field in sorted(Donor.model_fields.keys() - {"submission_id", "pseudonym"}):
             before = getattr(donor_before, field, None)
-            after = getattr(donor_after, field)
-            if before != after:
-                diff_table.add_row(
-                    field, _TEXT_MISSING if before is None else rich.pretty.Pretty(before), rich.pretty.Pretty(after)
-                )
-        if diff_table.row_count:
-            donor_diff_tables.append(diff_table)
+            after = getattr(donor_metadata, field)
+            donor_data.changes.append((field, before, after))
 
-    deleted_donors = tuple(
-        filter(
-            lambda donor: donor.pseudonym not in pending_pseudonyms,
-            pseudonym2before.values(),
-        )
-    )
-    for deleted_donor in deleted_donors:
-        donor_diff_tables.append(rich.text.Text(f"Donor {deleted_donor.pseudonym} deleted", style="red"))
+    return donor_data
 
-    return _DonorDiff(
-        added=tuple(added_donors),
-        updated=tuple(updated_donors),
-        deleted=deleted_donors,
-        diff_tables=tuple(donor_diff_tables),
-    )
+# def _diff_donors(metadata: SubmissionMetadata, donors_in_db_submission: dict[str, Donor], submission_id: str):
+#     donor_data = SubmissionDonorData([], [], [], [])
+#     donors_pseudonym_metadata: list[str] = []
 
+#     for donor in metadata.content.donors:
+#         donor_metadata = Donor.model_validate(
+#             {
+#                 "submission_id": submission_id,
+#                 "pseudonym": "index" if donor.relation == Relation.index_ else donor.donor_pseudonym,
+#                 "relation": Relation(donor.relation),
+#                 "library_types": {datum.library_type for datum in donor.lab_data},
+#                 "sequence_types": {datum.sequence_type for datum in donor.lab_data},
+#                 "sequence_subtypes": {datum.sequence_subtype for datum in donor.lab_data},
+#                 "mv_consented": donor.consents_to_mv(),
+#                 "research_consented": donor.consents_to_research(date=date.today()),
+#                 "research_consent_missing_justifications": {
+#                     consent.no_scope_justification
+#                     for consent in donor.research_consents
+#                     if consent.no_scope_justification is not None
+#                 }
+#                 if donor.research_consents
+#                 else None,
+#             }
+#         )
+#         donors_pseudonym_metadata.append(donor_metadata.pseudonym)
+#         donor_before = donors_in_db_submission.get(donor_metadata.pseudonym, None)
+#         if donor_before == donor_metadata:
+#             donor_data.unchanged.append(donor_metadata)
+#         elif donor_before is None:
+#             donor_data.db_ingest.append(donor_metadata)
+#             donor_data.change = True
+#         else:
+#             donor_data.update.append(donor_metadata)
+#             donor_data.change = True
+#     # build list of donors which are to be dropped from database because they are not in the downloaded sumbission anymore
+#     donor_data.delete = [db_donor for db_donor in donors_in_db_submission.values() if db_donor.pseudonym not in donors_pseudonym_metadata]
+#     if donor_data.delete: donor_data.change = True
+
+#     return donor_data
+
+# def _diff_donors(
+#     donors_in_submission: tuple[Donor, ...], submission_id: str, metadata: GrzSubmissionMetadata
+# ) -> _DonorDiff:
+#     pseudonym2before = {donor.pseudonym: donor for donor in donors_in_submission}
+
+#     added_donors = []
+#     updated_donors = []
+#     type Pseudonym = str
+#     pending_pseudonyms: set[Pseudonym] = set()
+#     donor_diff_tables: list[rich.console.RenderableType] = []
+#     for donor in metadata.donors:
+#         # we use submission ID passed to this function instead of metadata
+#         # because the tanG might be redacted and therefore the
+#         # metadata-calculated submission ID would change.
+#         # Also, we use model_validate here instead of __init__ because of:
+#         # https://github.com/fastapi/sqlmodel/issues/453
+#         donor_after = Donor.model_validate(
+#             {
+#                 "submission_id": submission_id,
+#                 "pseudonym": "index" if donor.relation == Relation.index_ else donor.donor_pseudonym,
+#                 "relation": Relation(donor.relation),
+#                 "library_types": {datum.library_type for datum in donor.lab_data},
+#                 "sequence_types": {datum.sequence_type for datum in donor.lab_data},
+#                 "sequence_subtypes": {datum.sequence_subtype for datum in donor.lab_data},
+#                 "mv_consented": donor.consents_to_mv(),
+#                 "research_consented": donor.consents_to_research(date=date.today()),
+#                 "research_consent_missing_justifications": {
+#                     consent.no_scope_justification
+#                     for consent in donor.research_consents
+#                     if consent.no_scope_justification is not None
+#                 }
+#                 if donor.research_consents
+#                 else None,
+#             }
+#         )
+#         donor_before = pseudonym2before.get(donor_after.pseudonym, None)
+#         pending_pseudonyms.add(donor_after.pseudonym)
+#         change = "added"
+#         if donor_before == donor_after:
+#             continue
+#         if donor_before is None:
+#             added_donors.append(donor_after)
+#         else:
+#             updated_donors.append(donor_after)
+#             change = "updated"
+
+#         table_title = f"[green]Donor '{donor_after.pseudonym}' {change}[/green]"
+#         diff_table = rich.table.Table(title=table_title, min_width=len(table_title), title_justify="left")
+#         diff_table.add_column("Key")
+#         diff_table.add_column("Before")
+#         diff_table.add_column("After")
+#         for field in sorted(Donor.model_fields.keys() - {"submission_id", "pseudonym"}):
+#             before = getattr(donor_before, field, None)
+#             after = getattr(donor_after, field)
+#             if before != after:
+#                 diff_table.add_row(
+#                     field, _TEXT_MISSING if before is None else rich.pretty.Pretty(before), rich.pretty.Pretty(after)
+#                 )
+#         if diff_table.row_count:
+#             donor_diff_tables.append(diff_table)
+
+#     deleted_donors = tuple(
+#         filter(
+#             lambda donor: donor.pseudonym not in pending_pseudonyms,
+#             pseudonym2before.values(),
+#         )
+#     )
+#     for deleted_donor in deleted_donors:
+#         donor_diff_tables.append(rich.text.Text(f"Donor {deleted_donor.pseudonym} deleted", style="red"))
+
+#     return _DonorDiff(
+#         added=tuple(added_donors),
+#         updated=tuple(updated_donors),
+#         deleted=deleted_donors,
+#         diff_tables=tuple(donor_diff_tables),
+#     )
 
 @submission.command()
 @click.argument("submission_id", type=str)
 @click.argument("metadata_path", metavar="path/to/metadata.json", type=str)
+@click.option(
+    "--submission_date",
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+    default=None,
+    help="Submission date of the submission; overwrites submissionDate in metadata.json",
+)
 @click.option(
     "--confirm/--no-confirm",
     default=True,
@@ -673,7 +887,18 @@ def _diff_donors(
     multiple=True,
 )
 @click.pass_context
-def populate(ctx: click.Context, submission_id: str, metadata_path: str, confirm: bool, ignore_field: list[str]):  # noqa: C901
+def populate(ctx: click.Context, submission_id: str, metadata_path: str, submission_date: datetime | None, confirm: bool, ignore_field: tuple[str]):  # noqa: C901
+    updates: bool = False
+    ignore_field = set(ignore_field)
+
+    if submission_date is not None:
+        submission_date = submission_date.date()
+        log.info("Submission date from provided option is used")
+        if submission_date >= date.today() + timedelta(days = 1):
+            raise RuntimeError(f"Submission date ({submission_date.date()}) is set to a future date (today: {date.today()}) which is not allowed") 
+    else:
+        log.warning("Submission date from metadata.json is used")
+
     """Populate the submission database from a metadata JSON file."""
     log.debug("Ignored fields for populate: %s", ignore_field)
 
@@ -693,35 +918,56 @@ def populate(ctx: click.Context, submission_id: str, metadata_path: str, confirm
         traceback.print_exc()
         raise click.ClickException(f"Failed to update submission state: {e}") from e
 
+    # store entries of donors in database
+    donors_in_db_submission = {donor.pseudonym : donor for donor in db_service.get_donors(submission_id=submission_id)}
+
     with open(metadata_path, encoding="utf-8") as metadata_file:
         metadata = GrzSubmissionMetadata.model_validate_json(metadata_file.read())
 
-    changes = _diff_metadata(submission, metadata, set(ignore_field))
+        metadata_file.seek(0)
+        metadata_content = json.load(metadata_file)
+        # redact tanG, local case id and potential tanG in the patient information
+        metadata_content = redact_metadata(metadata_content)
+        metadata_string = json.dumps(metadata_content)
 
-    # consent records
-    donor_diff = _diff_donors(
-        donors_in_submission=db_service.get_donors(submission_id=submission_id),
-        submission_id=submission_id,
-        metadata=metadata,
-    )
+    # add the filesize; would be better with SubmissionMetadata but then without validation
+    submission_size: int = 0  
+    for donor in metadata.donors:
+        for lab_datum in donor.lab_data:
+            if sequence_data := lab_datum.sequence_data:
+                for file in sequence_data.files:
+                    submission_size += file.file_size_in_bytes
 
-    if not any(dataclasses.astuple(donor_diff)):
+    submission_information = diff_metadata(submission, metadata, submission_size, submission_date, metadata_string, ignore_field)
+    diff_table_submission = _prepare_submission_console_table(submission_information.db_ingest)
+    if submission_information.change: updates = True
+
+    donors_in_metadata: list[str] = []
+    donor_diff = DonorDiff([], [], [], [], [])
+    for donor in metadata.donors:
+        donor_data = diff_donor(donor, donors_in_db_submission, submission_id)
+        donors_in_metadata.append(donor_data.name)
+        if donor_data.status != "unchanged":
+            updates = True
+            diff_table_donor = _prepare_donor_console_table(donor_data.changes, donor_data.name, donor_data.status)
+            donor_diff.diff_tables.append(diff_table_donor)
+            if donor_data.status == "new":
+                donor_diff.added.append(donor_data.donor)
+            else:
+                donor_diff.updated.append(donor_data.donor)
+        else:
+            donor_diff.unchanged.append(donor_data.donor)
+
+    donor_diff.deleted = [db_donor for db_donor in donors_in_db_submission.values() if db_donor.pseudonym not in donors_in_metadata]
+    for deleted_donor in donor_diff.deleted :
+        donor_diff.diff_tables.append(rich.text.Text(f"Donor {deleted_donor.pseudonym} deleted", style="red"))
+
+    if not updates:
         console_err.print("[green]Database is already up to date with the provided metadata![/green]")
         ctx.exit()
 
-    diff_table: rich.console.RenderableType
-    if changes:
-        diff_table = rich.table.Table(title="Submission Metadata")
-        diff_table.add_column("Key")
-        diff_table.add_column("Before")
-        diff_table.add_column("After")
-        for key, before, after in sorted(changes, key=itemgetter(0)):
-            diff_table.add_row(key, str(before) if before is not None else _TEXT_MISSING, str(after))
-    else:
-        diff_table = rich.padding.Padding(rich.text.Text("No changes to submission-level metadata."), pad=(0, 0, 1, 0))
-
     panel = rich.panel.Panel.fit(
-        rich.console.Group(diff_table, *donor_diff.diff_tables, fit=True), title="Pending Changes"
+        rich.console.Group(diff_table_submission, *donor_diff.diff_tables, fit=True), title="Pending Changes"
     )
     console.print(panel)
 
@@ -730,15 +976,114 @@ def populate(ctx: click.Context, submission_id: str, metadata_path: str, confirm
         default=False,
         show_default=True,
     ):
-        for key, _before, after in changes:
-            _ = db_service.modify_submission(submission_id, key=key, value=after)
+        for key, _before, after in submission_information.db_ingest:
+            db_service.modify_submission(submission_id, key=key, value=after)
         for added_donor in donor_diff.added:
-            _ = db_service.add_donor(added_donor)
+            db_service.add_donor(added_donor)
         for updated_donor in donor_diff.updated:
-            _ = db_service.update_donor(updated_donor)
+            db_service.update_donor(updated_donor)
         for deleted_donor in donor_diff.deleted:
             db_service.delete_donor(deleted_donor)
         console_err.print("[green]Database populated successfully.[/green]")
+
+
+# @submission.command()
+# @click.argument("submission_id", type=str)
+# @click.argument("metadata_path", metavar="path/to/metadata.json", type=str)
+# # @click.argument("submission_date", metavar="submission_date (YYYY-MM-DD)", type=click.DateTime(formats=["%Y-%m-%d"]), default = None)
+# @click.option(
+#     "--submission_date",
+#     type=click.DateTime(formats=["%Y-%m-%d"]),
+#     default=None,
+#     help="Submission date of the submission; overwrites submissionDate in metadata.json",
+# )
+# @click.option(
+#     "--confirm/--no-confirm",
+#     default=True,
+#     help="Whether to confirm changes before committing to database. (Default: confirm)",
+# )
+# @click.option(
+#     "--ignore-field",
+#     help="Do not populate the given key from the metadata to the database. Can be specified multiple times to ignore multiple keys.",
+#     multiple=True,
+# )
+# @click.pass_context
+# def populate(ctx: click.Context, submission_id: str, metadata_path: str, submission_date: datetime | None, confirm: bool, ignore_field: tuple[str]):  # noqa: C901
+#     # TODO: add submission_size
+#     ignore_field = set(ignore_field)
+#     if submission_date is not None:
+#         ignore_field.add("submission_date")
+#     """Populate the submission database from a metadata JSON file."""
+#     log.debug("Ignored fields for populate: %s", ignore_field)
+
+#     db = ctx.obj["db_url"]
+#     db_service = get_submission_db_instance(db, author=ctx.obj["author"])
+
+#     try:
+#         submission = db_service.get_submission(submission_id)
+#         if not submission:
+#             raise SubmissionNotFoundError(submission_id)
+#     except SubmissionNotFoundError as e:
+#         console_err.print(f"[red]Error: {e}[/red]")
+#         console_err.print(f"You might need to add it first: grz-cli db submission add {submission_id}")
+#         raise click.Abort() from e
+#     except Exception as e:
+#         console_err.print(f"[red]An unexpected error occurred: {e}[/red]")
+#         traceback.print_exc()
+#         raise click.ClickException(f"Failed to update submission state: {e}") from e
+
+#     with open(metadata_path, encoding="utf-8") as metadata_file:
+#         metadata = GrzSubmissionMetadata.model_validate_json(metadata_file.read())
+
+#         metadata_file.seek(0)
+#         metadata_content = json.load(metadata_file)
+#         # redact tanG, local case id and potential tanG in the patient information
+#         metadata_content = _redact_metadata(metadata_content)
+#         metadata_string = json.dumps(metadata_content)
+
+#     changes = _diff_metadata(submission, metadata, submission_date, metadata_string, ignore_field)
+
+#     # consent records
+#     donor_diff = _diff_donors(
+#         donors_in_submission=db_service.get_donors(submission_id=submission_id),
+#         submission_id=submission_id,
+#         metadata=metadata,
+#     )
+
+#     if not any(dataclasses.astuple(donor_diff)):
+#         console_err.print("[green]Database is already up to date with the provided metadata![/green]")
+#         ctx.exit()
+
+#     diff_table: rich.console.RenderableType
+#     if changes:
+#         diff_table = rich.table.Table(title="Submission Metadata")
+#         diff_table.add_column("Key")
+#         diff_table.add_column("Before")
+#         diff_table.add_column("After")
+#         for key, before, after in sorted(changes, key=itemgetter(0)):
+#             diff_table.add_row(key, str(before) if before is not None else _TEXT_MISSING, str(after))
+#     else:
+#         diff_table = rich.padding.Padding(rich.text.Text("No changes to submission-level metadata."), pad=(0, 0, 1, 0))
+
+#     panel = rich.panel.Panel.fit(
+#         rich.console.Group(diff_table, *donor_diff.diff_tables, fit=True), title="Pending Changes"
+#     )
+#     console.print(panel)
+
+#     if not confirm or click.confirm(
+#         "Are you sure you want to commit these changes to the database?",
+#         default=False,
+#         show_default=True,
+#     ):
+#         for key, _before, after in changes:
+#             _ = db_service.modify_submission(submission_id, key=key, value=after)
+#         for added_donor in donor_diff.added:
+#             _ = db_service.add_donor(added_donor)
+#         for updated_donor in donor_diff.updated:
+#             _ = db_service.update_donor(updated_donor)
+#         for deleted_donor in donor_diff.deleted:
+#             db_service.delete_donor(deleted_donor)
+#         console_err.print("[green]Database populated successfully.[/green]")
 
 
 class QCStatus(StrEnum):

--- a/packages/grzctl/src/grzctl/commands/download.py
+++ b/packages/grzctl/src/grzctl/commands/download.py
@@ -67,8 +67,7 @@ def download(  # noqa: PLR0913
         end_state=SubmissionStateEnum.DOWNLOADED,
         enabled=update_db,
     ):
-        #worker_inst.download(config.s3, submission_id, force=force)
-
+        worker_inst.download(config.s3, submission_id, force=force)
         worker_inst.populate(configuration, submission_id, True)
 
     log.info("Download finished!")

--- a/packages/grzctl/src/grzctl/commands/download.py
+++ b/packages/grzctl/src/grzctl/commands/download.py
@@ -34,7 +34,7 @@ def download(  # noqa: PLR0913
     threads,
     force,
     update_db,
-    populate
+    populate,
     **kwargs,
 ):
     """
@@ -68,6 +68,6 @@ def download(  # noqa: PLR0913
         enabled=update_db,
     ):
         worker_inst.download(config.s3, submission_id, force=force)
-        worker_inst.populate(configuration, submission_id, True)
+        worker_inst.populate(configuration, submission_id, populate)
 
     log.info("Download finished!")

--- a/packages/grzctl/src/grzctl/commands/download.py
+++ b/packages/grzctl/src/grzctl/commands/download.py
@@ -22,6 +22,11 @@ log = logging.getLogger(__name__)
 @grzcli.threads
 @grzcli.force
 @grzcli.update_db
+@click.option(
+    '--populate/--no-populate', 
+    default=True, 
+    help="Update the submission metadata with information from metadata.json and S3"
+)
 def download(  # noqa: PLR0913
     configuration: dict[str, Any],
     submission_id,
@@ -29,6 +34,7 @@ def download(  # noqa: PLR0913
     threads,
     force,
     update_db,
+    populate
     **kwargs,
 ):
     """
@@ -61,6 +67,8 @@ def download(  # noqa: PLR0913
         end_state=SubmissionStateEnum.DOWNLOADED,
         enabled=update_db,
     ):
-        worker_inst.download(config.s3, submission_id, force=force)
+        #worker_inst.download(config.s3, submission_id, force=force)
+
+        worker_inst.populate(configuration, submission_id, True)
 
     log.info("Download finished!")

--- a/packages/grzctl/src/grzctl/commands/download.py
+++ b/packages/grzctl/src/grzctl/commands/download.py
@@ -66,8 +66,8 @@ def download(  # noqa: PLR0913
         start_state=SubmissionStateEnum.DOWNLOADING,
         end_state=SubmissionStateEnum.DOWNLOADED,
         enabled=update_db,
-    ):
+    ) as db_context:
         worker_inst.download(config.s3, submission_id, force=force)
-        worker_inst.populate(configuration, submission_id, populate)
+        worker_inst.populate(config.s3, db_context, submission_id, populate)
 
     log.info("Download finished!")

--- a/packages/grzctl/src/grzctl/commands/download.py
+++ b/packages/grzctl/src/grzctl/commands/download.py
@@ -67,9 +67,7 @@ def download(  # noqa: PLR0913
         end_state=SubmissionStateEnum.DOWNLOADED,
         enabled=update_db,
     ) as db_context:
-        # worker_inst.download(config.s3, submission_id, force=force)
-        log.info("POPULATE")
-        if populate:
-            worker_inst.populate(config.s3, db_context, submission_id, force)
+        worker_inst.download(config.s3, submission_id, force=force)
+        if populate: worker_inst.populate(config.s3, db_context.db, submission_id, force_populate=force)
 
     log.info("Download finished!")

--- a/packages/grzctl/src/grzctl/commands/download.py
+++ b/packages/grzctl/src/grzctl/commands/download.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 @click.option(
     '--populate/--no-populate', 
     default=True, 
-    help="Update the submission metadata with information from metadata.json and S3"
+    help="Update the submission metadata with information from metadata.json and S3. If combined with --force, will overwrite information in db without asking."
 )
 def download(  # noqa: PLR0913
     configuration: dict[str, Any],
@@ -67,7 +67,9 @@ def download(  # noqa: PLR0913
         end_state=SubmissionStateEnum.DOWNLOADED,
         enabled=update_db,
     ) as db_context:
-        worker_inst.download(config.s3, submission_id, force=force)
-        worker_inst.populate(config.s3, db_context, submission_id, populate)
+        # worker_inst.download(config.s3, submission_id, force=force)
+        log.info("POPULATE")
+        if populate:
+            worker_inst.populate(config.s3, db_context, submission_id, force)
 
     log.info("Download finished!")

--- a/packages/grzctl/src/grzctl/dbcontext.py
+++ b/packages/grzctl/src/grzctl/dbcontext.py
@@ -95,7 +95,6 @@ class DbContext:
 
         return True
 
-    # TODO: move to grz_db.models.author?
     @property
     def author(self) -> Author:
         db_config = DbConfig.model_validate(self.configuration).db

--- a/packages/grzctl/src/grzctl/dbcontext.py
+++ b/packages/grzctl/src/grzctl/dbcontext.py
@@ -49,19 +49,7 @@ class DbContext:
         try:
             db_config = DbConfig.model_validate(self.configuration).db
 
-            author = None
-            if db_config.author:
-                key_path = Path(db_config.author.private_key_path)
-                if not key_path.exists():
-                    raise FileNotFoundError(f"Author private key not found at: {key_path}")
-
-                author = Author(
-                    name=db_config.author.name,
-                    private_key_bytes=key_path.read_bytes(),
-                    private_key_passphrase=db_config.author.private_key_passphrase,
-                )
-
-            self.db = get_submission_db_instance(db_config.database_url, author=author)
+            self.db = get_submission_db_instance(db_config.database_url, author=self.author)
 
             if self.db:
                 self._check_prerequisites()
@@ -103,6 +91,25 @@ class DbContext:
                 log.error(f"Failed to write success state to DB: {db_exc}")
 
         return True
+
+    # TODO: move to grz_db.models.author?
+    @property
+    def author(self) -> Author:
+        db_config = DbConfig.model_validate(self.configuration).db
+
+        author = None
+        if db_config.author:
+            key_path = Path(db_config.author.private_key_path)
+            if not key_path.exists():
+                raise FileNotFoundError(f"Author private key not found at: {key_path}")
+
+            author = Author(
+                name=db_config.author.name,
+                private_key_bytes=key_path.read_bytes(),
+                private_key_passphrase=db_config.author.private_key_passphrase,
+            )
+
+        return author
 
     def _check_prerequisites(self):
         """

--- a/packages/grzctl/src/grzctl/dbcontext.py
+++ b/packages/grzctl/src/grzctl/dbcontext.py
@@ -3,6 +3,7 @@ import traceback
 from pathlib import Path
 from typing import Any
 
+from grz_db.errors import SubmissionNotFoundError
 from grz_db.models.author import Author
 from grz_db.models.submission import SubmissionDb, SubmissionStateEnum
 from pydantic import ValidationError
@@ -60,6 +61,8 @@ class DbContext:
         except (ValidationError, KeyError) as e:
             log.warning(f"DB Configuration invalid or missing. State updates skipped. ({e})")
             self.db = None
+        except SubmissionNotFoundError:
+            raise
         except Exception as e:
             log.error(f"Failed to connect to DB: {e}. State updates skipped.")
             log.error(traceback.format_exc())
@@ -97,19 +100,21 @@ class DbContext:
     def author(self) -> Author:
         db_config = DbConfig.model_validate(self.configuration).db
 
-        author = None
-        if db_config.author:
-            key_path = Path(db_config.author.private_key_path)
-            if not key_path.exists():
-                raise FileNotFoundError(f"Author private key not found at: {key_path}")
+        if not db_config.author:
+            raise ValueError("Author configuration is missing")
 
-            author = Author(
-                name=db_config.author.name,
-                private_key_bytes=key_path.read_bytes(),
-                private_key_passphrase=db_config.author.private_key_passphrase,
-            )
+        if db_config.author.private_key_path is None:
+            raise ValueError("Author private key path is required but was None")
 
-        return author
+        key_path = Path(db_config.author.private_key_path)
+        if not key_path.exists():
+            raise FileNotFoundError(f"Author private key not found at: {key_path}")
+
+        return Author(
+            name=db_config.author.name,
+            private_key_bytes=key_path.read_bytes(),
+            private_key_passphrase=db_config.author.private_key_passphrase,
+        )
 
     def _check_prerequisites(self):
         """

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -59,9 +59,15 @@ def test_all_migrations(blank_initial_database_config_path):
 
 def test_populate(blank_database_config_path: Path):
     args_common = ["db", "--config-file", blank_database_config_path]
-    metadata = GrzSubmissionMetadata.model_validate_json(
-        (importlib.resources.files(test_resources) / "metadata.json").read_text()
-    )
+    # metadata = GrzSubmissionMetadata.model_validate_json(
+    #     (importlib.resources.files(test_resources) / "metadata.json").read_text()
+    # )
+
+    metadata_path = str(importlib.resources.files(test_resources) / "metadata.json")
+    with open(metadata_path, encoding="utf-8") as metadata_file:
+        metadata = GrzSubmissionMetadata.model_validate_json(metadata_file.read())
+        metadata_content = metadata.to_redacted_dict(False)
+        metadata_string = json.dumps(metadata_content)
 
     runner = click.testing.CliRunner(catch_exceptions=False)
     cli = grzctl.cli.build_cli()
@@ -92,6 +98,44 @@ def test_populate(blank_database_config_path: Path):
     assert {
         consent.no_scope_justification for consent in meta_father.research_consents
     } == db_father.research_consent_missing_justifications
+
+    assert submission.submission_metadata == metadata_string
+
+    assert submission.submission_size == metadata.get_submission_size()
+
+def test_populate_date(blank_database_config_path: Path):
+    args_common = ["db", "--config-file", blank_database_config_path]
+    changed_date = date(2026,1,1)
+    # metadata = GrzSubmissionMetadata.model_validate_json(
+    #     (importlib.resources.files(test_resources) / "metadata.json").read_text()
+    # )
+
+    metadata_path = str(importlib.resources.files(test_resources) / "metadata.json")
+    with open(metadata_path, encoding="utf-8") as metadata_file:
+        metadata = GrzSubmissionMetadata.model_validate_json(metadata_file.read())
+
+    runner = click.testing.CliRunner(catch_exceptions=False)
+    cli = grzctl.cli.build_cli()
+    result_add = runner.invoke(cli, [*args_common, "submission", "add", metadata.submission_id])
+    assert result_add.exit_code == 0, result_add.stderr
+
+    with importlib.resources.as_file(importlib.resources.files(test_resources) / "metadata.json") as metadata_path:
+        result_populate = runner.invoke(
+            cli, [*args_common, "submission", "populate", metadata.submission_id, str(metadata_path), "--no-confirm", "--submission_date", changed_date.strftime("%Y-%m-%d")]
+        )
+    assert result_populate.exit_code == 0, result_populate.stderr
+
+    result_show = runner.invoke(cli, [*args_common, "submission", "show", metadata.submission_id])
+    assert result_show.exit_code == 0, result_show.stderr
+    # shorter than tanG and less likely to be truncated in various terminal widths
+    assert metadata.submission.local_case_id in result_show.stdout, result_show.stdout
+
+    with open(blank_database_config_path, encoding="utf-8") as blank_database_config_file:
+        config = yaml.load(blank_database_config_file, Loader=yaml.Loader)
+    db = SubmissionDb(db_url=config["db"]["database_url"], author=None)
+
+    submission = db.get_submission(metadata.submission_id)
+    assert submission.submission_date == changed_date
 
 
 def test_populate_redacted(tmp_path: Path, blank_database_config_path: Path):
@@ -130,6 +174,7 @@ def test_repopulate(blank_database_config_path: Path, tmp_path: Path):
     """
     rng = random.Random()
     rng.seed(42)
+    changed_date = date(2026,1,1)
 
     args_common = ["db", "--config-file", blank_database_config_path]
     runner = click.testing.CliRunner()
@@ -198,6 +243,8 @@ def test_repopulate(blank_database_config_path: Path, tmp_path: Path):
             "tan_g",
             "--ignore-field",
             "pseudonym",
+            "--submission_date",
+            changed_date.strftime("%Y-%m-%d")
         ],
     )
     assert result_repopulate_s1.exit_code == 0, result_repopulate_s1.stderr
@@ -217,9 +264,11 @@ def test_repopulate(blank_database_config_path: Path, tmp_path: Path):
     assert not donors_s1[1].research_consented
     assert donors_s1[1].research_consent_missing_justifications == {"other patient-related reason"}
 
+    submission_s1 = db.get_submission(metadata_s1.submission_id)
+    assert submission_s1.submission_date == changed_date
+
     donors_s2 = sorted(db.get_donors(metadata_s2.submission_id), key=attrgetter("pseudonym"))
     assert len(donors_s2) == 2, "Expected two donors in submission 2"
-
 
 def test_populate_qc(blank_database_config_path: Path, tmp_path: Path):
     args_common = ["db", "--config-file", blank_database_config_path]
@@ -344,9 +393,15 @@ def test_submission_show_json(blank_database_config_path: Path):
     """
     args_common = ["db", "--config-file", blank_database_config_path]
 
-    metadata = GrzSubmissionMetadata.model_validate_json(
-        (importlib.resources.files(test_resources) / "metadata.json").read_text()
-    )
+    # metadata = GrzSubmissionMetadata.model_validate_json(
+        # (importlib.resources.files(test_resources) / "metadata.json").read_text()
+    # )
+
+    metadata_path = str(importlib.resources.files(test_resources) / "metadata.json")
+    with open(metadata_path, encoding="utf-8") as metadata_file:
+        metadata = GrzSubmissionMetadata.model_validate_json(metadata_file.read())
+        metadata_content = metadata.to_redacted_dict(False)
+        metadata_string = json.dumps(metadata_content)
 
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -377,7 +432,9 @@ def test_submission_show_json(blank_database_config_path: Path):
         "submission_date": metadata.submission.submission_date.isoformat()
         if metadata.submission.submission_date
         else None,
+        "submission_size": metadata.get_submission_size(),
         "submission_type": metadata.submission.submission_type,
+        "submission_metadata": metadata_string,
         "submitter_id": metadata.submission.submitter_id,
         "data_node_id": metadata.submission.genomic_data_center_id,
         "coverage_type": metadata.submission.coverage_type,

--- a/tests/cli/test_upload.py
+++ b/tests/cli/test_upload.py
@@ -41,9 +41,11 @@ def test_upload_download_submission(
     working_dir_path,
     tmpdir_factory,
     temp_s3_config_file_path,
+    temp_s3_db_config_file_path,
     remote_bucket,
 ):
     submission_dir = Path("tests/mock_files/submissions/valid_submission")
+    env = {"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test"}
 
     shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
     shutil.copytree(
@@ -81,7 +83,7 @@ def test_upload_download_submission(
             temp_s3_config_file_path,
         ]
 
-        runner = CliRunner()
+        runner = CliRunner(env=env)
         cli = grz_cli.cli.build_cli()
         result = runner.invoke(cli, upload_args, catch_exceptions=False)
 
@@ -95,6 +97,16 @@ def test_upload_download_submission(
 
         assert objects_in_bucket[f"{submission_id}/version"].get()["Body"].read().decode("utf-8") == version("grz-cli")
 
+        cli = grzctl.cli.build_cli()
+
+        init_args = [
+            "db",
+            "--config-file",
+            str(temp_s3_db_config_file_path),
+            "init"
+            ]
+        runner.invoke(cli, init_args, catch_exceptions=False)
+
         # download
         download_dir = tmpdir_factory.mktemp("submission_download")
         download_dir_path = Path(download_dir.strpath)
@@ -107,9 +119,10 @@ def test_upload_download_submission(
             "--output-dir",
             str(download_dir_path),
             "--config-file",
-            temp_s3_config_file_path,
+            str(temp_s3_db_config_file_path),
+            "--populate",
+            "--force"
         ]
-        cli = grzctl.cli.build_cli()
         result = runner.invoke(cli, download_args, catch_exceptions=False)
 
         assert result.exit_code == 0, result.output

--- a/tests/cli/test_upload.py
+++ b/tests/cli/test_upload.py
@@ -107,6 +107,16 @@ def test_upload_download_submission(
             ]
         runner.invoke(cli, init_args, catch_exceptions=False)
 
+        add_args = [
+            "db",
+            "--config-file",
+            str(temp_s3_db_config_file_path),
+            "submission",
+            "add",
+            submission_id,
+        ]
+        runner.invoke(cli, add_args, catch_exceptions=False)
+
         # download
         download_dir = tmpdir_factory.mktemp("submission_download")
         download_dir_path = Path(download_dir.strpath)
@@ -121,7 +131,6 @@ def test_upload_download_submission(
             "--config-file",
             str(temp_s3_db_config_file_path),
             "--populate",
-            "--force"
         ]
         result = runner.invoke(cli, download_args, catch_exceptions=False)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import grzctl.models.config
 import numpy as np
 import psycopg
 import pytest
+import yaml
 from grz_common.utils.crypt import Crypt4GH
 from grz_common.workers.submission import EncryptedSubmission, SubmissionMetadata
 from moto import mock_aws
@@ -335,6 +336,21 @@ def identifiers_config_model(identifiers_config_content):
 @pytest.fixture
 def pruefbericht_config_model(pruefbericht_config_content):
     return grzctl.models.config.PruefberichtConfig(**pruefbericht_config_content)
+
+
+@pytest.fixture
+def temp_s3_db_config_file_path(temp_data_dir_path, s3_config_model, db_config_model) -> Path:
+    config_file = temp_data_dir_path / "config.db_s3.yaml"
+
+    combined = {
+        **s3_config_model.model_dump(mode="json", exclude_none=True, exclude_unset=True, exclude_defaults=True),
+        **db_config_model.model_dump(mode="json", exclude_none=True, exclude_unset=True, exclude_defaults=True),
+    }
+
+    with open(config_file, "w") as fd:
+        yaml.safe_dump(combined, fd, sort_keys=False)
+
+    return config_file
 
 
 @pytest.fixture


### PR DESCRIPTION
## Info

- I wanted to push this to get general information about the code and placement of functions

## TODOs

- testcases
- [packages/grz-db/src/grz_db/migrations/README.md](https://github.com/BfArM-MVH/grz-tools/compare/main...overwrite_submission_date#diff-6b3cdcfe189aec31158525a68d5c12db4693db8edcc9345d98a3a8bbadd2a866) is describing a general way, but grz-tools offers internal migration; should be added to README
-  creating an author as function (https://github.com/BfArM-MVH/grz-tools/blob/33b678c177600ec52246efabfad9ed353322154b/packages/grz-common/src/grz_common/workers/worker.py#L51), can be moved?

## Tasks

- [ ] Replace this entire PR description with the desired final squash commit message.
  - Make sure to follow the [release-please](https://github.com/googleapis/release-please?tab=readme-ov-file#what-if-my-pr-contains-multiple-fixes-or-features) format by placing these at the end, separated by newlines.

Multiple [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0) statements can be included in the description, in addition to the PR title.
