### PR TITLE
feat(grz-db,grzctl): add selected_for_qc submission column to submission database

### DIFF
--- a/packages/grz-db/src/grz_db/errors.py
+++ b/packages/grz-db/src/grz_db/errors.py
@@ -1,46 +1,56 @@
-class SubmissionNotFoundError(ValueError):
+class GrzDbError(Exception):
+    """Base class for all grz_db errors."""
+
+
+class SubmissionError(GrzDbError):
+    """Base class for errors related to submissions."""
+
+
+class DatabaseError(GrzDbError):
+    """Base class for database-related errors."""
+
+
+class SubmissionNotFoundError(SubmissionError):
     """Exception for when a submission is not found in the database."""
 
     def __init__(self, submission_id: str):
         super().__init__(f"Submission not found for ID {submission_id}")
 
 
-class DuplicateSubmissionError(ValueError):
+class DuplicateSubmissionError(SubmissionError):
     """Exception for when a submission ID already exists in the database."""
 
     def __init__(self, submission_id: str):
         super().__init__(f"Duplicate submission ID {submission_id}")
 
 
-class DuplicateTanGError(ValueError):
+class DuplicateTanGError(SubmissionError):
     """Exception for when a tanG is already in use."""
 
     def __init__(self):
         super().__init__("Duplicate tanG")
 
 
-class SubmissionDateIsNoneError(ValueError):
+class SubmissionDateIsNoneError(SubmissionError):
     """Exception for when a submission date is None."""
 
     def __init__(self):
         super().__init__("Submission date is None")
 
 
-class SubmissionTypeIsNoneError(ValueError):
+class SubmissionTypeIsNoneError(SubmissionError):
     """Exception for when a submission type is None."""
 
     def __init__(self):
         super().__init__("Submission type is None")
 
 
-class SubmissionBasicQCNotPassedError(ValueError):
+class SubmissionBasicQCNotPassedError(SubmissionError):
     """Exception for when a submission has not passed basic QC."""
 
     def __init__(self, submission_id: str):
         super().__init__(f"Submission with ID {submission_id} has not passed basic QC")
 
 
-class DatabaseConfigurationError(Exception):
+class DatabaseConfigurationError(DatabaseError):
     """Exception for database configuration issues."""
-
-    pass

--- a/packages/grz-db/src/grz_db/errors.py
+++ b/packages/grz-db/src/grz_db/errors.py
@@ -19,6 +19,27 @@ class DuplicateTanGError(ValueError):
         super().__init__("Duplicate tanG")
 
 
+class SubmissionDateIsNoneError(ValueError):
+    """Exception for when a submission date is None."""
+
+    def __init__(self):
+        super().__init__("Submission date is None")
+
+
+class SubmissionTypeIsNoneError(ValueError):
+    """Exception for when a submission type is None."""
+
+    def __init__(self):
+        super().__init__("Submission type is None")
+
+
+class SubmissionBasicQCNotPassedError(ValueError):
+    """Exception for when a submission has not passed basic QC."""
+
+    def __init__(self, submission_id: str):
+        super().__init__(f"Submission with ID {submission_id} has not passed basic QC")
+
+
 class DatabaseConfigurationError(Exception):
     """Exception for database configuration issues."""
 

--- a/packages/grz-db/src/grz_db/migrations/versions/9023ab55c239_add_selected_for_qc.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/9023ab55c239_add_selected_for_qc.py
@@ -1,6 +1,6 @@
 """add selected_for_qc column
 
-Revision ID: 9023lnssn239
+Revision ID: 9023ab55c239
 Revises: 8aa6fc8d118a
 Create Date: 2026-03-17 08:33:43.113455+00:00
 
@@ -11,7 +11,7 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "9023lnssn239"
+revision: str = "9023ab55c239"
 down_revision: str | Sequence[str] | None = "8aa6fc8d118a"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/packages/grz-db/src/grz_db/migrations/versions/9023lnssn239_add_selected_for_qc.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/9023lnssn239_add_selected_for_qc.py
@@ -1,0 +1,27 @@
+"""add selected_for_qc column
+
+Revision ID: 9023lnssn239
+Revises: 8aa6fc8d118a
+Create Date: 2026-03-17 08:33:43.113455+00:00
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "9023lnssn239"
+down_revision: str | Sequence[str] | None = "8aa6fc8d118a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("submissions", sa.Column("selected_for_qc", sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    raise RuntimeError("Downgrades not supported.")

--- a/packages/grz-db/src/grz_db/migrations/versions/9023lnssn239_add_selected_for_qc.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/9023lnssn239_add_selected_for_qc.py
@@ -20,6 +20,19 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     """Upgrade schema."""
     op.add_column("submissions", sa.Column("selected_for_qc", sa.Boolean(), nullable=True))
+    op.execute(
+        sa.text(
+            """
+            UPDATE submissions
+            SET selected_for_qc = TRUE
+            WHERE id IN (
+                SELECT DISTINCT submission_id
+                FROM submission_states
+                WHERE state IN ('QCING', 'QCED')
+            )
+            """
+        )
+    )
 
 
 def downgrade() -> None:

--- a/packages/grz-db/src/grz_db/migrations/versions/f3a9c7d2e481_add_qc_queue_entry_table.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/f3a9c7d2e481_add_qc_queue_entry_table.py
@@ -1,0 +1,43 @@
+"""add qc_queue table
+
+Revision ID: f3a9c7d2e481
+Revises: 9023ab55c239
+Create Date: 2026-03-31 12:00:00.000000+00:00
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlmodel.sql.sqltypes import AutoString
+
+revision: str = "f3a9c7d2e481"
+down_revision: str | Sequence[str] | None = "9023ab55c239"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "qc_queue",
+        sa.Column("submission_id", AutoString(), primary_key=True),
+        sa.Column(
+            "basic_qc_passed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["submission_id"], ["submissions.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        index_name="ix_qc_queue_basic_qc_passed_at",
+        table_name="qc_queue",
+        columns=["basic_qc_passed_at"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    raise RuntimeError("Downgrades not supported.")

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -512,7 +512,7 @@ class SubmissionDb:
         submitter_id: SubmitterId | None,
         start_date: datetime.date,
         end_date: datetime.date,
-    ) -> list[Submission]:
+    ) -> Sequence[Submission]:
         with self._get_session() as session:
             return session.exec(
                 select(Submission)

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -507,6 +507,7 @@ class SubmissionDb:
                     # Basic QC passed -> Ensure that submission is tracked in the in-depth QC queue
                     session.add(QCQueueEntry(submission_id=submission_id))
                 elif submission.basic_qc_passed is not True and queue_entry is not None:
+                    # Basic QC failed -> Ensure that submission is absent from the in-depth QC queue
                     session.delete(queue_entry)
 
                 # Keep selection flag aligned with failed basic QC.

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -144,7 +144,7 @@ class SubmissionBase(SQLModel):
     genomic_study_type: GenomicStudyType | None = None
     genomic_study_subtype: GenomicStudySubtype | None = None
 
-    # boolean to exclude selected submissions from automatic processing of submissions for extended QC
+    # Database column indicating whether a submission is selected for in-depth QC (True/False) or not yet decided (None).
     selected_for_qc: bool | None = None
 
 

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -516,7 +516,7 @@ class SubmissionDb:
                 .where(Submission.basic_qc_passed)  # type: ignore[arg-type]
                 .where(Submission.submission_date.between(start_date, end_date))  # type: ignore[union-attr]
                 .where(Submission.submitter_id == submitter_id)
-                .order_by(Submission.submission_date)  # type: ignore[arg-type]
+                .order_by(Submission.submission_date, Submission.id)  # type: ignore[arg-type]
             ).all()
 
     def _is_under_qc_target(
@@ -547,20 +547,24 @@ class SubmissionDb:
         salt: str | None,
     ) -> bool:
         logger.debug("Randomly choosing whether to QC or not.")
+        if target_proportion <= 0:
+            return False
+
+        submission_ids = [submitter_submission.id for submitter_submission in submissions]
+        try:
+            absolute_index = submission_ids.index(submission.id)
+        except ValueError:
+            # if the submission ID isn't in the quarter list, it hasn't met the requirements to be detailed QCed
+            return False
+
         block_size = math.floor(1 / target_proportion)
-        block_index = len(submissions) // block_size
+        block_index = absolute_index // block_size
         submission_quarter, submission_year = date_to_quarter_year(submission.submission_date)  # type: ignore[arg-type]
         seed = f"{submission.submitter_id}-{submission_year}-{submission_quarter}-{block_index}-{salt}"
         rng = random.Random(seed)  # noqa: S311
 
         target_index_in_block = rng.randint(0, block_size - 1)
-        try:
-            current_index_in_block = [submitter_submission.id for submitter_submission in submissions].index(
-                submission.id
-            )
-        except ValueError:
-            # if the submission ID isn't in the quarter list, it hasn't met the requirements to be detailed QCed (e.g. passed basic QC)
-            return False
+        current_index_in_block = absolute_index % block_size
         return current_index_in_block == target_index_in_block
 
     def update_submission_state(

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -896,17 +896,18 @@ class SubmissionDb:
             should_select = True
 
         # yes if we are under target percentage for submitter for the submission's quarter
-        submitter_submissions_quarter = self._list_submitter_qc_candidates(
-            submitter_id=submission.submitter_id,
-            start_date=submission_quarter_start,
-            end_date=submission_quarter_end,
-        )
-        if not should_select and self._is_under_qc_target(
-            submitter_submissions_quarter,
-            target_proportion,
-            period_label="quarter",
-        ):
-            should_select = True
+        if not should_select:
+            submitter_submissions_quarter = self._list_submitter_qc_candidates(
+                submitter_id=submission.submitter_id,
+                start_date=submission_quarter_start,
+                end_date=submission_quarter_end,
+            )
+            if self._is_under_qc_target(
+                submitter_submissions_quarter,
+                target_proportion,
+                period_label="quarter",
+            ):
+                should_select = True
 
         # randomly, but reproducibly, select submissions for a given submitter, quarter, block, and salt
         if not should_select:

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -500,6 +500,7 @@ class SubmissionDb:
 
             setattr(submission, key, value)
             if key == "basic_qc_passed":
+                # Basic QC state changed -> Align the in-depth QC queue to the new state
                 queue_entry = session.get(QCQueueEntry, submission_id)
 
                 if submission.basic_qc_passed is True and queue_entry is None:

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -879,6 +879,9 @@ class SubmissionDb:
         if submission_type != SubmissionType.initial:
             # only initial submissions matter for detailed QC selection
             return False
+        if submission.basic_qc_passed is not True:
+            # only submissions that passed basic QC are eligible for detailed QC
+            raise ValueError("Submission did not pass basic QC and is therefore not eligible for detailed QC.")
         if submission.selected_for_qc is True:
             return True
 

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -42,7 +42,14 @@ from ..common import (
     ListableEnum,
     serialize_datetime_to_iso_z,
 )
-from ..errors import DuplicateSubmissionError, DuplicateTanGError, SubmissionNotFoundError
+from ..errors import (
+    DuplicateSubmissionError,
+    DuplicateTanGError,
+    SubmissionBasicQCNotPassedError,
+    SubmissionDateIsNoneError,
+    SubmissionNotFoundError,
+    SubmissionTypeIsNoneError,
+)
 from .author import Author
 from .base import BaseSignablePayload, VerifiableLog
 
@@ -369,6 +376,19 @@ class DetailedQCResult(SQLModel, table=True):
         return serialize_datetime_to_iso_z(ts)
 
 
+class QCQueueEntry(SQLModel, table=True):
+    """Queue of submissions that passed basic QC, ordered by pass timestamp."""
+
+    __tablename__ = "qc_queue"
+    __table_args__ = {"extend_existing": True}
+
+    submission_id: str = Field(foreign_key="submissions.id", primary_key=True, index=True)
+    basic_qc_passed_at: datetime.datetime = Field(
+        default_factory=lambda: datetime.datetime.now(datetime.UTC),
+        sa_column=Column(DateTime(timezone=True), nullable=False, index=True),
+    )
+
+
 class SubmissionDb:
     """
     API entrypoint for managing submissions.
@@ -467,7 +487,7 @@ class SubmissionDb:
                 session.rollback()
                 raise
 
-    def modify_submission(self, submission_id: str, key: str, value: str) -> Submission:
+    def modify_submission(self, submission_id: str, key: str, value: str) -> Submission:  # noqa: C901
         if key not in SubmissionBase.model_fields:
             raise ValueError(f"Unknown column key '{key}'")
         elif key in SubmissionBase.immutable_fields:
@@ -479,6 +499,17 @@ class SubmissionDb:
                 raise SubmissionNotFoundError(submission_id)
 
             setattr(submission, key, value)
+            if key == "basic_qc_passed":
+                queue_entry = session.get(QCQueueEntry, submission_id)
+
+                if submission.basic_qc_passed is True and queue_entry is None:
+                    session.add(QCQueueEntry(submission_id=submission_id))
+                elif submission.basic_qc_passed is not True and queue_entry is not None:
+                    session.delete(queue_entry)
+
+                # Keep selection flag aligned with failed basic QC.
+                if submission.basic_qc_passed is False:
+                    submission.selected_for_qc = False
             session.add(submission)
             try:
                 session.commit()
@@ -500,7 +531,7 @@ class SubmissionDb:
     def _submission_counts_as_selected_for_qc(self, submission: Submission) -> bool:
         if submission.selected_for_qc is True:
             return True
-        return any(state.state in (SubmissionStateEnum.QCING, SubmissionStateEnum.QCED) for state in submission.states)
+        return any(state.state in (SubmissionStateEnum.QCING, SubmissionStateEnum.QCED) for state in submission.states)  # type: ignore[union-attr]
 
     def _list_submitter_qc_candidates(
         self,
@@ -512,11 +543,12 @@ class SubmissionDb:
             return session.exec(
                 select(Submission)
                 .options(selectinload(Submission.states))  # type: ignore[arg-type]
+                .join(QCQueueEntry, QCQueueEntry.submission_id == Submission.id)  # type: ignore[arg-type]
                 .where(Submission.submission_type == SubmissionType.initial)
                 .where(Submission.basic_qc_passed)  # type: ignore[arg-type]
                 .where(Submission.submission_date.between(start_date, end_date))  # type: ignore[union-attr]
                 .where(Submission.submitter_id == submitter_id)
-                .order_by(Submission.submission_date, Submission.id)  # type: ignore[arg-type]
+                .order_by(QCQueueEntry.basic_qc_passed_at, Submission.id)  # type: ignore[arg-type]
             ).all()
 
     def _is_under_qc_target(
@@ -872,18 +904,20 @@ class SubmissionDb:
             raise SubmissionNotFoundError(submission_id)
         submission_date = submission.submission_date
         if submission_date is None:
-            raise ValueError("Submission has no submission date set.")
+            raise SubmissionDateIsNoneError()
         submission_type = submission.submission_type
         if submission_type is None:
-            raise ValueError("Submission has no type set.")
+            raise SubmissionTypeIsNoneError()
         if submission_type != SubmissionType.initial:
             # only initial submissions matter for detailed QC selection
             return False
         if submission.basic_qc_passed is not True:
             # only submissions that passed basic QC are eligible for detailed QC
-            raise ValueError("Submission did not pass basic QC and is therefore not eligible for detailed QC.")
+            raise SubmissionBasicQCNotPassedError(submission_id)
         if submission.selected_for_qc is True:
             return True
+        if submission.selected_for_qc is False:
+            return False
 
         submission_month = submission_date.month
         submission_quarter, submission_year = date_to_quarter_year(submission_date)
@@ -925,6 +959,5 @@ class SubmissionDb:
                 salt=salt,
             )
 
-        if should_select:
-            self.set_selected_for_qc(submission_id, True)
+        self.set_selected_for_qc(submission_id, should_select)
         return should_select

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -500,12 +500,7 @@ class SubmissionDb:
     def _submission_counts_as_selected_for_qc(self, submission: Submission) -> bool:
         if submission.selected_for_qc is True:
             return True
-        latest_state = submission.get_latest_state()
-        return (
-            latest_state.state in (SubmissionStateEnum.QCING, SubmissionStateEnum.QCED)
-            if latest_state is not None
-            else False
-        )
+        return any(state.state in (SubmissionStateEnum.QCING, SubmissionStateEnum.QCED) for state in submission.states)
 
     def _list_submitter_qc_candidates(
         self,

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -137,6 +137,9 @@ class SubmissionBase(SQLModel):
     genomic_study_type: GenomicStudyType | None = None
     genomic_study_subtype: GenomicStudySubtype | None = None
 
+    # boolean to exclude selected submissions from automatic processing of submissions for extended QC
+    selected_for_qc: bool | None = None
+
 
 class Submission(SubmissionBase, table=True):
     """Submission table model."""

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -504,6 +504,7 @@ class SubmissionDb:
                 queue_entry = session.get(QCQueueEntry, submission_id)
 
                 if submission.basic_qc_passed is True and queue_entry is None:
+                    # Basic QC passed -> Ensure that submission is tracked in the in-depth QC queue
                     session.add(QCQueueEntry(submission_id=submission_id))
                 elif submission.basic_qc_passed is not True and queue_entry is not None:
                     session.delete(queue_entry)

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -857,7 +857,7 @@ class SubmissionDb:
             change_requests = session.exec(statement).all()
             return change_requests
 
-    def should_qc(self, submission_id: str, target_percentage: float, salt: str | None) -> bool:
+    def should_qc(self, submission_id: str, target_percentage: float, salt: str | None) -> bool:  # noqa: C901
         """
         Determines whether or not a submission should go through detailed QC or not.
         """

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -493,6 +493,81 @@ class SubmissionDb:
                 session.rollback()
                 raise
 
+    def set_selected_for_qc(self, submission_id: str, selected_for_qc: bool) -> Submission:
+        value = "true" if selected_for_qc else "false"
+        return self.modify_submission(submission_id, "selected_for_qc", value)
+
+    def _submission_counts_as_selected_for_qc(self, submission: Submission) -> bool:
+        if submission.selected_for_qc is True:
+            return True
+        latest_state = submission.get_latest_state()
+        return (
+            latest_state.state in (SubmissionStateEnum.QCING, SubmissionStateEnum.QCED)
+            if latest_state is not None
+            else False
+        )
+
+    def _list_submitter_qc_candidates(
+        self,
+        submitter_id: SubmitterId | None,
+        start_date: datetime.date,
+        end_date: datetime.date,
+    ) -> list[Submission]:
+        with self._get_session() as session:
+            return session.exec(
+                select(Submission)
+                .options(selectinload(Submission.states))  # type: ignore[arg-type]
+                .where(Submission.submission_type == SubmissionType.initial)
+                .where(Submission.basic_qc_passed)  # type: ignore[arg-type]
+                .where(Submission.submission_date.between(start_date, end_date))  # type: ignore[union-attr]
+                .where(Submission.submitter_id == submitter_id)
+                .order_by(Submission.submission_date)  # type: ignore[arg-type]
+            ).all()
+
+    def _is_under_qc_target(
+        self,
+        submissions: Sequence[Submission],
+        target_proportion: float,
+        period_label: str,
+    ) -> bool:
+        total_selected = sum(map(self._submission_counts_as_selected_for_qc, submissions))
+        logger.debug(
+            "Total submissions selected for QC for submitter in submission's %s: %s", period_label, total_selected
+        )
+        if period_label == "month":
+            return not total_selected
+
+        qc_ratio = total_selected / len(submissions)
+        logger.debug(f"Total submissions for submitter in submission's {period_label}: {len(submissions)}")
+        logger.debug(
+            f"Ratio of submissions selected for QC for submitter in submission's {period_label}: {qc_ratio:.2%}"
+        )
+        return qc_ratio <= target_proportion
+
+    def _is_randomly_selected_for_qc(
+        self,
+        submission: Submission,
+        submissions: Sequence[Submission],
+        target_proportion: float,
+        salt: str | None,
+    ) -> bool:
+        logger.debug("Randomly choosing whether to QC or not.")
+        block_size = math.floor(1 / target_proportion)
+        block_index = len(submissions) // block_size
+        submission_quarter, submission_year = date_to_quarter_year(submission.submission_date)  # type: ignore[arg-type]
+        seed = f"{submission.submitter_id}-{submission_year}-{submission_quarter}-{block_index}-{salt}"
+        rng = random.Random(seed)  # noqa: S311
+
+        target_index_in_block = rng.randint(0, block_size - 1)
+        try:
+            current_index_in_block = [submitter_submission.id for submitter_submission in submissions].index(
+                submission.id
+            )
+        except ValueError:
+            # if the submission ID isn't in the quarter list, it hasn't met the requirements to be detailed QCed (e.g. passed basic QC)
+            return False
+        return current_index_in_block == target_index_in_block
+
     def update_submission_state(
         self,
         submission_id: str,
@@ -805,6 +880,8 @@ class SubmissionDb:
         if submission_type != SubmissionType.initial:
             # only initial submissions matter for detailed QC selection
             return False
+        if submission.selected_for_qc is True:
+            return True
 
         submission_month = submission_date.month
         submission_quarter, submission_year = date_to_quarter_year(submission_date)
@@ -812,84 +889,39 @@ class SubmissionDb:
             quarter=submission_quarter, year=submission_year
         )
         _, days_in_submission_month = calendar.monthrange(submission_year, submission_month)
-
-        # used instead of a lambda below to type check properly (get_latest_state() can return None)
-        def latest_state_is_qcing(submission: Submission):
-            latest_state = submission.get_latest_state()
-            return latest_state.state == SubmissionStateEnum.QCING if latest_state is not None else False
+        should_select = False
 
         # yes if none QCed/QCing from submitter yet for the submission month
-        with self._get_session() as session:
-            submitter_submissions_month = session.exec(
-                select(Submission)
-                .options(selectinload(Submission.states))  # type: ignore[arg-type]
-                .where(Submission.submission_type == SubmissionType.initial)
-                .where(Submission.basic_qc_passed)  # type: ignore[arg-type]
-                .where(
-                    Submission.submission_date.between(  # type: ignore[union-attr]
-                        datetime.date(year=submission_year, month=submission_month, day=1),
-                        datetime.date(year=submission_year, month=submission_month, day=days_in_submission_month),
-                    )
-                )
-                .where(Submission.submitter_id == submission.submitter_id)
-            ).all()
-            submitter_submissions_month_total_qced = sum(
-                map(lambda s: s.detailed_qc_passed is not None, submitter_submissions_month)
-            )
-            logger.debug(
-                f"Total QCed submissions for submitter in submission's month: {submitter_submissions_month_total_qced}"
-            )
-            submitter_submissions_month_total_qcing = sum(map(latest_state_is_qcing, submitter_submissions_month))
-            logger.debug(
-                f"Total QCing submissions for submitter in submission's month: {submitter_submissions_month_total_qcing}"
-            )
-            if not (submitter_submissions_month_total_qced + submitter_submissions_month_total_qcing):
-                return True
+        submitter_submissions_month = self._list_submitter_qc_candidates(
+            submitter_id=submission.submitter_id,
+            start_date=datetime.date(year=submission_year, month=submission_month, day=1),
+            end_date=datetime.date(year=submission_year, month=submission_month, day=days_in_submission_month),
+        )
+        if self._is_under_qc_target(submitter_submissions_month, target_proportion, period_label="month"):
+            should_select = True
 
         # yes if we are under target percentage for submitter for the submission's quarter
-        with self._get_session() as session:
-            submitter_submissions_quarter = session.exec(
-                select(Submission)
-                .options(selectinload(Submission.states))  # type: ignore[arg-type]
-                .where(Submission.submission_type == SubmissionType.initial)
-                .where(Submission.basic_qc_passed)  # type: ignore[arg-type]
-                .where(Submission.submission_date.between(submission_quarter_start, submission_quarter_end))  # type: ignore[union-attr]
-                .where(Submission.submitter_id == submission.submitter_id)
-                .order_by(Submission.submission_date)  # type: ignore[arg-type]
-            ).all()
-            submitter_submissions_quarter_total_qced = sum(
-                map(lambda s: s.detailed_qc_passed is not None, submitter_submissions_quarter)
-            )
-            logger.debug(
-                f"Total QCed submissions for submitter in submission's quarter: {submitter_submissions_quarter_total_qced}"
-            )
-            submitter_submissions_quarter_total_qcing = sum(map(latest_state_is_qcing, submitter_submissions_quarter))
-            logger.debug(
-                f"Total QCing submissions for submitter in submission's quarter: {submitter_submissions_quarter_total_qcing}"
-            )
-            qc_ratio = (submitter_submissions_quarter_total_qced + submitter_submissions_quarter_total_qcing) / len(
-                submitter_submissions_quarter
-            )
-            logger.debug(
-                f"Total submissions for submitter in submission's quarter: {len(submitter_submissions_quarter)}"
-            )
-            logger.debug(f"Ratio of submissions QCing/QCed for submitter in submission's quarter: {qc_ratio:.2%}")
-            if qc_ratio <= target_proportion:
-                return True
+        submitter_submissions_quarter = self._list_submitter_qc_candidates(
+            submitter_id=submission.submitter_id,
+            start_date=submission_quarter_start,
+            end_date=submission_quarter_end,
+        )
+        if not should_select and self._is_under_qc_target(
+            submitter_submissions_quarter,
+            target_proportion,
+            period_label="quarter",
+        ):
+            should_select = True
 
         # randomly, but reproducibly, select submissions for a given submitter, quarter, block, and salt
-        logger.debug("Randomly choosing whether to QC or not.")
-        block_size = math.floor(1 / target_proportion)
-        block_index = len(submitter_submissions_quarter) // block_size
-        seed = f"{submission.submitter_id}-{submission_year}-{submission_quarter}-{block_index}-{salt}"
-        rng = random.Random(seed)  # noqa: S311
-
-        target_index_in_block = rng.randint(0, block_size - 1)
-        try:
-            current_index_in_block = [submission.id for submission in submitter_submissions_quarter].index(
-                submission_id
+        if not should_select:
+            should_select = self._is_randomly_selected_for_qc(
+                submission=submission,
+                submissions=submitter_submissions_quarter,
+                target_proportion=target_proportion,
+                salt=salt,
             )
-        except ValueError:
-            # if the submission ID isn't in the quarter list, it hasn't met the requirements to be detailed QCed (e.g. passed basic QC)
-            return False
-        return current_index_in_block == target_index_in_block
+
+        if should_select:
+            self.set_selected_for_qc(submission_id, True)
+        return should_select

--- a/packages/grz-db/tests/test_should_qc.py
+++ b/packages/grz-db/tests/test_should_qc.py
@@ -359,7 +359,7 @@ class TestQcStrategy:
         start_time = datetime.datetime.combine(base_date, datetime.time(8, 0), tzinfo=datetime.UTC)
 
         block_size = math.floor(1 / (target_percentage / 100.0))
-        limit = block_size
+        limit = block_size * 2
 
         qced_count = 0
         total_count = 0
@@ -374,12 +374,13 @@ class TestQcStrategy:
             current_ratio = qced_count / total_count
             is_ratio_trigger = current_ratio <= (target_percentage / 100.0)
 
-            block_index = total_count // block_size
+            absolute_index = i
+            block_index = absolute_index // block_size
             seed = f"{SUBMITTER_ID}-{base_date.year}-3-{block_index}-{salt}"
             rng = random.Random(seed)
             target_index_in_block = rng.randint(0, block_size - 1)
 
-            is_random_trigger = i == target_index_in_block
+            is_random_trigger = (absolute_index % block_size) == target_index_in_block
 
             expect_qc = False
             if is_first_of_month_trigger:
@@ -416,3 +417,38 @@ class TestQcStrategy:
                 )
                 db.modify_submission(submission_id, "detailed_qc_passed", "true")
                 qced_count += 1
+
+    def test_is_randomly_selected_for_qc_uses_block_relative_index_for_later_blocks(self, db: SubmissionDb):
+        target_percentage = 2.0
+        target_proportion = target_percentage / 100.0
+        salt = "test-salt"
+        base_date = datetime.date(2025, 7, 1)
+        start_time = datetime.datetime.combine(base_date, datetime.time(8, 0), tzinfo=datetime.UTC)
+        block_size = math.floor(1 / target_proportion)
+
+        submissions = []
+        for i in range(block_size * 2):
+            submission_id = f"{SUBMITTER_ID}_{base_date}_{i:0>8}"
+            _add_submission_with_history(
+                db,
+                submission_id,
+                SUBMITTER_ID,
+                base_date,
+                DEFAULT_HISTORY,
+                base_timestamp=start_time + datetime.timedelta(minutes=i * 10),
+                is_qced=False,
+            )
+            submission = db.get_submission(submission_id)
+            assert submission is not None
+            submissions.append(submission)
+
+        absolute_index = block_size + 7
+        submission = submissions[absolute_index]
+        block_index = absolute_index // block_size
+
+        seed = f"{SUBMITTER_ID}-{base_date.year}-3-{block_index}-{salt}"
+        rng = random.Random(seed)
+        target_index_in_block = rng.randint(0, block_size - 1)
+        expected = (absolute_index % block_size) == target_index_in_block
+
+        assert db._is_randomly_selected_for_qc(submission, submissions, target_proportion, salt) is expected

--- a/packages/grz-db/tests/test_should_qc.py
+++ b/packages/grz-db/tests/test_should_qc.py
@@ -6,6 +6,11 @@ from pathlib import Path
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
+from grz_db.errors import (
+    SubmissionBasicQCNotPassedError,
+    SubmissionDateIsNoneError,
+    SubmissionTypeIsNoneError,
+)
 from grz_db.models.author import Author
 from grz_db.models.submission import SubmissionDb, SubmissionStateEnum, SubmissionStateLog, SubmissionType
 from sqlmodel import Session
@@ -116,7 +121,7 @@ class TestQcStrategy:
 
         assert should_run is True
 
-    def test_should_qc_recomputes_when_selected_for_qc_is_false(self, db: SubmissionDb):
+    def test_should_qc_returns_existing_selected_for_qc_false(self, db: SubmissionDb):
         test_date = datetime.date(2025, 12, 1)
         base_timestamp = datetime.datetime.combine(test_date, datetime.time(10, 0), tzinfo=datetime.UTC)
         submission_id = f"{SUBMITTER_ID}_{test_date}_00000000"
@@ -138,7 +143,7 @@ class TestQcStrategy:
             salt="any_salt",
         )
 
-        assert should_run is True
+        assert should_run is False
 
     def test_should_qc_persists_selected_for_qc_result(self, db: SubmissionDb):
         test_date = datetime.date(2025, 12, 1)
@@ -167,7 +172,7 @@ class TestQcStrategy:
         assert submission is not None
         assert submission.selected_for_qc is True
 
-    def test_should_qc_does_not_persist_false_result(self, db: SubmissionDb):
+    def test_should_qc_persists_false_result(self, db: SubmissionDb):
         target_percentage = 20.0
         salt = "ratio-test"
         base_date = datetime.date(2025, 12, 1)
@@ -202,7 +207,7 @@ class TestQcStrategy:
         assert should_run is False
         submission = db.get_submission(candidate_submission_id)
         assert submission is not None
-        assert submission.selected_for_qc is None
+        assert submission.selected_for_qc is False
 
     def test_should_qc_counts_existing_selected_for_qc_without_double_counting(self, db: SubmissionDb):
         target_percentage = 20.0
@@ -298,13 +303,15 @@ class TestQcStrategy:
 
     def test_quarterly_ratio_catchup(self, db: SubmissionDb):
         """
-        Tests that the quarterly target is met.
+        Tests that the quarter selection combines ratio catchup and random selection.
         Target: 20%.
         """
         target_percentage = 20.0
+        target_proportion = target_percentage / 100.0
         salt = "ratio-test"
         base_date = datetime.date(2025, 12, 1)
         start_time = datetime.datetime.combine(base_date, datetime.time(9, 0), tzinfo=datetime.UTC)
+        block_size = math.floor(1 / target_proportion)
 
         submission_id = f"{SUBMITTER_ID}_{base_date}_00000000"
         _add_submission_with_history(
@@ -317,6 +324,8 @@ class TestQcStrategy:
             is_qced=True,
         )
 
+        qced_count = 1
+        total_count = 1
         for i in range(1, 10):
             submission_id = f"{SUBMITTER_ID}_{base_date}_{i:0>8}"
             submission_timestamp = start_time + datetime.timedelta(minutes=i * 10)
@@ -331,22 +340,34 @@ class TestQcStrategy:
                 is_qced=False,
             )
 
+            total_count += 1
+            current_ratio = qced_count / total_count
+            is_ratio_trigger = current_ratio <= target_proportion
+
+            absolute_index = i
+            block_index = absolute_index // block_size
+            seed = f"{SUBMITTER_ID}-{base_date.year}-4-{block_index}-{salt}"
+            rng = random.Random(seed)
+            target_index_in_block = rng.randint(0, block_size - 1)
+            is_random_trigger = (absolute_index % block_size) == target_index_in_block
+
+            expect_qc = is_ratio_trigger or is_random_trigger
             should_run = db.should_qc(submission_id, target_percentage, salt)
 
-            # Ratio hits 20% exactly at indices 4 (1/5) and 9 (2/10)
-            if i in (4, 9):
-                assert should_run is True, f"Index {i} should have been selected for QC (Ratio catchup)"
+            assert should_run is expect_qc, (
+                f"Index {i}: Expect={expect_qc}, Got={should_run}. "
+                f"(Ratio: {current_ratio:.3f} vs {target_proportion}, Stats: QCed={qced_count}, Total={total_count})"
+            )
 
+            if should_run:
                 _update_submission_state(
                     db, submission_id, SubmissionStateEnum.QCING, submission_timestamp + datetime.timedelta(minutes=1)
                 )
                 _update_submission_state(
                     db, submission_id, SubmissionStateEnum.QCED, submission_timestamp + datetime.timedelta(minutes=2)
                 )
-
                 db.modify_submission(submission_id, "detailed_qc_passed", "true")
-            else:
-                assert should_run is False, f"Index {i} should NOT have been selected for QC"
+                qced_count += 1
 
     @pytest.mark.parametrize("target_percentage", [1.0, 2.0, 4.0, 5.0, 10.0, 20.0, 100.0])
     def test_random_selection(self, db: SubmissionDb, target_percentage: float):
@@ -452,3 +473,40 @@ class TestQcStrategy:
         expected = (absolute_index % block_size) == target_index_in_block
 
         assert db._is_randomly_selected_for_qc(submission, submissions, target_proportion, salt) is expected
+
+    def test_should_qc_raises_on_missing_submission_date(self, db: SubmissionDb):
+        """Verify SubmissionDateIsNoneError when submission_date is None."""
+        submission_id = f"{SUBMITTER_ID}_2025-12-01_00000000"
+        db.add_submission(submission_id)
+        db.modify_submission(submission_id, "submission_type", SubmissionType.initial.value)
+        db.modify_submission(submission_id, "basic_qc_passed", "true")
+
+        with pytest.raises(SubmissionDateIsNoneError):
+            db.should_qc(submission_id, 2.0, "salt")
+
+    def test_should_qc_raises_on_missing_submission_type(self, db: SubmissionDb):
+        """Verify SubmissionTypeIsNoneError when submission_type is None."""
+        submission_id = f"{SUBMITTER_ID}_2025-12-01_00000000"
+        db.add_submission(submission_id)
+        db.modify_submission(submission_id, "submission_date", "2025-12-01")
+        db.modify_submission(submission_id, "basic_qc_passed", "true")
+
+        with pytest.raises(SubmissionTypeIsNoneError):
+            db.should_qc(submission_id, 2.0, "salt")
+
+    def test_should_qc_raises_on_failed_basic_qc(self, db: SubmissionDb):
+        """Verify SubmissionBasicQCNotPassedError when basic_qc_passed is False."""
+        test_date = datetime.date(2025, 12, 1)
+        submission_id = f"{SUBMITTER_ID}_{test_date}_00000000"
+        _add_submission_with_history(
+            db,
+            submission_id,
+            SUBMITTER_ID,
+            test_date,
+            DEFAULT_HISTORY,
+            base_timestamp=datetime.datetime.combine(test_date, datetime.time(10, 0), tzinfo=datetime.UTC),
+        )
+        db.modify_submission(submission_id, "basic_qc_passed", "false")
+
+        with pytest.raises(SubmissionBasicQCNotPassedError):
+            db.should_qc(submission_id, 2.0, "salt")

--- a/packages/grz-db/tests/test_should_qc.py
+++ b/packages/grz-db/tests/test_should_qc.py
@@ -92,6 +92,152 @@ def _add_submission_with_history(
 class TestQcStrategy:
     """Tests the QC selection strategy method db.should_qc."""
 
+    def test_should_qc_returns_existing_selected_for_qc_true(self, db: SubmissionDb):
+        test_date = datetime.date(2025, 12, 1)
+        base_timestamp = datetime.datetime.combine(test_date, datetime.time(10, 0), tzinfo=datetime.UTC)
+        submission_id = f"{SUBMITTER_ID}_{test_date}_00000000"
+
+        _add_submission_with_history(
+            db,
+            submission_id,
+            SUBMITTER_ID,
+            test_date,
+            DEFAULT_HISTORY,
+            base_timestamp=base_timestamp,
+            is_qced=False,
+        )
+        db.modify_submission(submission_id, "selected_for_qc", "true")
+
+        should_run = db.should_qc(
+            submission_id=submission_id,
+            target_percentage=2.0,
+            salt="any_salt",
+        )
+
+        assert should_run is True
+
+    def test_should_qc_recomputes_when_selected_for_qc_is_false(self, db: SubmissionDb):
+        test_date = datetime.date(2025, 12, 1)
+        base_timestamp = datetime.datetime.combine(test_date, datetime.time(10, 0), tzinfo=datetime.UTC)
+        submission_id = f"{SUBMITTER_ID}_{test_date}_00000000"
+
+        _add_submission_with_history(
+            db,
+            submission_id,
+            SUBMITTER_ID,
+            test_date,
+            DEFAULT_HISTORY,
+            base_timestamp=base_timestamp,
+            is_qced=False,
+        )
+        db.modify_submission(submission_id, "selected_for_qc", "false")
+
+        should_run = db.should_qc(
+            submission_id=submission_id,
+            target_percentage=2.0,
+            salt="any_salt",
+        )
+
+        assert should_run is True
+
+    def test_should_qc_persists_selected_for_qc_result(self, db: SubmissionDb):
+        test_date = datetime.date(2025, 12, 1)
+        base_timestamp = datetime.datetime.combine(test_date, datetime.time(10, 0), tzinfo=datetime.UTC)
+        submission_id = f"{SUBMITTER_ID}_{test_date}_00000000"
+
+        _add_submission_with_history(
+            db,
+            submission_id,
+            SUBMITTER_ID,
+            test_date,
+            DEFAULT_HISTORY,
+            base_timestamp=base_timestamp,
+            is_qced=False,
+        )
+
+        should_run = db.should_qc(
+            submission_id=submission_id,
+            target_percentage=2.0,
+            salt="any_salt",
+        )
+
+        assert should_run is True
+
+        submission = db.get_submission(submission_id)
+        assert submission is not None
+        assert submission.selected_for_qc is True
+
+    def test_should_qc_does_not_persist_false_result(self, db: SubmissionDb):
+        target_percentage = 20.0
+        salt = "ratio-test"
+        base_date = datetime.date(2025, 12, 1)
+        start_time = datetime.datetime.combine(base_date, datetime.time(9, 0), tzinfo=datetime.UTC)
+
+        selected_submission_id = f"{SUBMITTER_ID}_{base_date}_00000000"
+        _add_submission_with_history(
+            db,
+            selected_submission_id,
+            SUBMITTER_ID,
+            base_date,
+            [*DEFAULT_HISTORY, "qcing"],
+            base_timestamp=start_time,
+            is_qced=False,
+        )
+        db.modify_submission(selected_submission_id, "selected_for_qc", "true")
+
+        candidate_submission_id = f"{SUBMITTER_ID}_{base_date}_00000001"
+        candidate_timestamp = start_time + datetime.timedelta(minutes=10)
+        _add_submission_with_history(
+            db,
+            candidate_submission_id,
+            SUBMITTER_ID,
+            base_date,
+            DEFAULT_HISTORY,
+            base_timestamp=candidate_timestamp,
+            is_qced=False,
+        )
+
+        should_run = db.should_qc(candidate_submission_id, target_percentage, salt)
+
+        assert should_run is False
+        submission = db.get_submission(candidate_submission_id)
+        assert submission is not None
+        assert submission.selected_for_qc is None
+
+    def test_should_qc_counts_existing_selected_for_qc_without_double_counting(self, db: SubmissionDb):
+        target_percentage = 20.0
+        salt = "ratio-test"
+        base_date = datetime.date(2025, 12, 1)
+        start_time = datetime.datetime.combine(base_date, datetime.time(9, 0), tzinfo=datetime.UTC)
+
+        selected_submission_id = f"{SUBMITTER_ID}_{base_date}_00000000"
+        _add_submission_with_history(
+            db,
+            selected_submission_id,
+            SUBMITTER_ID,
+            base_date,
+            [*DEFAULT_HISTORY, "qcing"],
+            base_timestamp=start_time,
+            is_qced=False,
+        )
+        db.modify_submission(selected_submission_id, "selected_for_qc", "true")
+
+        candidate_submission_id = f"{SUBMITTER_ID}_{base_date}_00000001"
+        candidate_timestamp = start_time + datetime.timedelta(minutes=10)
+        _add_submission_with_history(
+            db,
+            candidate_submission_id,
+            SUBMITTER_ID,
+            base_date,
+            DEFAULT_HISTORY,
+            base_timestamp=candidate_timestamp,
+            is_qced=False,
+        )
+
+        should_run = db.should_qc(candidate_submission_id, target_percentage, salt)
+
+        assert should_run is False
+
     def test_first_of_month_always_runs(self, db: SubmissionDb):
         """
         Test that the first (validated, initial) submission of a month is always QCed.

--- a/packages/grz-db/tests/test_should_qc.py
+++ b/packages/grz-db/tests/test_should_qc.py
@@ -238,6 +238,39 @@ class TestQcStrategy:
 
         assert should_run is False
 
+    def test_should_qc_counts_historical_qcing_or_qced_states(self, db: SubmissionDb):
+        target_percentage = 20.0
+        salt = "ratio-test"
+        base_date = datetime.date(2025, 12, 1)
+        start_time = datetime.datetime.combine(base_date, datetime.time(9, 0), tzinfo=datetime.UTC)
+
+        historical_qc_submission_id = f"{SUBMITTER_ID}_{base_date}_00000000"
+        _add_submission_with_history(
+            db,
+            historical_qc_submission_id,
+            SUBMITTER_ID,
+            base_date,
+            [*DEFAULT_HISTORY, "qcing", "qced", "cleaning", "cleaned"],
+            base_timestamp=start_time,
+            is_qced=True,
+        )
+
+        candidate_submission_id = f"{SUBMITTER_ID}_{base_date}_00000001"
+        candidate_timestamp = start_time + datetime.timedelta(minutes=10)
+        _add_submission_with_history(
+            db,
+            candidate_submission_id,
+            SUBMITTER_ID,
+            base_date,
+            DEFAULT_HISTORY,
+            base_timestamp=candidate_timestamp,
+            is_qced=False,
+        )
+
+        should_run = db.should_qc(candidate_submission_id, target_percentage, salt)
+
+        assert should_run is False
+
     def test_first_of_month_always_runs(self, db: SubmissionDb):
         """
         Test that the first (validated, initial) submission of a month is always QCed.

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -945,6 +945,7 @@ def show(ctx: click.Context, submission_id: str, output_json: bool):
         ("Genomic Study Subtype", "genomic_study_subtype"),
         ("Basic QC Passed", "basic_qc_passed"),
         ("Consented", "consented"),
+        ("Selected For QC", "selected_for_qc"),
         ("Detailed QC Passed", "detailed_qc_passed"),
     ):
         attr = getattr(submission, attr_name)

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -29,7 +29,10 @@ from grz_db.errors import (
     DatabaseConfigurationError,
     DuplicateSubmissionError,
     DuplicateTanGError,
+    SubmissionBasicQCNotPassedError,
+    SubmissionDateIsNoneError,
     SubmissionNotFoundError,
+    SubmissionTypeIsNoneError,
 )
 from grz_db.models.author import Author
 from grz_db.models.submission import (
@@ -372,9 +375,12 @@ def should_qc(ctx: click.Context, submission_id: str, target_percentage: float, 
     database_url = ctx.obj["db_url"]
     database = get_submission_db_instance(database_url)
 
-    click.echo(
-        str(database.should_qc(submission_id=submission_id, target_percentage=target_percentage, salt=salt)).lower()
-    )
+    try:
+        result = database.should_qc(submission_id=submission_id, target_percentage=target_percentage, salt=salt)
+        click.echo(str(result).lower())
+    except (SubmissionDateIsNoneError, SubmissionTypeIsNoneError, SubmissionBasicQCNotPassedError) as e:
+        click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1) from e
 
 
 def _build_submission_dict_from(

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -27,12 +27,8 @@ from grz_common.logging import LOGGING_DATEFMT, LOGGING_FORMAT
 from grz_common.workers.download import query_submissions
 from grz_db.errors import (
     DatabaseConfigurationError,
-    DuplicateSubmissionError,
-    DuplicateTanGError,
-    SubmissionBasicQCNotPassedError,
-    SubmissionDateIsNoneError,
+    SubmissionError,
     SubmissionNotFoundError,
-    SubmissionTypeIsNoneError,
 )
 from grz_db.models.author import Author
 from grz_db.models.submission import (
@@ -90,7 +86,7 @@ def db(
     config = DbConfig.model_validate(configuration)
     db_config = config.db
     if not db_config:
-        raise ValueError("DB config not found")
+        raise DatabaseConfigurationError("DB config not found")
     author_name = db_config.author.name
 
     if path := db_config.author.private_key_path:
@@ -99,7 +95,7 @@ def db(
     elif key := db_config.author.private_key:
         private_key_bytes = key.encode("utf-8")
     else:
-        raise ValueError("Either private_key or private_key_path must be provided.")
+        raise DatabaseConfigurationError("Either private_key or private_key_path must be provided.")
 
     log.debug("Reading known public keys...")
     KnownKeyEntry = namedtuple("KnownKeyEntry", ["key_format", "public_key_base64", "comment"])
@@ -378,7 +374,7 @@ def should_qc(ctx: click.Context, submission_id: str, target_percentage: float, 
     try:
         result = database.should_qc(submission_id=submission_id, target_percentage=target_percentage, salt=salt)
         click.echo(str(result).lower())
-    except (SubmissionDateIsNoneError, SubmissionTypeIsNoneError, SubmissionBasicQCNotPassedError) as e:
+    except SubmissionError as e:
         click.echo(f"Error: {e}", err=True)
         raise SystemExit(1) from e
 
@@ -430,7 +426,7 @@ def add(ctx: click.Context, submission_id: str):
     try:
         db_submission = db_service.add_submission(submission_id)
         console_err.print(f"[green]Submission '{db_submission.id}' added successfully.[/green]")
-    except (DuplicateSubmissionError, DuplicateTanGError) as e:
+    except SubmissionError as e:
         console_err.print(f"[red]Error: {e}[/red]")
         raise click.Abort() from e
     except Exception as e:

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -6,7 +6,7 @@ import hashlib
 import importlib.resources
 import json
 import random
-from datetime import date
+from datetime import UTC, date, datetime
 from operator import attrgetter
 from pathlib import Path
 from textwrap import dedent
@@ -36,6 +36,21 @@ def test_all_migrations(blank_initial_database_config_path):
             sqlalchemy.insert(Submission),
             {"tan_g": tan_g, "pseudonym": pseudonym, "id": submission_id},
         )
+        connection.execute(
+            sqlalchemy.text(
+                """
+                INSERT INTO submission_states (state, data, timestamp, submission_id, author_name, signature)
+                VALUES (:state, NULL, :timestamp, :submission_id, :author_name, :signature)
+                """
+            ),
+            {
+                "state": "QCING",
+                "timestamp": datetime.now(UTC),
+                "submission_id": submission_id,
+                "author_name": "alice",
+                "signature": "dummy",
+            },
+        )
         connection.commit()
 
     # ensure db command raises appropriate error before migration
@@ -55,6 +70,11 @@ def test_all_migrations(blank_initial_database_config_path):
     assert result_show.exit_code == 0, result_show.stderr
     # shorter than tanG and less likely to be truncated in various terminal widths
     assert pseudonym in result_show.stdout, result_show.stdout
+
+    db = SubmissionDb(db_url=config.db.database_url, author=None)
+    submission = db.get_submission(submission_id)
+    assert submission is not None
+    assert submission.selected_for_qc is True
 
 
 def test_populate(blank_database_config_path: Path):

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -384,6 +384,7 @@ def test_submission_show_json(blank_database_config_path: Path):
         "disease_type": metadata.submission.disease_type,
         "basic_qc_passed": None,
         "consented": metadata.consents_to_research(date=date.today()),
+        "selected_for_qc": None,
         "detailed_qc_passed": None,
         "genomic_study_type": metadata.submission.genomic_study_type,
         "genomic_study_subtype": metadata.submission.genomic_study_subtype,


### PR DESCRIPTION
## Summary

Introduce persisted QC selection decisions via selected_for_qc and a QC queue table, aligning should_qc() behavior with the streaming approach of submissions.

## Changes

- Add selected_for_qc: bool | None to the submission model.
- Add an Alembic migration to create the selected_for_qc column on submissions.
- Backfill selected_for_qc = true for historical submissions already in QCING / QCED.
- Add a QC queue table (qc_queue) to track submissions that passed basic QC, ordered by basic_qc_passed_at.
- Keep the QC queue in sync when basic_qc_passed changes (insert/remove queue entry; force selected_for_qc=false on basic_qc_passed=false).
- Update should_qc() so selected_for_qc is the primary, persisted decision signal:
- selected_for_qc=True returns True (cached yes)
- selected_for_qc=False returns False (cached no)
- selected_for_qc=None computes the decision and persists True or False
- Keep selection logic backward-compatible by also counting historical QCING / QCED states as “selected” when evaluating monthly/quarterly targets.
- Improve CLI handling: grzctl db should-qc exits cleanly with an error message when the submission is not eligible/missing required metadata.
- Update/extend tests to reflect persisted selected_for_qc behavior and the random-selection stage.

## Notes

- selected_for_qc represents a durable selection decision, not a transient hint: both positive and negative outcomes are persisted to ensure idempotent behavior across repeated should_qc() calls.
- Historical rows are initialized from existing QCING / QCED states. For new rows, should_qc() is the source of truth for setting selected_for_qc.
- The QC queue table reflects the “passed basic QC → eligible for selection” step in streaming_approach_flo.md.

Fixes #530
