### PR TITLE
feat(grz-tools): add structured failure reason tracking for submissions

### DIFF
--- a/packages/grz-db/src/grz_db/common.py
+++ b/packages/grz-db/src/grz_db/common.py
@@ -38,14 +38,10 @@ class CaseInsensitiveStrEnum(enum.StrEnum):
         """
         return hash(self.value.casefold())
 
-
-class ListableEnum(enum.StrEnum):
-    """Mixin for enum classes whose members can be listed."""
-
     @classmethod
     def list(cls) -> list[str]:
         """Returns a list of enum members."""
-        return list(map(lambda c: c.value, cls))
+        return [m.value for m in cls]
 
 
 def serialize_datetime_to_iso_z(dt: datetime.datetime) -> str:

--- a/packages/grz-db/src/grz_db/migrations/versions/c063b408d262_add_failure_reason_column_to_submission_.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/c063b408d262_add_failure_reason_column_to_submission_.py
@@ -1,7 +1,7 @@
 """Add failure_reason column to submission_states
 
 Revision ID: c063b408d262
-Revises: 8aa6fc8d118a
+Revises: 9023ab55c239, f3a9c7d2e481
 Create Date: 2026-04-13 09:51:49.819155+00:00
 
 """
@@ -14,7 +14,7 @@ from grz_db.models.submission import FailureReasonEnum
 
 # revision identifiers, used by Alembic.
 revision: str = "c063b408d262"
-down_revision: str | Sequence[str] | None = "8aa6fc8d118a"
+down_revision: str | Sequence[str] | None = ("9023ab55c239", "f3a9c7d2e481")
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/packages/grz-db/src/grz_db/migrations/versions/c063b408d262_add_failure_reason_column_to_submission_.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/c063b408d262_add_failure_reason_column_to_submission_.py
@@ -1,0 +1,31 @@
+"""Add failure_reason column to submission_states
+
+Revision ID: c063b408d262
+Revises: 8aa6fc8d118a
+Create Date: 2026-04-13 09:51:49.819155+00:00
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from grz_db.models.submission import FailureReasonEnum
+
+# revision identifiers, used by Alembic.
+revision: str = "c063b408d262"
+down_revision: str | Sequence[str] | None = "8aa6fc8d118a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema - added the failure_reason column to submission_states."""
+    failure_reason_enum = sa.Enum(*[e.value for e in FailureReasonEnum], name="failure_reason_enum")
+    failure_reason_enum.create(op.get_bind())
+    op.add_column("submission_states", sa.Column("failure_reason", failure_reason_enum, nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    raise RuntimeError("Downgrades not supported.")

--- a/packages/grz-db/src/grz_db/models/submission.py
+++ b/packages/grz-db/src/grz_db/models/submission.py
@@ -39,7 +39,6 @@ from sqlmodel import DateTime, Field, Relationship, Session, SQLModel, create_en
 
 from ..common import (
     CaseInsensitiveStrEnum,
-    ListableEnum,
     serialize_datetime_to_iso_z,
 )
 from ..errors import DuplicateSubmissionError, DuplicateTanGError, SubmissionNotFoundError
@@ -53,7 +52,7 @@ class OutdatedDatabaseSchemaError(Exception):
     pass
 
 
-class SubmissionStateEnum(CaseInsensitiveStrEnum, ListableEnum):  # type: ignore[misc]
+class SubmissionStateEnum(CaseInsensitiveStrEnum):  # type: ignore[misc]
     """Submission state enum."""
 
     UPLOADING = "Uploading"
@@ -78,7 +77,7 @@ class SubmissionStateEnum(CaseInsensitiveStrEnum, ListableEnum):  # type: ignore
     ERROR = "Error"
 
 
-class SubmissionStateFilterModeEnum(CaseInsensitiveStrEnum, ListableEnum):  # type: ignore[misc]
+class SubmissionStateFilterModeEnum(CaseInsensitiveStrEnum):
     """Submission state filter mode enum."""
 
     LATEST = "latest"
@@ -110,6 +109,15 @@ class SemicolonSeparatedStringSet(sa.types.TypeDecorator):
 
     def process_result_value(self, value: str | None, dialect: sa.engine.Dialect) -> set[str] | None:
         return None if value is None else set(value.split(";"))
+
+
+class FailureReasonEnum(CaseInsensitiveStrEnum):
+    """Failure reason enum with controlled vocabulary."""
+
+    DUPLICATE_TANG = "Duplicate TanG"
+    MISSING_DATA = "Missing Data"
+    DECRYPTION_ERROR = "Decryption Error"
+    NETWORK_ERROR = "Network Error"
 
 
 class SubmissionBase(SQLModel):
@@ -182,6 +190,10 @@ class SubmissionStateLogBase(SQLModel):
     model_config = ConfigDict(  # type: ignore
         populate_by_name=True,
     )
+    failure_reason: FailureReasonEnum | None = Field(
+        default=None,
+        sa_column=Column(Enum(FailureReasonEnum, values_callable=lambda e: [x.value for x in e], python_type=str)),
+    )
 
     @field_serializer("timestamp")
     def serialize_timestamp(self, ts: datetime.datetime) -> str:
@@ -228,7 +240,7 @@ class SubmissionCreate(SubmissionBase):
     id: str
 
 
-class ChangeRequestEnum(CaseInsensitiveStrEnum, ListableEnum):  # type: ignore[misc]
+class ChangeRequestEnum(CaseInsensitiveStrEnum):
     """Change request enum."""
 
     MODIFY = "Modify"
@@ -495,6 +507,7 @@ class SubmissionDb:
         submission_id: str,
         state: SubmissionStateEnum,
         data: dict | None = None,
+        failure_reason: FailureReasonEnum | None = None,
     ) -> SubmissionStateLog:
         """
         Updates a submission's state to the specified state.
@@ -515,7 +528,11 @@ class SubmissionDb:
                 raise ValueError("No author defined")
 
             state_log_payload = SubmissionStateLogPayload(
-                submission_id=submission_id, author_name=self._author.name, state=state, data=data
+                submission_id=submission_id,
+                author_name=self._author.name,
+                state=state,
+                data=data,
+                failure_reason=failure_reason,
             )
             signature = state_log_payload.sign(self._author.private_key())
 

--- a/packages/grz-db/tests/test_failure_reason.py
+++ b/packages/grz-db/tests/test_failure_reason.py
@@ -1,0 +1,28 @@
+"""Tests for FailureReasonEnum."""
+
+from grz_db.models.submission import FailureReasonEnum
+
+
+def test_failure_reason_enum_values():
+    """Test that all enum values are correctly defined."""
+    assert FailureReasonEnum.DUPLICATE_TANG == "Duplicate TanG"
+    assert FailureReasonEnum.MISSING_DATA == "Missing Data"
+    assert FailureReasonEnum.DECRYPTION_ERROR == "Decryption Error"
+    assert FailureReasonEnum.NETWORK_ERROR == "Network Error"
+
+
+def test_failure_reason_enum_case_insensitive():
+    """Test case insensitive enum behavior."""
+    assert FailureReasonEnum("duplicate tang") == FailureReasonEnum.DUPLICATE_TANG
+    assert FailureReasonEnum("MISSING DATA") == FailureReasonEnum.MISSING_DATA
+    assert FailureReasonEnum("Decryption Error") == FailureReasonEnum.DECRYPTION_ERROR
+
+
+def test_failure_reason_enum_listable():
+    """Test that the enum can be listed for CLI choices."""
+    reasons = FailureReasonEnum.list()
+    assert len(reasons) == 4
+    assert "Duplicate TanG" in reasons
+    assert "Missing Data" in reasons
+    assert "Decryption Error" in reasons
+    assert "Network Error" in reasons

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -37,6 +37,7 @@ from grz_db.models.submission import (
     ChangeRequestLog,
     DetailedQCResult,
     Donor,
+    FailureReasonEnum,
     Submission,
     SubmissionDb,
     SubmissionStateEnum,
@@ -432,21 +433,21 @@ def add(ctx: click.Context, submission_id: str):
         raise click.ClickException(f"Failed to add submission: {e}") from e
 
 
-@submission.command()
 @click.argument("submission_id", type=str)
 @click.argument("state_str", metavar="STATE", type=click.Choice(SubmissionStateEnum.list(), case_sensitive=False))
-@click.option("--data", "data_json", type=str, default=None, help='Additional JSON data (e.g., \'{"k":"v"}\').')
-@click.option("--ignore-error-state/--confirm-error-state")
-@click.pass_context
-def update(ctx: click.Context, submission_id: str, state_str: str, data_json: str | None, ignore_error_state: bool):  # noqa: C901
-    """Update a submission to the given state. Optionally accepts additional JSON data to associate with the log entry."""
-    db = ctx.obj["db_url"]
-    db_service = get_submission_db_instance(db, author=ctx.obj["author"])
+def _parse_update_args(
+    state_str: str, data_json: str | None, failure_reason: str | None
+) -> tuple[SubmissionStateEnum, dict | None, FailureReasonEnum | None]:
+    """Parse and validate arguments for the update command."""
     try:
         state_enum = SubmissionStateEnum(state_str)
     except ValueError as e:
         console_err.print(f"[red]Error: Invalid state value '{state_str}'.[/red]")
         raise click.Abort() from e
+
+    failure_reason_enum = None
+    if failure_reason:
+        failure_reason_enum = FailureReasonEnum(failure_reason)
 
     parsed_data = None
     if data_json:
@@ -455,25 +456,62 @@ def update(ctx: click.Context, submission_id: str, state_str: str, data_json: st
         except json.JSONDecodeError as e:
             console_err.print(f"[red]Error: Invalid JSON string for --data: {data_json}[/red]")
             raise click.Abort() from e
+
+    return state_enum, parsed_data, failure_reason_enum
+
+
+def _check_error_state_transition(
+    submission: Submission, state_enum: SubmissionStateEnum, ignore_error_state: bool
+) -> None:
+    """Check if transitioning from error state requires confirmation."""
+    latest_state = submission.get_latest_state()
+    latest_state_is_error = latest_state is not None and latest_state.state == SubmissionStateEnum.ERROR
+    if (
+        latest_state_is_error
+        and not ignore_error_state
+        and not click.confirm(
+            f"Submission is currently in an 'Error' state. Are you sure you want to set it to '{state_enum}'?",
+            default=False,
+            show_default=True,
+        )
+    ):
+        console_err.print(f"[yellow]Not modifying state of errored submission '{submission.id}'.[/yellow]")
+        raise click.Abort()
+
+
+@submission.command()
+@click.option(
+    "--failure-reason",
+    type=click.Choice([r.lower() for r in FailureReasonEnum.list()], case_sensitive=False),
+    help="Reason for failure (when state is Error)",
+)
+@click.option("--ignore-error-state/--confirm-error-state")
+@click.argument("submission_id", type=str)
+@click.argument("state_str", metavar="STATE", type=click.Choice(SubmissionStateEnum.list(), case_sensitive=False))
+@click.option("--data", "data_json", type=str, default=None, help='Additional JSON data (e.g., \'{"k":"v"}\').')
+@click.pass_context
+def update(  # noqa: PLR0913
+    ctx: click.Context,
+    submission_id: str,
+    state_str: str,
+    data_json: str | None,
+    failure_reason: str | None,
+    ignore_error_state: bool,
+):
+    """Update a submission to the given state. Optionally accepts additional JSON data to associate with the log entry."""
+    db = ctx.obj["db_url"]
+    db_service = get_submission_db_instance(db, author=ctx.obj["author"])
+
+    state_enum, parsed_data, failure_reason_enum = _parse_update_args(state_str, data_json, failure_reason)
+
     try:
         submission = db_service.get_submission(submission_id)
         if not submission:
             raise SubmissionNotFoundError(submission_id)
-        latest_state = submission.get_latest_state()
-        latest_state_is_error = latest_state is not None and latest_state.state == SubmissionStateEnum.ERROR
-        if (
-            latest_state_is_error
-            and not ignore_error_state
-            and not click.confirm(
-                f"Submission is currently in an 'Error' state. Are you sure you want to set it to '{state_enum}'?",
-                default=False,
-                show_default=True,
-            )
-        ):
-            console_err.print(f"[yellow]Not modifying state of errored submission '{submission_id}'.[/yellow]")
-            ctx.exit()
 
-        new_state_log = db_service.update_submission_state(submission_id, state_enum, parsed_data)
+        _check_error_state_transition(submission, state_enum, ignore_error_state)
+
+        new_state_log = db_service.update_submission_state(submission_id, state_enum, parsed_data, failure_reason_enum)
         console_err.print(
             f"[green]Submission '{submission_id}' updated to state '{new_state_log.state.value}'. Log ID: {new_state_log.id}[/green]"
         )
@@ -921,7 +959,9 @@ def show(ctx: click.Context, submission_id: str, output_json: bool):
             signature_status, verifying_key_comment = _verify_signature(
                 ctx.obj["public_keys"], state_log.author_name, state_log
             )
-            state_dict = state_log.model_dump(mode="json", include={"id", "timestamp", "state", "data"})
+            state_dict = state_log.model_dump(
+                mode="json", include={"id", "timestamp", "state", "data", "failure_reason"}
+            )
             state_dict["data_steward"] = state_log.author_name
             state_dict["data_steward_signature"] = signature_status
             state_dict["signature_key_comment"] = verifying_key_comment
@@ -959,6 +999,7 @@ def show(ctx: click.Context, submission_id: str, output_json: bool):
         state_table.add_column("Log ID", style="dim", width=12)
         state_table.add_column("Timestamp (UTC)", style="yellow")
         state_table.add_column("State", style="green")
+        state_table.add_column("Failure Reason", style="red")
         state_table.add_column("Data", style="cyan", overflow="ellipsis")
         state_table.add_column("Data Steward", style="magenta")
         state_table.add_column("Signature Status")
@@ -968,6 +1009,7 @@ def show(ctx: click.Context, submission_id: str, output_json: bool):
             data_str = json.dumps(state_log.data) if state_log.data else ""
             state = state_log.state.value
             state_str = f"[red]{state}[/red]" if state == SubmissionStateEnum.ERROR else state
+            failure_reason_str = state_log.failure_reason.value if state_log.failure_reason else ""
             data_steward_str = state_log.author_name
             signature_status, verifying_key_comment = _verify_signature(
                 ctx.obj["public_keys"], data_steward_str, state_log
@@ -978,6 +1020,7 @@ def show(ctx: click.Context, submission_id: str, output_json: bool):
                 str(state_log.id),
                 state_log.timestamp.isoformat(),
                 state_str,
+                failure_reason_str,
                 data_str,
                 data_steward_str,
                 signature_status_str,

--- a/packages/grzctl/tests/cli/conftest.py
+++ b/packages/grzctl/tests/cli/conftest.py
@@ -28,7 +28,7 @@ def blank_database_config(request: pytest.FixtureRequest, tmp_path: Path) -> DbC
             private_key.private_bytes(
                 encoding=cryptser.Encoding.PEM,
                 format=cryptser.PrivateFormat.OpenSSH,
-                encryption_algorithm=cryptser.NoEncryption(),
+                encryption_algorithm=cryptser.BestAvailableEncryption(b"test"),
             )
         )
 
@@ -52,7 +52,7 @@ def blank_database_config(request: pytest.FixtureRequest, tmp_path: Path) -> DbC
             "author": {
                 "name": "alice",
                 "private_key_path": str(private_key_path.resolve()),
-                "private_key_passphrase": "",
+                "private_key_passphrase": "test",
             },
             "known_public_keys": str(public_key_path.resolve()),
         }

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -508,3 +508,173 @@ def test_list_filter_modes_and_multiple_states(blank_database_config_path: Path)
     assert result_state_alias.exit_code == 0, result_state_alias.stderr
     parsed_state_alias = json.loads(result_state_alias.stdout)
     assert {item["id"] for item in parsed_state_alias} == {sub_latest_downloaded}
+
+
+def test_update_with_failure_reason(blank_database_config_path: Path):
+    """Test CLI update command with failure reason option."""
+    args_common = ["db", "--config-file", blank_database_config_path]
+
+    runner = click.testing.CliRunner(env={"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test"}, catch_exceptions=False)
+    cli = grzctl.cli.build_cli()
+
+    # Add submission
+    result = runner.invoke(cli, [*args_common, "submission", "add", "123456789_2025-01-01_12345678"])
+    assert result.exit_code == 0, result.stderr
+
+    # Update with failure reason
+    result = runner.invoke(
+        cli,
+        [
+            *args_common,
+            "submission",
+            "update",
+            "123456789_2025-01-01_12345678",
+            "Error",
+            "--failure-reason",
+            "duplicate tang",  # ← "duplicate tang"
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    # Check that the failure reason was stored
+    import yaml
+    from grzctl.commands.db.cli import get_submission_db_instance
+    from grzctl.models.config import DbConfig
+
+    with open(blank_database_config_path) as f:
+        config_dict = yaml.safe_load(f)
+    db_config = DbConfig.model_validate(config_dict).db
+    db_service = get_submission_db_instance(db_config.database_url)
+    submission = db_service.get_submission("123456789_2025-01-01_12345678")
+    assert submission is not None
+    latest_state = submission.get_latest_state()
+    assert latest_state is not None
+    assert latest_state.failure_reason is not None
+    assert latest_state.failure_reason.value == "Duplicate TanG"  # ← "Duplicate TanG"
+
+
+def test_update_with_all_failure_reasons(blank_database_config_path: Path):
+    """Test CLI update with all possible failure reasons."""
+    args_common = ["db", "--config-file", blank_database_config_path]
+    runner = click.testing.CliRunner(env={"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test"})
+    cli = grzctl.cli.build_cli()
+
+    # Add submission
+    result = runner.invoke(cli, [*args_common, "submission", "add", "123456789_2025-01-01_11111111"])
+    assert result.exit_code == 0
+
+    failure_reasons = ["duplicate tang", "missing data", "decryption error", "network error"]  # ← failure reasons
+
+    for reason in failure_reasons:
+        # Reset to non-error state first
+        runner.invoke(
+            cli,
+            [*args_common, "submission", "update", "123456789_2025-01-01_11111111", "Uploaded", "--ignore-error-state"],
+        )
+
+        # Update to error with specific reason
+        result = runner.invoke(
+            cli,
+            [
+                *args_common,
+                "submission",
+                "update",
+                "123456789_2025-01-01_11111111",
+                "Error",
+                "--failure-reason",
+                reason,
+            ],
+        )
+        assert result.exit_code == 0
+
+
+def test_failure_reason_case_insensitive_cli(blank_database_config_path: Path):
+    """Test CLI accepts case insensitive failure reasons."""
+    args_common = ["db", "--config-file", blank_database_config_path]
+
+    runner = click.testing.CliRunner(env={"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test"})
+    cli = grzctl.cli.build_cli()
+
+    # Add submission
+    result = runner.invoke(cli, [*args_common, "submission", "add", "123456789_2025-01-01_22222222"])
+    assert result.exit_code == 0
+
+    # Test various case combinations (these should be normalized by the CLI to match enum)
+    test_cases = [
+        "duplicate tang",
+        "missing data",
+        "decryption error",
+        "network error",
+    ]  # ← case insensitive test cases
+
+    for case in test_cases:
+        # Reset state first
+        runner.invoke(
+            cli,
+            [*args_common, "submission", "update", "123456789_2025-01-01_22222222", "Uploaded", "--ignore-error-state"],
+        )
+
+        result = runner.invoke(
+            cli,
+            [*args_common, "submission", "update", "123456789_2025-01-01_22222222", "Error", "--failure-reason", case],
+        )
+        assert result.exit_code == 0
+
+
+def test_failure_reason_end_to_end(blank_database_config_path: Path):
+    """Test complete failure reason workflow."""
+    args_common = ["db", "--config-file", blank_database_config_path]
+
+    runner = click.testing.CliRunner(env={"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test"})
+    cli = grzctl.cli.build_cli()
+    submission_id = "123456789_2025-01-01_33333333"
+
+    # Create submission
+    result = runner.invoke(cli, [*args_common, "submission", "add", submission_id])
+    assert result.exit_code == 0
+
+    # Update to error with failure reason
+    result = runner.invoke(
+        cli,
+        [
+            *args_common,
+            "submission",
+            "update",
+            submission_id,
+            "Error",
+            "--failure-reason",
+            "Missing Data",
+        ],  # ← "Missing Data"
+    )
+    assert result.exit_code == 0
+
+    # Show submission details
+    result = runner.invoke(cli, [*args_common, "submission", "show", submission_id])
+    assert result.exit_code == 0
+
+    # List submissions
+    result = runner.invoke(cli, [*args_common, "list", "--json"])
+    assert result.exit_code == 0
+
+
+def test_invalid_failure_reason_cli(blank_database_config_path: Path):
+    """Test CLI rejects invalid failure reasons."""
+    args_common = ["db", "--config-file", blank_database_config_path]
+
+    runner = click.testing.CliRunner(env={"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test"})
+    cli = grzctl.cli.build_cli()  # ← ADD THIS LINE
+
+    # Try invalid failure reason
+    result = runner.invoke(
+        cli,
+        [
+            *args_common,
+            "submission",
+            "update",
+            "123456789_2025-01-01_test111",
+            "Error",
+            "--failure-reason",
+            "Invalid Reason",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Invalid value" in result.output

--- a/packages/grzctl/tests/cli/test_db_sync.py
+++ b/packages/grzctl/tests/cli/test_db_sync.py
@@ -85,7 +85,7 @@ def test_sync_from_inbox(blank_database_config_path, tmp_path):
 
     with open(config_data["db"]["author"]["private_key_path"], "rb") as f:
         pk_bytes = f.read()
-    author = Author(name="alice", private_key_bytes=pk_bytes, private_key_passphrase="")
+    author = Author(name="alice", private_key_bytes=pk_bytes, private_key_passphrase="test")
 
     db = SubmissionDb(db_url=db_config.db.database_url, author=author)
 


### PR DESCRIPTION
This PR addresses the error tracking in the database issue #481 

1. A new FailureReasonEnum (Duplicate TanG, Missing Data, Decryption Error, Network Error) is added and stored as a nullable column on submission_states via an Alembic migration.
2. The failure reason can be set via the --failure-reason option on the grzctl submission update command, and is displayed in both the table and JSON output of grzctl submission show.
3. The ListableEnum mixin is removed, with its list() method folded into CaseInsensitiveStrEnum to simplify the enum hierarchy.
