### PR TITLE
feat(grzctl): Update DbContext for more stringent exception handling

### DIFF
--- a/packages/grzctl/src/grzctl/commands/download.py
+++ b/packages/grzctl/src/grzctl/commands/download.py
@@ -65,6 +65,10 @@ def download(  # noqa: PLR0913
         submission_id=submission_id,
         start_state=SubmissionStateEnum.DOWNLOADING,
         end_state=SubmissionStateEnum.DOWNLOADED,
+        expected_prior_states={
+            None,
+            SubmissionStateEnum.UPLOADED,
+        },
         enabled=update_db,
     ) as db_context:
         worker_inst.download(config.s3, submission_id, force=force)

--- a/packages/grzctl/src/grzctl/commands/download.py
+++ b/packages/grzctl/src/grzctl/commands/download.py
@@ -65,10 +65,6 @@ def download(  # noqa: PLR0913
         submission_id=submission_id,
         start_state=SubmissionStateEnum.DOWNLOADING,
         end_state=SubmissionStateEnum.DOWNLOADED,
-        expected_prior_states={
-            None,
-            SubmissionStateEnum.UPLOADED,
-        },
         enabled=update_db,
     ) as db_context:
         worker_inst.download(config.s3, submission_id, force=force)

--- a/packages/grzctl/src/grzctl/dbcontext.py
+++ b/packages/grzctl/src/grzctl/dbcontext.py
@@ -1,8 +1,9 @@
 import logging
-import traceback
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
+from grz_db.errors import SubmissionNotFoundError
 from grz_db.models.author import Author
 from grz_db.models.submission import SubmissionDb, SubmissionStateEnum
 from pydantic import ValidationError
@@ -15,23 +16,66 @@ log = logging.getLogger(__name__)
 
 class DbContext:
     """
-    Context manager to handle automatic DB state updates for state updates.
+    Context manager that brackets a long-running operation with DB state transitions.
 
-    Usage:
-        with DbContext(config, submission_id, start_state=SubmissionStateEnum.DOWNLOADING, end_state=SubmissionStateEnum.DOWNLOADED) as db:
+    **Lifecycle:**
+
+    1. *Enter*: connects to the DB, validates prerequisites (see below), then
+       transitions the submission to ``start_state``.
+    2. *Body*: the caller performs the actual work.
+    3. *Exit (success)*: transitions the submission to ``end_state``.
+       *Exit (exception)*: transitions the submission to ``ERROR`` and stores
+       ``{"error": "<message>"}`` in the state log; the exception is then re-raised.
+
+    **Prerequisite validation:**
+
+    Before setting ``start_state``, the current state of the submission is compared
+    against ``expected_prior_states``:
+
+    - If the current state **matches** one of the expected prior states, the
+      transition proceeds normally.
+    - If the current state **does not match**, a warning is logged but the
+      transition still proceeds (no hard failure).
+    - If the submission **does not exist** in the DB:
+
+      - and ``None`` is in ``expected_prior_states``: the submission is
+        automatically created and the transition proceeds.
+      - otherwise: ``SubmissionNotFoundError`` is raised immediately.
+
+    Errors raised inside ``__enter__`` (other than ``SubmissionNotFoundError``) are
+    wrapped in ``RuntimeError`` so callers always receive a consistent exception type.
+
+    Example::
+
+        with DbContext(
+            config,
+            submission_id,
+            start_state=SubmissionStateEnum.DOWNLOADING,
+            end_state=SubmissionStateEnum.DOWNLOADED,
+        ):
             do_work_here()
 
-    If an exception occurs within the block, the state is updated to ERROR,
-    and the error message is added in the `data` blob, i.e., `{"error": str(error)}`.
-    If the block finishes successfully, the state is updated to success_state.
+    :param configuration: Nested dictionary that must contain a ``"db"`` key matching
+        the ``DbConfig`` model (database URL, optional author credentials, …).
+    :param submission_id: Submission ID to operate on.
+    :param start_state: State written to the DB when entering the context.
+    :param end_state: State written to the DB when exiting the context successfully.
+    :param expected_prior_states: Iterable of states considered valid preconditions.
+        Pass ``None`` (the default) to derive the expected prior state automatically
+          from the state preceding ``start_state`` in ``SubmissionStateEnum``.
+        Include ``None`` as an *element* to allow the submission to be absent from
+          the DB; it will then be created on the fly.
+    :param enabled: Set to ``False`` to skip all DB interactions (useful when no DB
+        is configured).
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         configuration: dict[str, Any],
         submission_id: str,
         start_state: SubmissionStateEnum,
         end_state: SubmissionStateEnum,
+        expected_prior_states: Iterable[SubmissionStateEnum | None] | None = None,
         enabled: bool = True,
     ):
         self.configuration = configuration
@@ -39,7 +83,24 @@ class DbContext:
         self.start_state = start_state
         self.end_state = end_state
         self.enabled = enabled
+        self._expected_prior_states = set(expected_prior_states) if expected_prior_states else None
         self.db: SubmissionDb | None = None
+
+    @property
+    def expected_prior_states(self) -> set[SubmissionStateEnum | None]:
+        if self._expected_prior_states is None:
+            # determine expected prior state based on order of enums
+            members = list(SubmissionStateEnum)
+            start_index = members.index(self.start_state)
+
+            if start_index == 0:
+                # first state in the enum, no prior state expected
+                return {None}
+            else:
+                # return previous state in the enum as expected prior state
+                return {members[start_index - 1]}
+        else:
+            return self._expected_prior_states
 
     def __enter__(self):
         """Initializes DB connection, checks prerequisites, and sets the initial state."""
@@ -63,19 +124,18 @@ class DbContext:
 
             self.db = get_submission_db_instance(db_config.database_url, author=author)
 
-            if self.db:
-                self._check_prerequisites()
+            # Check if the state transition is valid.
+            self._check_prerequisites()
 
-                log.debug(f"Updating submission {self.submission_id} state to {self.start_state.name}")
-                self.db.update_submission_state(self.submission_id, self.start_state)
+            log.debug(f"Updating submission {self.submission_id} state to {self.start_state.name}")
+            self.db.update_submission_state(self.submission_id, self.start_state)
 
+        except SubmissionNotFoundError:
+            raise
         except (ValidationError, KeyError) as e:
-            log.warning(f"DB Configuration invalid or missing. State updates skipped. ({e})")
-            self.db = None
+            raise RuntimeError("DB Configuration invalid or missing") from e
         except Exception as e:
-            log.error(f"Failed to connect to DB: {e}. State updates skipped.")
-            log.error(traceback.format_exc())
-            self.db = None
+            raise RuntimeError("Failed to connect to DB") from e
 
         return self
 
@@ -108,38 +168,28 @@ class DbContext:
         """
         Checks if the state transition is valid.
         """
-        if not self.db:
-            return
-
-        # determine expected prior state
-        members = list(SubmissionStateEnum)
-        start_index = members.index(self.start_state)
-        if start_index == 0:
-            # first state in the enum, no prior state expected
-            return
-
-        expected_prior_state = members[start_index - 1]
-        expected_prior_state = str(expected_prior_state).casefold()
-
         submission = self.db.get_submission(self.submission_id)
-        if not submission:
-            return
+        if submission is None:
+            if None in self.expected_prior_states:
+                # submission missing in DB is expected; add submission to DB
+                submission = self.db.add_submission(self.submission_id)
+            else:
+                raise SubmissionNotFoundError(self.submission_id)
 
         latest_state_log = submission.get_latest_state()
         current_state = latest_state_log.state if latest_state_log else None
-        current_state = str(current_state).casefold() if current_state else None
 
-        if current_state != expected_prior_state:
+        if current_state not in self.expected_prior_states:
             log.warning(
                 f"Submission {self.submission_id} is currently in state '{current_state}'. "
-                f"Expected '{expected_prior_state}' before updating to '{self.start_state.name}'."
+                f"Expected any of '{self._expected_prior_states}' before updating to '{self.start_state.name}'."
             )
 
         history = submission.states
-        found_in_history = any(str(entry.state).casefold() == expected_prior_state for entry in history)
+        found_in_history = any(entry.state in self.expected_prior_states for entry in history)
 
         if not found_in_history:
             log.warning(
                 f"Submission {self.submission_id} is being updated to '{self.start_state.name}' "
-                f"but state history does not contain '{expected_prior_state}'."
+                f"but state history does not contain any of '{self.expected_prior_states}'."
             )

--- a/packages/grzctl/src/grzctl/dbcontext.py
+++ b/packages/grzctl/src/grzctl/dbcontext.py
@@ -1,5 +1,4 @@
 import logging
-from collections.abc import Iterable
 from functools import cached_property
 from pathlib import Path
 from typing import Any
@@ -65,7 +64,7 @@ class DbContext:
         is configured).
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         configuration: dict[str, Any],
         submission_id: str,

--- a/packages/grzctl/src/grzctl/dbcontext.py
+++ b/packages/grzctl/src/grzctl/dbcontext.py
@@ -61,11 +61,6 @@ class DbContext:
     :param submission_id: Submission ID to operate on.
     :param start_state: State written to the DB when entering the context.
     :param end_state: State written to the DB when exiting the context successfully.
-    :param expected_prior_states: Iterable of states considered valid preconditions.
-        Pass ``None`` (the default) to derive the expected prior state automatically
-          from the state preceding ``start_state`` in ``SubmissionStateEnum``.
-        Include ``None`` as an *element* to allow the submission to be absent from
-          the DB; it will then be created on the fly.
     :param enabled: Set to ``False`` to skip all DB interactions (useful when no DB
         is configured).
     """
@@ -76,7 +71,6 @@ class DbContext:
         submission_id: str,
         start_state: SubmissionStateEnum,
         end_state: SubmissionStateEnum,
-        expected_prior_states: Iterable[SubmissionStateEnum | None] | None = None,
         enabled: bool = True,
     ):
         self.configuration = configuration
@@ -84,24 +78,20 @@ class DbContext:
         self.start_state = start_state
         self.end_state = end_state
         self.enabled = enabled
-        self._expected_prior_states = set(expected_prior_states) if expected_prior_states else None
         self.db: SubmissionDb | None = None
 
-    @property
+    @cached_property
     def expected_prior_states(self) -> set[SubmissionStateEnum | None]:
-        if self._expected_prior_states is None:
-            # determine expected prior state based on order of enums
-            members = list(SubmissionStateEnum)
-            start_index = members.index(self.start_state)
+        # determine expected prior state based on order of enums
+        members = list(SubmissionStateEnum)
+        start_index = members.index(self.start_state)
 
-            if start_index == 0:
-                # first state in the enum, no prior state expected
-                return {None}
-            else:
-                # return previous state in the enum as expected prior state
-                return {members[start_index - 1]}
+        if start_index == 0:
+            # first state in the enum, no prior state expected
+            return {None}
         else:
-            return self._expected_prior_states
+            # return previous state in the enum as expected prior state
+            return {members[start_index - 1]}
 
     def __enter__(self):
         """Initializes DB connection, checks prerequisites, and sets the initial state."""
@@ -191,7 +181,7 @@ class DbContext:
         if current_state not in self.expected_prior_states:
             log.warning(
                 f"Submission {self.submission_id} is currently in state '{current_state}'. "
-                f"Expected any of '{self._expected_prior_states}' before updating to '{self.start_state.name}'."
+                f"Expected any of '{self.expected_prior_states}' before updating to '{self.start_state.name}'."
             )
 
         history = submission.states

--- a/packages/grzctl/src/grzctl/dbcontext.py
+++ b/packages/grzctl/src/grzctl/dbcontext.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Iterable
+from functools import cached_property
 from pathlib import Path
 from typing import Any
 
@@ -110,19 +111,7 @@ class DbContext:
         try:
             db_config = DbConfig.model_validate(self.configuration).db
 
-            author = None
-            if db_config.author:
-                key_path = Path(db_config.author.private_key_path)
-                if not key_path.exists():
-                    raise FileNotFoundError(f"Author private key not found at: {key_path}")
-
-                author = Author(
-                    name=db_config.author.name,
-                    private_key_bytes=key_path.read_bytes(),
-                    private_key_passphrase=db_config.author.private_key_passphrase,
-                )
-
-            self.db = get_submission_db_instance(db_config.database_url, author=author)
+            self.db = get_submission_db_instance(db_config.database_url, author=self.author)
 
             # Check if the state transition is valid.
             self._check_prerequisites()
@@ -163,6 +152,26 @@ class DbContext:
                 log.error(f"Failed to write success state to DB: {db_exc}")
 
         return True
+
+    @cached_property
+    def author(self) -> Author:
+        db_config = DbConfig.model_validate(self.configuration).db
+
+        if not db_config.author:
+            raise ValueError("Author configuration is missing")
+
+        if db_config.author.private_key_path is None:
+            raise ValueError("Author private key path is required but was None")
+
+        key_path = Path(db_config.author.private_key_path)
+        if not key_path.exists():
+            raise FileNotFoundError(f"Author private key not found at: {key_path}")
+
+        return Author(
+            name=db_config.author.name,
+            private_key_bytes=key_path.read_bytes(),
+            private_key_passphrase=db_config.author.private_key_passphrase,
+        )
 
     def _check_prerequisites(self):
         """

--- a/tests/cli/test_archive.py
+++ b/tests/cli/test_archive.py
@@ -38,6 +38,7 @@ def test_archive(temp_s3_config_file_path, remote_bucket_with_version, working_d
             temp_s3_config_file_path,
             "--submission-dir",
             str(working_dir_path),
+            "--no-update-db",
         ]
 
         runner = click.testing.CliRunner(

--- a/tests/cli/test_clean.py
+++ b/tests/cli/test_clean.py
@@ -67,6 +67,7 @@ def test_clean_and_list(temp_s3_config_file_path, remote_bucket_with_version, wo
             "--config-file",
             temp_s3_config_file_path,
             "--yes-i-really-mean-it",
+            "--no-update-db",
         ]
 
         result_clean = runner.invoke(cli, clean_args, catch_exceptions=False)

--- a/tests/cli/test_crypt.py
+++ b/tests/cli/test_crypt.py
@@ -88,6 +88,7 @@ def test_decrypt_submission(working_dir_path, temp_keys_config_file_path):
         str(working_dir_path),
         "--config-file",
         temp_keys_config_file_path,
+        "--no-update-db",
     ]
     runner = CliRunner()
     cli = grzctl.cli.build_cli()
@@ -148,6 +149,7 @@ def test_encrypt_decrypt_submission(
         str(working_dir_path),
         "--config-file",
         temp_keys_config_file_path,
+        "--no-update-db",
     ]
 
     runner = CliRunner()

--- a/tests/cli/test_db_context.py
+++ b/tests/cli/test_db_context.py
@@ -1,3 +1,4 @@
+import contextlib
 import shutil
 from unittest.mock import MagicMock, patch
 
@@ -5,6 +6,7 @@ import click.testing
 import pytest
 import sqlalchemy
 import yaml
+from grz_db.errors import SubmissionNotFoundError
 from grz_db.models.submission import Submission, SubmissionStateEnum
 from grzctl.cli import build_cli
 from grzctl.models.config import DbConfig
@@ -98,16 +100,79 @@ def get_state_history(engine, submission_id) -> list[SubmissionStateEnum]:
         return [log.state for log in sorted(submission.states, key=lambda x: x.id)]
 
 
+@contextlib.contextmanager
+def mock_command(command_spec, submission_id):
+    """
+    Patch the Worker class and/or extra callable described by *command_spec*, then yield
+    ``(mock_worker_instance, mock_extra)`` so callers can make assertions on them.
+
+    Uses ExitStack so every patch is registered individually and all are torn down
+    automatically when the ``with`` block exits, regardless of exceptions.
+    """
+    with contextlib.ExitStack() as stack:
+        mock_worker = None
+        mock_extra = None
+
+        if "worker_patch" in command_spec:
+            # Patch the Worker *class* so that Worker(...) returns our mock instance.
+            mock_worker_cls = stack.enter_context(patch(command_spec["worker_patch"]))
+            mock_worker = mock_worker_cls.return_value
+
+            # Whichever parse_* method the command calls must return a submission
+            # whose ID matches the one we put in the DB.
+            mock_submission = MagicMock()
+            mock_submission.metadata.content.submission_id = submission_id
+            mock_submission.submission_id = submission_id
+
+            if command_spec["id_source"] == "submission":
+                mock_worker.parse_submission.return_value = mock_submission
+            elif command_spec["id_source"] == "encrypted_submission":
+                mock_worker.parse_encrypted_submission.return_value = mock_submission
+
+        if "extra_patch" in command_spec:
+            # Some commands invoke a standalone callable (e.g. validate.callback,
+            # _clean_submission_from_bucket) instead of a Worker method.
+            mock_extra = stack.enter_context(patch(command_spec["extra_patch"]))
+
+        yield mock_worker, mock_extra
+
+
+def build_args(
+    command_spec,
+    submission_dir=None,
+    output_dir=None,
+    submission_id=None,
+    config_path=None,
+    extra_flags=(),
+):
+    """Translate a command_spec cmd list (with placeholders) into a concrete argv list."""
+    args = []
+    for arg in command_spec["cmd"]:
+        if arg == "SUBMISSION_DIR":
+            args.append(str(submission_dir))
+        elif arg == "OUTPUT_DIR":
+            args.append(str(output_dir))
+        elif arg == "SUBMISSION_ID":
+            args.append(submission_id)
+        else:
+            args.append(arg)
+    if config_path:
+        args.extend(["--config-file", str(config_path)])
+    args.extend(extra_flags)
+    return args
+
+
 @pytest.mark.parametrize(
     "command_spec",
     [
         {
-            "cmd": ["archive", "--submission-dir", "SUBMISSION_DIR"],
-            "worker_patch": "grzctl.commands.archive.Worker",
-            "id_source": "encrypted_submission",
-            "initial_state": SubmissionStateEnum.ENCRYPTED,
-            "intermediate_state": SubmissionStateEnum.ARCHIVING,
-            "expected_state": SubmissionStateEnum.ARCHIVED,
+            "cmd": ["download", "--submission-id", "SUBMISSION_ID", "--output-dir", "OUTPUT_DIR"],
+            "worker_patch": "grzctl.commands.download.Worker",
+            "id_source": "arg",
+            "initial_state": None,
+            "intermediate_state": SubmissionStateEnum.DOWNLOADING,
+            "expected_state": SubmissionStateEnum.DOWNLOADED,
+            "skip_populate": True,
         },
         {
             "cmd": ["download", "--submission-id", "SUBMISSION_ID", "--output-dir", "OUTPUT_DIR"],
@@ -145,6 +210,14 @@ def get_state_history(engine, submission_id) -> list[SubmissionStateEnum]:
             "expected_state": SubmissionStateEnum.ENCRYPTED,
         },
         {
+            "cmd": ["archive", "--submission-dir", "SUBMISSION_DIR"],
+            "worker_patch": "grzctl.commands.archive.Worker",
+            "id_source": "encrypted_submission",
+            "initial_state": SubmissionStateEnum.ENCRYPTED,
+            "intermediate_state": SubmissionStateEnum.ARCHIVING,
+            "expected_state": SubmissionStateEnum.ARCHIVED,
+        },
+        {
             "cmd": ["clean", "--submission-id", "SUBMISSION_ID", "--yes-i-really-mean-it"],
             "extra_patch": "grzctl.commands.clean._clean_submission_from_bucket",
             "id_source": "arg",
@@ -155,7 +228,7 @@ def get_state_history(engine, submission_id) -> list[SubmissionStateEnum]:
         },
     ],
 )
-def test_db_wrappers(  # noqa: C901
+def test_db_wrappers(
     command_spec,
     db_engine,
     full_config_path,
@@ -186,43 +259,16 @@ def test_db_wrappers(  # noqa: C901
         initial_state=command_spec["initial_state"],
     )
 
-    args = []
-    for arg in command_spec["cmd"]:
-        if arg == "SUBMISSION_DIR":
-            args.append(str(submission_dir))
-        elif arg == "OUTPUT_DIR":
-            args.append(str(output_dir))
-        elif arg == "SUBMISSION_ID":
-            args.append(submission_id)
-        else:
-            args.append(arg)
+    args = build_args(
+        command_spec,
+        submission_dir=submission_dir,
+        output_dir=output_dir,
+        submission_id=submission_id,
+        config_path=full_config_path,
+        extra_flags=["--update-db"],
+    )
 
-    args.extend(["--config-file", str(full_config_path), "--update-db"])
-
-    worker_patcher = None
-    extra_patcher = None
-    mock_worker = None
-    mock_extra = None
-
-    try:
-        if "worker_patch" in command_spec:
-            worker_patcher = patch(command_spec["worker_patch"])
-            mock_worker_cls = worker_patcher.start()
-            mock_worker = mock_worker_cls.return_value
-
-            mock_submission = MagicMock()
-            mock_submission.metadata.content.submission_id = submission_id
-            mock_submission.submission_id = submission_id
-
-            if command_spec["id_source"] == "submission":
-                mock_worker.parse_submission.return_value = mock_submission
-            elif command_spec["id_source"] == "encrypted_submission":
-                mock_worker.parse_encrypted_submission.return_value = mock_submission
-
-        if "extra_patch" in command_spec:
-            extra_patcher = patch(command_spec["extra_patch"])
-            mock_extra = extra_patcher.start()
-
+    with mock_command(command_spec, submission_id) as (mock_worker, mock_extra):
         result = runner.invoke(cli, args)
 
         assert result.exit_code == 0, f"Command failed: {result.output}"
@@ -240,11 +286,176 @@ def test_db_wrappers(  # noqa: C901
         if command_spec["initial_state"]:
             assert history[-3] == command_spec["initial_state"]
 
-    finally:
-        if extra_patcher:
-            extra_patcher.stop()
-        if worker_patcher:
-            worker_patcher.stop()
+
+@pytest.mark.parametrize(
+    "command_spec",
+    [
+        {
+            "cmd": ["decrypt", "--submission-dir", "SUBMISSION_DIR"],
+            "worker_patch": "grzctl.commands.decrypt.Worker",
+            "id_source": "encrypted_submission",
+        },
+        {
+            "cmd": ["validate", "--submission-dir", "SUBMISSION_DIR"],
+            "worker_patch": "grzctl.commands.validate.Worker",
+            "extra_patch": "grzctl.commands.validate.validate_module.validate.callback",
+            "id_source": "submission",
+        },
+        {
+            "cmd": ["encrypt", "--submission-dir", "SUBMISSION_DIR"],
+            "worker_patch": "grzctl.commands.encrypt.Worker",
+            "extra_patch": "grzctl.commands.encrypt.encrypt_module.encrypt.callback",
+            "id_source": "submission",
+        },
+        {
+            "cmd": ["archive", "--submission-dir", "SUBMISSION_DIR"],
+            "worker_patch": "grzctl.commands.archive.Worker",
+            "id_source": "encrypted_submission",
+        },
+        {
+            "cmd": ["clean", "--submission-id", "SUBMISSION_ID", "--yes-i-really-mean-it"],
+            "extra_patch": "grzctl.commands.clean._clean_submission_from_bucket",
+            "id_source": "arg",
+        },
+    ],
+)
+def test_db_wrappers_submission_not_in_db(
+    command_spec,
+    db_engine,
+    full_config_path,
+    test_metadata,
+    tmp_path,
+):
+    """Test that commands fail with SubmissionNotFoundError when the submission has not been added to the DB yet."""
+    runner = click.testing.CliRunner()
+    cli = build_cli()
+
+    parsed_metadata, _ = test_metadata
+    submission_id = parsed_metadata.submission_id
+
+    submission_dir = tmp_path / "submission"
+    submission_dir.mkdir()
+    for d in ["metadata", "files", "logs", "encrypted_files"]:
+        (submission_dir / d).mkdir()
+    output_dir = tmp_path / "output"
+
+    # Deliberately skip adding the submission to the DB
+
+    args = build_args(
+        command_spec,
+        submission_dir=submission_dir,
+        output_dir=output_dir,
+        submission_id=submission_id,
+        config_path=full_config_path,
+        extra_flags=["--update-db"],
+    )
+
+    with mock_command(command_spec, submission_id):
+        result = runner.invoke(cli, args)
+
+        assert result.exit_code != 0, (
+            f"Expected command '{command_spec['cmd'][0]}' to fail when submission is not in DB, "
+            f"but it succeeded. Output: {result.output}"
+        )
+        assert isinstance(result.exception, SubmissionNotFoundError), (
+            f"Expected SubmissionNotFoundError, got {type(result.exception)}: {result.exception}"
+        )
+
+
+@pytest.mark.parametrize(
+    "command_spec",
+    [
+        {
+            "cmd": ["decrypt", "--submission-dir", "SUBMISSION_DIR"],
+            "worker_patch": "grzctl.commands.decrypt.Worker",
+            "id_source": "encrypted_submission",
+            "wrong_state": SubmissionStateEnum.ENCRYPTED,  # expected: DOWNLOADED
+            "intermediate_state": SubmissionStateEnum.DECRYPTING,
+            "expected_state": SubmissionStateEnum.DECRYPTED,
+        },
+        {
+            "cmd": ["validate", "--submission-dir", "SUBMISSION_DIR"],
+            "worker_patch": "grzctl.commands.validate.Worker",
+            "extra_patch": "grzctl.commands.validate.validate_module.validate.callback",
+            "id_source": "submission",
+            "wrong_state": SubmissionStateEnum.ENCRYPTED,  # expected: DECRYPTED
+            "intermediate_state": SubmissionStateEnum.VALIDATING,
+            "expected_state": SubmissionStateEnum.VALIDATED,
+        },
+        {
+            "cmd": ["encrypt", "--submission-dir", "SUBMISSION_DIR"],
+            "worker_patch": "grzctl.commands.encrypt.Worker",
+            "extra_patch": "grzctl.commands.encrypt.encrypt_module.encrypt.callback",
+            "id_source": "submission",
+            "wrong_state": SubmissionStateEnum.DOWNLOADED,  # expected: VALIDATED
+            "intermediate_state": SubmissionStateEnum.ENCRYPTING,
+            "expected_state": SubmissionStateEnum.ENCRYPTED,
+        },
+        {
+            "cmd": ["archive", "--submission-dir", "SUBMISSION_DIR"],
+            "worker_patch": "grzctl.commands.archive.Worker",
+            "id_source": "encrypted_submission",
+            "wrong_state": SubmissionStateEnum.DOWNLOADED,  # expected: ENCRYPTED
+            "intermediate_state": SubmissionStateEnum.ARCHIVING,
+            "expected_state": SubmissionStateEnum.ARCHIVED,
+        },
+    ],
+)
+def test_db_wrappers_wrong_initial_state(
+    command_spec,
+    db_engine,
+    full_config_path,
+    test_metadata,
+    tmp_path,
+):
+    """
+    Test that commands still run (with a warning) when the submission is in an unexpected state.
+    The DbContext only logs a warning for mismatched states and does not block execution.
+    The state transition (intermediate → expected) should still be recorded.
+    """
+    runner = click.testing.CliRunner()
+    cli = build_cli()
+
+    parsed_metadata, metadata_path_fixture = test_metadata
+    submission_id = parsed_metadata.submission_id
+
+    submission_dir = tmp_path / "submission"
+    submission_dir.mkdir()
+    for d in ["metadata", "files", "logs", "encrypted_files"]:
+        (submission_dir / d).mkdir()
+    shutil.copy(metadata_path_fixture, submission_dir / "metadata" / "metadata.json")
+
+    # Add submission with a wrong/unexpected initial state
+    setup_db_state(
+        runner,
+        cli,
+        full_config_path,
+        submission_id,
+        metadata_path_fixture,
+        initial_state=command_spec["wrong_state"],
+    )
+
+    args = build_args(
+        command_spec,
+        submission_dir=submission_dir,
+        submission_id=submission_id,
+        config_path=full_config_path,
+        extra_flags=["--update-db"],
+    )
+
+    with mock_command(command_spec, submission_id):
+        result = runner.invoke(cli, args)
+
+        # The command should still succeed — wrong state is only a warning, not a hard failure
+        assert result.exit_code == 0, (
+            f"Command '{command_spec['cmd'][0]}' unexpectedly failed with wrong initial state. Output: {result.output}"
+        )
+
+        history = get_state_history(db_engine, submission_id)
+        assert history[-1] == command_spec["expected_state"], f"Unexpected final state: {history}"
+        assert history[-2] == command_spec["intermediate_state"], f"Unexpected intermediate state: {history}"
+        # The wrong state should be present earlier in history
+        assert command_spec["wrong_state"] in history, f"Wrong state not found in history: {history}"
 
 
 def test_pruefbericht_wrapper(db_engine, full_config_path, test_metadata, tmp_path):

--- a/tests/cli/test_pruefbericht.py
+++ b/tests/cli/test_pruefbericht.py
@@ -131,6 +131,7 @@ def test_valid_submission(bfarm_auth_api, bfarm_submit_api, temp_pruefbericht_co
             temp_pruefbericht_config_file_path,
             "--pruefbericht-file",
             str(pruefbericht_json_path),
+            "--no-update-db",
         ]
         submit_result = runner.invoke(cli, submit_args, catch_exceptions=False)
 
@@ -169,6 +170,7 @@ def test_valid_submission_with_token(bfarm_submit_api, temp_pruefbericht_config_
             str(pruefbericht_json_path),
             "--token",
             "my_token",
+            "--no-update-db",
         ]
         submit_result = runner.invoke(cli, submit_args, catch_exceptions=False)
 
@@ -209,6 +211,7 @@ def test_valid_submission_with_expired_token(
             str(pruefbericht_json_path),
             "--token",
             "expired_token",
+            "--no-update-db",
         ]
         submit_result = runner.invoke(cli, submit_args, catch_exceptions=False)
 

--- a/tests/cli/test_upload.py
+++ b/tests/cli/test_upload.py
@@ -122,6 +122,7 @@ def test_upload_download_submission(
             str(download_dir_path),
             "--config-file",
             str(temp_s3_db_config_file_path),
+            "--no-update-db",
             "--populate",
         ]
         result = runner.invoke(cli, download_args, catch_exceptions=False)


### PR DESCRIPTION
This PR changes the behavior of the DbContext.
- DbContext will now raise exceptions on database connection errors instead of continuing with a warning
- DbContext accepts an explicit sequence of `expected_prior_states` that should be excepted without a warning.
- `grzctl download` will now accept when the submission ID is missing from the database and simply create an entry

Question:
Should we raise an exception if the prior state(s) do not match the expected states?