### PR TITLE
ci(repo): fix tox/pytest execution args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
         run: which grz-check && grz-check --version
 
       - name: Test ${{ matrix.python-version }}
-        run: uv run tox -e ${{ matrix.python-version }}
+        run: uv run tox -e ${{ matrix.python-version }} -- tests/
 
   test-changed-packages-python:
     name: Test Changed Python Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,4 +335,4 @@ jobs:
         run: cd ${{ matrix.package.path }} && uv lock --check
 
       - name: Run tests for ${{ steps.pkg_info.outputs.name }}
-        run: cd ${{ matrix.package.path }} && uv run tox -e py${{ matrix.python-version }}
+        run: uv run tox -e py${{ matrix.python-version }} -- ${{ matrix.package.path }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,14 +32,6 @@ uv sync --all-packages --all-groups --all-extras
 To run integration tests for all packages in this monorepo, run the following from the repository root:
 
 ```bash
-for d in packages/*; do
-   if [ -f "$d/pyproject.toml" ]; then
-      printf '\n\033[1;97;44m  RUNNING TESTS: %s  \033[0m\n\n' "$d"
-      (cd "$d" && uv run tox)
-   fi
-done
-
-printf '\n\033[1;97;44m  RUNNING GLOBAL TESTS  \033[0m\n\n'
 uv run tox
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,7 @@ isolated_build = true
 runner = "uv-venv-lock-runner"
 description = "run unit tests"
 dependency_groups = ["test"]
-commands = [["pytest", { replace = "posargs", default = ["tests"], extend = true }]]
+commands = [["pytest", { replace = "posargs", default = [], extend = true }]]
 # isolate Cargo build directories per tox environment, otherwise Cargo caches the compiled Rust extension (and then we end up with mismatches between ABI versions).
 setenv = { UV_REINSTALL_PACKAGE = "grz-check", CARGO_TARGET_DIR = "{work_dir}/cargo_target_{env_name}" }
 


### PR DESCRIPTION
Seems like only top level tests were executed in CI.
An alternative would be to remove the default "tests" in the root pyproject.toml tox config from
```
commands = [["pytest", { replace = "posargs", default = ["tests"], extend = true }]]
```
to
```
commands = [["pytest", { replace = "posargs", default = [], extend = true }]]
```
but then that would do pytest auto discovery, which triggers testing _everything_ all the time.