### PR TITLE
fix(grz-pydantic-models,grz-cli,grz-common): adapt to 01.06.2026 changes

### DIFF
--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -1280,7 +1280,7 @@ class GrzSubmissionMetadata(StrictBaseModel):
                 for lab_datum in donor.lab_data:
                     if lab_datum.library_type not in allowed_library_types:
                         message = f"Using libraryType {lab_datum.library_type} for diseaseType {DiseaseType.rare} is no longer allowed starting 01.06.2026"
-                        if self.submission.submission_date > date(2026, 6, 1):
+                        if self.submission.submission_date >= date(2026, 6, 1):
                             raise ValueError(message)
                         else:
                             log.warning(message)

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -307,6 +307,21 @@ class ResearchConsent(StrictBaseModel):
     no_scope_justification: ResearchConsentNoScopeJustification | None = None
 
     @model_validator(mode="after")
+    def ensure_no_scope_justification_is_not_technical_or_organizational(self):
+        today = date.today()
+        relevant_date = max(self.presentation_date or today, today)
+        if self.no_scope_justification in {
+            ResearchConsentNoScopeJustification.LE_TECH,
+            ResearchConsentNoScopeJustification.LE_ORG,
+        }:
+            message = f"Setting noScopeJustification to {self.no_scope_justification} is no longer allowed starting 01.06.2026."
+            if relevant_date >= date(2026, 6, 1):
+                raise ValueError(message)
+            else:
+                log.warning(message)
+        return self
+
+    @model_validator(mode="after")
     def ensure_scope_xor_justification(self):
         if (self.scope is None) != (self.no_scope_justification is None):
             return self

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -1281,6 +1281,29 @@ class GrzSubmissionMetadata(StrictBaseModel):
             return self
 
     @model_validator(mode="after")
+    def ensure_disease_type_rare_has_matching_library_types(self):
+        allowed_library_types: set[LibraryType] = {
+            LibraryType.wgs,
+            LibraryType.wgs_lr,
+            LibraryType.wxs,
+            LibraryType.wxs_lr,
+            LibraryType.other,
+            LibraryType.unknown,
+        }
+        today = date.today()
+        relevant_date = max(self.submission.submission_date, today)
+        if self.submission.disease_type == DiseaseType.rare:
+            for donor in self.donors:
+                for lab_datum in donor.lab_data:
+                    if lab_datum.library_type not in allowed_library_types:
+                        message = f"Using libraryType {lab_datum.library_type} for diseaseType {DiseaseType.rare} is no longer allowed starting 01.06.2026"
+                        if relevant_date > date(2026, 6, 1):
+                            raise ValueError(message)
+                        else:
+                            log.warning(message)
+        return self
+
+    @model_validator(mode="after")
     def check_for_tumor_cell_count(self):
         """
         Check if oncology samples have tumor cell counts.

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -1267,23 +1267,20 @@ class GrzSubmissionMetadata(StrictBaseModel):
 
     @model_validator(mode="after")
     def ensure_disease_type_rare_has_matching_library_types(self):
-        allowed_library_types: set[LibraryType] = {
-            LibraryType.wgs,
-            LibraryType.wgs_lr,
-            LibraryType.wxs,
-            LibraryType.wxs_lr,
-            LibraryType.other,
-            LibraryType.unknown,
-        }
         if self.submission.disease_type == DiseaseType.rare:
-            for donor in self.donors:
-                for lab_datum in donor.lab_data:
-                    if lab_datum.library_type not in allowed_library_types:
-                        message = f"Using libraryType {lab_datum.library_type} for diseaseType {DiseaseType.rare} is no longer allowed starting 01.06.2026"
-                        if self.submission.submission_date >= date(2026, 6, 1):
-                            raise ValueError(message)
-                        else:
-                            log.warning(message)
+            mandatory_index_types: set[LibraryType] = {LibraryType.wgs, LibraryType.wgs_lr}
+            index_library_types = {datum.library_type for datum in self.index_donor.lab_data}
+
+            if not (index_library_types & mandatory_index_types):
+                message = (
+                    f"For diseaseType '{DiseaseType.rare}', the index donor must have at least one lab datum with "
+                    f"libraryType 'wgs' or 'wgs_lr', starting 01.06.2026."
+                )
+                if self.submission.submission_date >= date(2026, 6, 1):
+                    raise ValueError(message)
+                else:
+                    log.warning(message)
+
         return self
 
     @model_validator(mode="after")

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -307,21 +307,6 @@ class ResearchConsent(StrictBaseModel):
     no_scope_justification: ResearchConsentNoScopeJustification | None = None
 
     @model_validator(mode="after")
-    def ensure_no_scope_justification_is_not_technical_or_organizational(self):
-        today = date.today()
-        relevant_date = max(self.presentation_date or today, today)
-        if self.no_scope_justification in {
-            ResearchConsentNoScopeJustification.LE_TECH,
-            ResearchConsentNoScopeJustification.LE_ORG,
-        }:
-            message = f"Setting noScopeJustification to {self.no_scope_justification} is no longer allowed starting 01.06.2026."
-            if relevant_date >= date(2026, 6, 1):
-                raise ValueError(message)
-            else:
-                log.warning(message)
-        return self
-
-    @model_validator(mode="after")
     def ensure_scope_xor_justification(self):
         if (self.scope is None) != (self.no_scope_justification is None):
             return self
@@ -1290,14 +1275,12 @@ class GrzSubmissionMetadata(StrictBaseModel):
             LibraryType.other,
             LibraryType.unknown,
         }
-        today = date.today()
-        relevant_date = max(self.submission.submission_date, today)
         if self.submission.disease_type == DiseaseType.rare:
             for donor in self.donors:
                 for lab_datum in donor.lab_data:
                     if lab_datum.library_type not in allowed_library_types:
                         message = f"Using libraryType {lab_datum.library_type} for diseaseType {DiseaseType.rare} is no longer allowed starting 01.06.2026"
-                        if relevant_date > date(2026, 6, 1):
+                        if self.submission.submission_date > date(2026, 6, 1):
                             raise ValueError(message)
                         else:
                             log.warning(message)
@@ -1489,6 +1472,21 @@ class GrzSubmissionMetadata(StrictBaseModel):
                 f"Reference genomes: {reference_genomes}"
             )
 
+        return self
+
+    @model_validator(mode="after")
+    def ensure_no_scope_justification_is_not_technical_or_organizational(self):
+        for donor in self.donors:
+            for consent in donor.research_consents:
+                if consent.no_scope_justification in {
+                    ResearchConsentNoScopeJustification.LE_TECH,
+                    ResearchConsentNoScopeJustification.LE_ORG,
+                }:
+                    message = f"Setting noScopeJustification to {consent.no_scope_justification} is no longer allowed starting 01.06.2026."
+                    if self.submission.submission_date >= date(2026, 6, 1):
+                        raise ValueError(message)
+                    else:
+                        log.warning(message)
         return self
 
 

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -12,7 +12,13 @@ from grz_pydantic_models.submission.metadata import (
     DiseaseType,
     ResearchConsentNoScopeJustification,
 )
-from grz_pydantic_models.submission.metadata.v1 import File, FileType, GrzSubmissionMetadata, ResearchConsent
+from grz_pydantic_models.submission.metadata.v1 import (
+    File,
+    FileType,
+    GrzSubmissionMetadata,
+    LibraryType,
+    ResearchConsent,
+)
 from grz_pydantic_models_testing import example_metadata, example_research_consent
 from packaging.version import Version
 from pydantic import ValidationError
@@ -404,29 +410,26 @@ def test_research_consent_no_subprovisions():
         TESTED_VERSIONS,
     ),
 )
-def test_disease_type_rare_invalid_library_raises(dataset: str, version: str):
-    """These datasets natively use panel or wes. If diseaseType is rare, they must fail on/after 01.06.2026."""
+def test_disease_type_rare_missing_wgs_raises(dataset: str, version: str):
+    """
+    These datasets natively use panel or wes. For rare diseases, they fail the wgs check.
+    """
     metadata = json.loads(importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text())
     metadata["submission"]["diseaseType"] = DiseaseType.rare.value
     metadata["submission"]["submissionDate"] = "2026-06-01"
 
-    with pytest.raises(ValidationError, match=r"is no longer allowed starting 01\.06\.2026"):
+    with pytest.raises(
+        ValidationError, match=r"the index donor must have at least one lab datum with libraryType 'wgs' or 'wgs_lr'"
+    ):
         GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
 
 @pytest.mark.parametrize(
     "dataset,version",
-    itertools.product(
-        [
-            "oncomine_panel_tumor_only",
-            "panel_tumor_only",
-            "wes_tumor_germline",
-        ],
-        TESTED_VERSIONS,
-    ),
+    itertools.product(["wes_tumor_germline"], TESTED_VERSIONS),
 )
-def test_disease_type_rare_invalid_library_warns(dataset: str, version: str, caplog):
-    """These datasets natively use panel or wes. If diseaseType is rare, they warn before 01.06.2026."""
+def test_disease_type_rare_missing_wgs_warns_before_cutoff(dataset: str, version: str, caplog):
+    """Before the cutoff, missing wgs for a rare disease should only log a warning."""
     metadata = json.loads(importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text())
     metadata["submission"]["diseaseType"] = DiseaseType.rare.value
     metadata["submission"]["submissionDate"] = "2026-05-31"
@@ -434,11 +437,44 @@ def test_disease_type_rare_invalid_library_warns(dataset: str, version: str, cap
     try:
         GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
     except ValidationError as e:
-        # If mutating diseaseType triggers an unrelated structural error in the mock,
-        # we just ensure our target date error isn't the one blocking it.
-        assert "is no longer allowed starting 01.06.2026" not in str(e)
+        assert "starting 01.06.2026" not in str(e)
 
-    assert "is no longer allowed starting 01.06.2026" in caplog.text
+    assert "starting 01.06.2026" in caplog.text
+
+
+@pytest.mark.parametrize("version", TESTED_VERSIONS)
+def test_disease_type_rare_index_has_wgs_and_panel_passes(version: str):
+    """
+    If the index donor has at least WGS but additionally some panel data, it should still pass.
+    """
+    metadata = json.loads(
+        importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
+    )
+    metadata["submission"]["diseaseType"] = DiseaseType.rare.value
+    metadata["submission"]["submissionDate"] = "2026-06-01"
+
+    # duplicate the WGS lab datum but change its type to panel
+    panel_datum = copy.deepcopy(metadata["donors"][0]["labData"][0])
+    panel_datum["libraryType"] = LibraryType.panel.value
+    panel_datum["labDataName"] += "_panel"
+
+    # panels require a BED file
+    panel_datum["sequenceData"]["files"].append(
+        {"filePath": "dummy_panel_target.bed", "fileType": "bed", "fileChecksum": "c" * 64, "fileSizeInBytes": 1000}
+    )
+
+    # change file paths/checksums so it doesn't fail unique run/checksum validators
+    for i, file in enumerate(panel_datum["sequenceData"]["files"]):
+        file["fileChecksum"] = f"c{i:063d}"
+        if file["fileType"] == "fastq":
+            file["filePath"] = f"panel_{i}.fastq.gz"
+
+    metadata["donors"][0]["labData"].append(panel_datum)
+
+    try:
+        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+    except ValidationError as e:
+        assert "starting 01.06.2026" not in str(e)
 
 
 @pytest.mark.parametrize(
@@ -453,7 +489,7 @@ def test_disease_type_rare_invalid_library_warns(dataset: str, version: str, cap
     ),
 )
 def test_disease_type_rare_valid_library_passes(dataset: str, version: str):
-    """These datasets natively use wgs or wgs_lr. If diseaseType is rare, they must pass."""
+    """These datasets natively use wgs or wgs_lr. For rare diseases, they must pass."""
     metadata = json.loads(importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text())
     metadata["submission"]["diseaseType"] = DiseaseType.rare.value
     metadata["submission"]["submissionDate"] = "2026-06-01"
@@ -461,7 +497,37 @@ def test_disease_type_rare_valid_library_passes(dataset: str, version: str):
     try:
         GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
     except ValidationError as e:
-        assert "is no longer allowed starting 01.06.2026" not in str(e)
+        assert "starting 01.06.2026" not in str(e)
+
+
+@pytest.mark.parametrize("version", TESTED_VERSIONS)
+def test_disease_type_rare_non_index_unrestricted(version: str):
+    """Non-index donors (e.g., parents in a trio) are exempt from the WGS rule."""
+    metadata = json.loads(
+        importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
+    )
+    metadata["submission"]["diseaseType"] = DiseaseType.rare.value
+    metadata["submission"]["submissionDate"] = "2026-06-01"
+
+    # modify a non-index donor (donor[1]) to use a panel
+    for idx, datum in enumerate(metadata["donors"][1]["labData"]):
+        datum["libraryType"] = LibraryType.panel.value
+
+        # panels require a BED file
+        datum["sequenceData"]["files"].append(
+            {
+                "filePath": f"dummy_target_{idx}.bed",
+                "fileType": "bed",
+                "fileChecksum": f"c{idx:063d}",
+                "fileSizeInBytes": 1000,
+            }
+        )
+
+    try:
+        # should pass because the index donor still has WGS
+        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+    except ValidationError as e:
+        assert "starting 01.06.2026" not in str(e)
 
 
 @pytest.mark.parametrize(

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -8,6 +8,10 @@ from datetime import date
 
 import pytest
 from grz_pydantic_models.mii.consent import Consent
+from grz_pydantic_models.submission.metadata import (
+    DiseaseType,
+    ResearchConsentNoScopeJustification,
+)
 from grz_pydantic_models.submission.metadata.v1 import File, FileType, GrzSubmissionMetadata, ResearchConsent
 from grz_pydantic_models_testing import example_metadata, example_research_consent
 from packaging.version import Version
@@ -387,3 +391,155 @@ def test_research_consent_no_subprovisions():
     )
     del consent_json_raw["provision"]["provision"]
     Consent.model_validate_json(json.dumps(consent_json_raw))
+
+
+@pytest.mark.parametrize(
+    "dataset,version",
+    itertools.product(
+        [
+            "oncomine_panel_tumor_only",
+            "panel_tumor_only",
+            "wes_tumor_germline",
+        ],
+        TESTED_VERSIONS,
+    ),
+)
+def test_disease_type_rare_invalid_library_raises(dataset: str, version: str):
+    """These datasets natively use panel or wes. If diseaseType is rare, they must fail on/after 01.06.2026."""
+    metadata = json.loads(importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text())
+    metadata["submission"]["diseaseType"] = DiseaseType.rare.value
+    metadata["submission"]["submissionDate"] = "2026-06-01"
+
+    with pytest.raises(ValidationError, match=r"is no longer allowed starting 01\.06\.2026"):
+        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+
+
+@pytest.mark.parametrize(
+    "dataset,version",
+    itertools.product(
+        [
+            "oncomine_panel_tumor_only",
+            "panel_tumor_only",
+            "wes_tumor_germline",
+        ],
+        TESTED_VERSIONS,
+    ),
+)
+def test_disease_type_rare_invalid_library_warns(dataset: str, version: str, caplog):
+    """These datasets natively use panel or wes. If diseaseType is rare, they warn before 01.06.2026."""
+    metadata = json.loads(importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text())
+    metadata["submission"]["diseaseType"] = DiseaseType.rare.value
+    metadata["submission"]["submissionDate"] = "2026-05-31"
+
+    try:
+        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+    except ValidationError as e:
+        # If mutating diseaseType triggers an unrelated structural error in the mock,
+        # we just ensure our target date error isn't the one blocking it.
+        assert "is no longer allowed starting 01.06.2026" not in str(e)
+
+    assert "is no longer allowed starting 01.06.2026" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "dataset,version",
+    itertools.product(
+        [
+            "wgs_tumor_germline",
+            "wgs_lr_tumor_only",
+            "wgs_trio",
+        ],
+        TESTED_VERSIONS,
+    ),
+)
+def test_disease_type_rare_valid_library_passes(dataset: str, version: str):
+    """These datasets natively use wgs or wgs_lr. If diseaseType is rare, they must pass."""
+    metadata = json.loads(importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text())
+    metadata["submission"]["diseaseType"] = DiseaseType.rare.value
+    metadata["submission"]["submissionDate"] = "2026-06-01"
+
+    try:
+        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+    except ValidationError as e:
+        assert "is no longer allowed starting 01.06.2026" not in str(e)
+
+
+@pytest.mark.parametrize(
+    "version,justification",
+    itertools.product(
+        TESTED_VERSIONS,
+        [ResearchConsentNoScopeJustification.LE_TECH.value, ResearchConsentNoScopeJustification.LE_ORG.value],
+    ),
+)
+def test_no_scope_justification_tech_org_raises(version: str, justification: str):
+    """LE_TECH and LE_ORG justifications should raise an error starting exactly 01.06.2026."""
+    metadata = json.loads(
+        importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
+    )
+    metadata["submission"]["submissionDate"] = "2026-06-01"
+
+    # Apply to all consents to be thorough
+    for donor in metadata["donors"]:
+        for consent in donor.get("researchConsents", []):
+            consent["noScopeJustification"] = justification
+            consent.pop("scope", None)
+
+    with pytest.raises(ValidationError, match=r"is no longer allowed starting 01\.06\.2026"):
+        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+
+
+@pytest.mark.parametrize(
+    "version,justification",
+    itertools.product(
+        TESTED_VERSIONS,
+        [ResearchConsentNoScopeJustification.LE_TECH.value, ResearchConsentNoScopeJustification.LE_ORG.value],
+    ),
+)
+def test_no_scope_justification_tech_org_warns(version: str, justification: str, caplog):
+    """LE_TECH and LE_ORG justifications should only warn strictly before 01.06.2026."""
+    metadata = json.loads(
+        importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
+    )
+    metadata["submission"]["submissionDate"] = "2026-05-31"
+
+    for donor in metadata["donors"]:
+        for consent in donor.get("researchConsents", []):
+            consent["noScopeJustification"] = justification
+            consent.pop("scope", None)
+
+    try:
+        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+    except ValidationError as e:
+        assert "is no longer allowed starting 01.06.2026" not in str(e)
+
+    assert "is no longer allowed starting 01.06.2026" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "version,justification",
+    itertools.product(
+        TESTED_VERSIONS,
+        [
+            ResearchConsentNoScopeJustification.UNABLE.value,
+            ResearchConsentNoScopeJustification.REFUSED.value,
+            ResearchConsentNoScopeJustification.NO_RETURN.value,
+            ResearchConsentNoScopeJustification.OTHER.value,
+        ],
+    ),
+)
+def test_no_scope_justification_standard_passes_after_cutoff(version: str, justification: str):
+    """Standard valid justifications should continue to pass seamlessly after 01.06.2026."""
+    metadata = json.loads(
+        importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
+    )
+    metadata["submission"]["submissionDate"] = "2026-06-01"
+
+    for donor in metadata["donors"]:
+        for consent in donor.get("researchConsents", []):
+            consent["noScopeJustification"] = justification
+            consent.pop("scope", None)
+
+    try:
+        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+    except ValidationError as e:
+        assert "is no longer allowed starting 01.06.2026" not in str(e)


### PR DESCRIPTION
This PR adapts the metadata validation according to BfArM requirements, starting 01.06.2026; the switch from warning to error happens time based.
