### PR TITLE
chore(grz-common): silence repetitive alembic info logs

### DIFF
--- a/packages/grz-common/src/grz_common/logging.py
+++ b/packages/grz-common/src/grz_common/logging.py
@@ -16,6 +16,17 @@ LOGGING_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 LOGGING_DATEFMT = "%Y-%m-%d %I:%M %p"
 
 
+class AlembicInfoNoiseFilter(logging.Filter):
+    """Filter out repetitive initialization messages from Alembic."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.name == "alembic.runtime.migration":
+            msg = record.getMessage()
+            if "Context impl" in msg or "Will assume transactional DDL" in msg:
+                return False
+        return True
+
+
 def add_filelogger(file_path: str | PathLike, level: str = "INFO", logger_name: str | None = None) -> None:
     """
     Add file logging for the specified package.
@@ -61,5 +72,6 @@ def setup_cli_logging(log_file: str | None, log_level: str):
             log_file,
             log_level.upper(),
         )
+    logging.getLogger("alembic.runtime.migration").addFilter(AlembicInfoNoiseFilter())
 
     log.debug("Logging setup complete.")


### PR DESCRIPTION
this silences alembic log INFO level messages:

- "alembic.runtime.migration: Context impl XYZ."
- "alembic.runtime.migration: Will assume transactional DDL"

so as not to clutter/swamp other more informative logs.