### PR TITLE
chore(grzctl): during backfill, distinguish reasons for skipping

### DIFF
--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -1023,7 +1023,9 @@ def _fetch_metadata_json(s3_client: Any, bucket: str, submission_id: str) -> str
 
 class _BackfillResult(StrEnum):
     UPDATED = "updated"
-    SKIPPED = "skipped"
+    UP_TO_DATE = "up_to_date"
+    NOT_FOUND = "not_found"
+    WOULD_OVERWRITE = "would_overwrite"
     ERROR = "error"
 
 
@@ -1057,8 +1059,9 @@ def _backfill_submission(  # noqa: PLR0911, PLR0913
         return _BackfillResult.ERROR
 
     if raw_json is None:
-        console_err.print(f"[yellow]  {submission_id}: metadata.json not found in S3, skipping.[/yellow]")
-        return _BackfillResult.SKIPPED
+        # this is expected for submissions residing in the other consent bucket, so we do not explicitly log that here
+        # but still report them in the final stats
+        return _BackfillResult.NOT_FOUND
 
     try:
         metadata = GrzSubmissionMetadata.model_validate_json(raw_json)
@@ -1079,7 +1082,7 @@ def _backfill_submission(  # noqa: PLR0911, PLR0913
 
     if not submission_diff.has_pending and not donors_diff.has_pending:
         console_err.print(f"[dim]  {submission_id}: already up to date, skipping.[/dim]")
-        return _BackfillResult.SKIPPED
+        return _BackfillResult.UP_TO_DATE
 
     if dry_run:
         console_err.print(
@@ -1091,7 +1094,7 @@ def _backfill_submission(  # noqa: PLR0911, PLR0913
         console_err.print(
             f"[dim]  {submission_id}: would overwrite {', '.join(i.key for i in itertools.chain(submission_diff.updated, submission_diff.deleted))}, skipping (use --force to overwrite).[/dim]"
         )
-        return _BackfillResult.SKIPPED
+        return _BackfillResult.WOULD_OVERWRITE
 
     try:
         db_service.commit_changes(submission_id, submission_diff, donors_diff)
@@ -1225,9 +1228,11 @@ def backfill(  # noqa: PLR0913
     prefix = "[dry-run] " if dry_run else ""
     verb = "Would update" if dry_run else "Updated"
     console_err.print(
-        f"\n[cyan]{prefix}Done. {verb}: {counts[_BackfillResult.UPDATED]}, "
-        f"Skipped (already populated, no S3 object, up to date, or would overwrite without --force): {counts[_BackfillResult.SKIPPED]}, "
-        f"Errors: {counts[_BackfillResult.ERROR]}[/cyan]"
+        f"\n[cyan]{prefix}Done. {verb}: {counts[_BackfillResult.UPDATED]}\n"
+        f"  Up to date: {counts[_BackfillResult.UP_TO_DATE]}\n"
+        f"  Not in bucket (split consent): {counts[_BackfillResult.NOT_FOUND]}\n"
+        f"  Would overwrite (needs --force): {counts[_BackfillResult.WOULD_OVERWRITE]}\n"
+        f"  Errors: {counts[_BackfillResult.ERROR]}[/cyan]"
     )
     if counts[_BackfillResult.ERROR]:
         sys.exit(1)

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -114,10 +114,10 @@ def test_backfill_submission_happy_path(
     assert persisted.submission_metadata == metadata.to_redacted_dict()
 
 
-def test_backfill_submission_skips_when_metadata_missing_in_s3(
+def test_backfill_submission_returns_not_found_when_metadata_missing_in_s3(
     db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata, submission_id: str
 ) -> None:
-    """When metadata.json does not exist in S3, the submission is recorded as skipped and the row stays NULL."""
+    """When metadata.json does not exist in S3, the submission is recorded as NOT_FOUND and the row stays NULL."""
     current = db.add_submission(submission_id)
 
     result = _backfill_submission(
@@ -130,7 +130,7 @@ def test_backfill_submission_skips_when_metadata_missing_in_s3(
         ignore_fields=IGNORE_FIELDS,
     )
 
-    assert result == _BackfillResult.SKIPPED
+    assert result == _BackfillResult.NOT_FOUND
     persisted = db.get_submission(submission_id)
     assert persisted.submission_size is None
     assert persisted.submission_metadata is None
@@ -163,10 +163,10 @@ def test_backfill_submission_records_error_on_invalid_json(
     assert persisted.submission_metadata is None
 
 
-def test_backfill_submission_skips_when_no_pending_diff(
+def test_backfill_submission_returns_up_to_date_when_no_pending_diff(
     db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata, submission_id: str
 ) -> None:
-    """With force=True against an already-in-sync row, the diff path runs and reports skipped (no updates)."""
+    """With force=True against an already-in-sync row, the diff path runs and reports UP_TO_DATE (no updates)."""
     current = _populate_full_row(db, submission_id, metadata)
     _put_metadata(s3_client_mock, submission_id, metadata)
 
@@ -180,13 +180,13 @@ def test_backfill_submission_skips_when_no_pending_diff(
         ignore_fields=IGNORE_FIELDS,
     )
 
-    assert result == _BackfillResult.SKIPPED
+    assert result == _BackfillResult.UP_TO_DATE
 
 
-def test_backfill_submission_skips_destructive_changes_without_force(
+def test_backfill_submission_returns_would_overwrite_for_destructive_changes_without_force(
     db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata, submission_id: str
 ) -> None:
-    """Without --force, a submission whose non-NULL field differs from S3 is skipped and the DB is unchanged."""
+    """Without --force, a submission whose non-NULL field differs from S3 returns WOULD_OVERWRITE and the DB is unchanged."""
     current = db.add_submission(submission_id)
     current.submission_size = 1  # non-NULL value that will differ from metadata
     db.update_submission(current)
@@ -203,7 +203,7 @@ def test_backfill_submission_skips_destructive_changes_without_force(
         ignore_fields=IGNORE_FIELDS,
     )
 
-    assert result == _BackfillResult.SKIPPED
+    assert result == _BackfillResult.WOULD_OVERWRITE
     persisted = db.get_submission(submission_id)
     assert persisted.submission_size == 1
 


### PR DESCRIPTION
… that way, you don't get spammed by _expected_ "not found" warnings (because you won't find non-consented submissions in the consented bucket and vice-versa), but still get the summary stats, slightly more informative than before.