### PR TITLE
fix(grz-cli): handle tuple from multi-config in submit

### DIFF
--- a/packages/grz-cli/src/grz_cli/commands/submit.py
+++ b/packages/grz-cli/src/grz_cli/commands/submit.py
@@ -1,6 +1,7 @@
 """Command for submitting (validating, encrypting, and uploading) a submission."""
 
 import logging
+from typing import Any
 
 import click
 from grz_cli.utils.version_check import check_version_and_exit_if_needed
@@ -18,11 +19,11 @@ from ..models.config import UploadConfig
 
 @click.command("submit")
 @grzcli.submission_dir
-@grzcli.config_file
+@grzcli.configuration
 @grzcli.threads
 @grzcli.force
 @click.pass_context
-def submit(ctx, submission_dir, config_file, threads, force):
+def submit(ctx, configuration: dict[str, Any], submission_dir, threads, force, **kwargs):
     """
     Validate, encrypt, and then upload.
 
@@ -31,11 +32,11 @@ def submit(ctx, submission_dir, config_file, threads, force):
     2. Encrypt the submission
     3. Upload the encrypted submission
     """
-    config = UploadConfig.from_path(config_file)
+    config = UploadConfig.model_validate(configuration)
     check_version_and_exit_if_needed(config.s3)
 
     click.echo("Starting submission process...")
-    ctx.invoke(validate, submission_dir=submission_dir, config_file=config_file, force=force)
-    ctx.invoke(encrypt, submission_dir=submission_dir, config_file=config_file, force=force, check_validation_logs=True)
-    ctx.invoke(upload, submission_dir=submission_dir, config_file=config_file, threads=threads)
+    ctx.invoke(validate, submission_dir=submission_dir, force=force)
+    ctx.invoke(encrypt, submission_dir=submission_dir, force=force, check_validation_logs=True)
+    ctx.invoke(upload, submission_dir=submission_dir, threads=threads)
     click.echo("Submission finished!")

--- a/packages/grz-cli/tests/conftest.py
+++ b/packages/grz-cli/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Shared fixtures for grz-cli tests."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+MINIMAL_S3_CONFIG: dict[str, dict[str, str]] = {
+    "s3": {
+        "endpoint_url": "https://example.invalid",
+        "bucket": "test-bucket",
+        "access_key": "test-key",
+        "secret": "test-secret",
+    },
+}
+
+
+@pytest.fixture
+def s3_config_path(tmp_path: Path) -> Path:
+    """Write a minimal S3 config file and return its path."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump(MINIMAL_S3_CONFIG))
+    return config_path
+
+
+@pytest.fixture
+def submission_dir(tmp_path: Path) -> Path:
+    """Empty submission directory with the four standard subdirectories."""
+    submission_dir = tmp_path / "submission"
+    for sub in ("metadata", "files", "encrypted_files", "logs"):
+        (submission_dir / sub).mkdir(parents=True)
+    return submission_dir

--- a/packages/grz-cli/tests/test_submit.py
+++ b/packages/grz-cli/tests/test_submit.py
@@ -1,104 +1,67 @@
+"""Integration tests for the ``grz-cli submit`` command."""
+
 from pathlib import Path
 
 import click.testing
+import pytest
 import yaml
+from pytest_mock import MockerFixture
+
+from grz_cli.cli import build_cli
 
 
-MINIMAL_CONFIG = {
-    "s3": {
-        "endpoint_url": "https://example.invalid",
-        "bucket": "test-bucket",
-        "access_key": "AKIA-test",
-        "secret": "test-secret",
-    },
-}
+@pytest.fixture
+def stub_subcommands(mocker: MockerFixture) -> dict[str, object]:
+    """Replace the subcommands ``submit`` invokes with no-op mocks.
+
+    ``ctx.invoke`` accepts any callable when the target is not a click
+    ``Command``, so swapping the module-level imports lets the real submit
+    callback run end-to-end without executing real validation, encryption,
+    or upload.
+    """
+    mocker.patch("grz_cli.commands.submit.check_version_and_exit_if_needed")
+    return {
+        "validate": mocker.patch("grz_cli.commands.submit.validate"),
+        "encrypt": mocker.patch("grz_cli.commands.submit.encrypt"),
+        "upload": mocker.patch("grz_cli.commands.submit.upload"),
+    }
 
 
-def _write_config(tmp_path: Path) -> Path:
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text(yaml.dump(MINIMAL_CONFIG))
-    return config_path
-
-
-def _make_submission_dir(tmp_path: Path) -> Path:
-    submission_dir = tmp_path / "submission"
-    for sub in ("metadata", "files", "encrypted_files", "logs"):
-        (submission_dir / sub).mkdir(parents=True)
-    return submission_dir
-
-
-def test_submit_invokes_subcommands(tmp_path, monkeypatch):
-    """submit should parse config + run validate, encrypt, upload in order."""
-    from grz_cli.cli import build_cli
-    from grz_cli.commands import submit as submit_module
-
-    calls: list[str] = []
-
-    def fake_validate(*args, **kwargs):
-        calls.append("validate")
-
-    def fake_encrypt(*args, **kwargs):
-        calls.append("encrypt")
-
-    def fake_upload(*args, **kwargs):
-        calls.append("upload")
-
-    monkeypatch.setattr(submit_module.validate, "callback", fake_validate)
-    monkeypatch.setattr(submit_module.encrypt, "callback", fake_encrypt)
-    monkeypatch.setattr(submit_module.upload, "callback", fake_upload)
-    monkeypatch.setattr(submit_module, "check_version_and_exit_if_needed", lambda _s3: None)
-
-    config_path = _write_config(tmp_path)
-    submission_dir = _make_submission_dir(tmp_path)
-
+def _invoke_submit(*extra_args: str) -> click.testing.Result:
     runner = click.testing.CliRunner()
-    result = runner.invoke(
-        build_cli(),
-        [
-            "submit",
-            "--submission-dir",
-            str(submission_dir),
-            "--config-file",
-            str(config_path),
-        ],
-        catch_exceptions=False,
+    return runner.invoke(build_cli(), ["submit", *extra_args], catch_exceptions=False)
+
+
+def test_submit_runs_subcommands_in_order(
+    s3_config_path: Path,
+    submission_dir: Path,
+    stub_subcommands: dict[str, object],
+) -> None:
+    result = _invoke_submit(
+        "--submission-dir", str(submission_dir),
+        "--config-file", str(s3_config_path),
     )
 
     assert result.exit_code == 0, result.output
-    assert calls == ["validate", "encrypt", "upload"]
+    stub_subcommands["validate"].assert_called_once()
+    stub_subcommands["encrypt"].assert_called_once()
+    stub_subcommands["upload"].assert_called_once()
 
 
-def test_submit_accepts_multiple_config_files(tmp_path, monkeypatch):
-    """Regression: repeated --config-file once produced a tuple that crashed UploadConfig.from_path."""
-    from grz_cli.cli import build_cli
-    from grz_cli.commands import submit as submit_module
+def test_submit_accepts_multiple_config_files(
+    tmp_path: Path,
+    s3_config_path: Path,
+    submission_dir: Path,
+    stub_subcommands: dict[str, object],
+) -> None:
+    """Regression: repeated ``--config-file`` once produced a tuple that crashed config parsing."""
+    override_path = tmp_path / "override.yaml"
+    override_path.write_text(yaml.dump({"s3": {"access_key": "override-key"}}))
 
-    monkeypatch.setattr(submit_module.validate, "callback", lambda *a, **kw: None)
-    monkeypatch.setattr(submit_module.encrypt, "callback", lambda *a, **kw: None)
-    monkeypatch.setattr(submit_module.upload, "callback", lambda *a, **kw: None)
-    monkeypatch.setattr(submit_module, "check_version_and_exit_if_needed", lambda _s3: None)
-
-    base_config_path = tmp_path / "base.yaml"
-    base_config_path.write_text(yaml.dump({"s3": {"endpoint_url": "https://example.invalid", "bucket": "x"}}))
-
-    override_config_path = tmp_path / "override.yaml"
-    override_config_path.write_text(yaml.dump({"s3": {"access_key": "k", "secret": "s"}}))
-
-    submission_dir = _make_submission_dir(tmp_path)
-
-    runner = click.testing.CliRunner()
-    result = runner.invoke(
-        build_cli(),
-        [
-            "submit",
-            "--submission-dir",
-            str(submission_dir),
-            "--config-file",
-            str(base_config_path),
-            "--config-file",
-            str(override_config_path),
-        ],
-        catch_exceptions=False,
+    result = _invoke_submit(
+        "--submission-dir", str(submission_dir),
+        "--config-file", str(s3_config_path),
+        "--config-file", str(override_path),
     )
 
     assert result.exit_code == 0, result.output

--- a/packages/grz-cli/tests/test_submit.py
+++ b/packages/grz-cli/tests/test_submit.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+
+import click.testing
+import yaml
+
+
+MINIMAL_CONFIG = {
+    "s3": {
+        "endpoint_url": "https://example.invalid",
+        "bucket": "test-bucket",
+        "access_key": "AKIA-test",
+        "secret": "test-secret",
+    },
+}
+
+
+def _write_config(tmp_path: Path) -> Path:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump(MINIMAL_CONFIG))
+    return config_path
+
+
+def _make_submission_dir(tmp_path: Path) -> Path:
+    submission_dir = tmp_path / "submission"
+    for sub in ("metadata", "files", "encrypted_files", "logs"):
+        (submission_dir / sub).mkdir(parents=True)
+    return submission_dir
+
+
+def test_submit_invokes_subcommands(tmp_path, monkeypatch):
+    """submit should parse config + run validate, encrypt, upload in order."""
+    from grz_cli.cli import build_cli
+    from grz_cli.commands import submit as submit_module
+
+    calls: list[str] = []
+
+    def fake_validate(*args, **kwargs):
+        calls.append("validate")
+
+    def fake_encrypt(*args, **kwargs):
+        calls.append("encrypt")
+
+    def fake_upload(*args, **kwargs):
+        calls.append("upload")
+
+    monkeypatch.setattr(submit_module.validate, "callback", fake_validate)
+    monkeypatch.setattr(submit_module.encrypt, "callback", fake_encrypt)
+    monkeypatch.setattr(submit_module.upload, "callback", fake_upload)
+    monkeypatch.setattr(submit_module, "check_version_and_exit_if_needed", lambda _s3: None)
+
+    config_path = _write_config(tmp_path)
+    submission_dir = _make_submission_dir(tmp_path)
+
+    runner = click.testing.CliRunner()
+    result = runner.invoke(
+        build_cli(),
+        [
+            "submit",
+            "--submission-dir",
+            str(submission_dir),
+            "--config-file",
+            str(config_path),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == ["validate", "encrypt", "upload"]
+
+
+def test_submit_accepts_multiple_config_files(tmp_path, monkeypatch):
+    """Regression: repeated --config-file once produced a tuple that crashed UploadConfig.from_path."""
+    from grz_cli.cli import build_cli
+    from grz_cli.commands import submit as submit_module
+
+    monkeypatch.setattr(submit_module.validate, "callback", lambda *a, **kw: None)
+    monkeypatch.setattr(submit_module.encrypt, "callback", lambda *a, **kw: None)
+    monkeypatch.setattr(submit_module.upload, "callback", lambda *a, **kw: None)
+    monkeypatch.setattr(submit_module, "check_version_and_exit_if_needed", lambda _s3: None)
+
+    base_config_path = tmp_path / "base.yaml"
+    base_config_path.write_text(yaml.dump({"s3": {"endpoint_url": "https://example.invalid", "bucket": "x"}}))
+
+    override_config_path = tmp_path / "override.yaml"
+    override_config_path.write_text(yaml.dump({"s3": {"access_key": "k", "secret": "s"}}))
+
+    submission_dir = _make_submission_dir(tmp_path)
+
+    runner = click.testing.CliRunner()
+    result = runner.invoke(
+        build_cli(),
+        [
+            "submit",
+            "--submission-dir",
+            str(submission_dir),
+            "--config-file",
+            str(base_config_path),
+            "--config-file",
+            str(override_config_path),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output

--- a/packages/grz-cli/tests/test_submit.py
+++ b/packages/grz-cli/tests/test_submit.py
@@ -5,9 +5,8 @@ from pathlib import Path
 import click.testing
 import pytest
 import yaml
-from pytest_mock import MockerFixture
-
 from grz_cli.cli import build_cli
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture
@@ -38,8 +37,10 @@ def test_submit_runs_subcommands_in_order(
     stub_subcommands: dict[str, object],
 ) -> None:
     result = _invoke_submit(
-        "--submission-dir", str(submission_dir),
-        "--config-file", str(s3_config_path),
+        "--submission-dir",
+        str(submission_dir),
+        "--config-file",
+        str(s3_config_path),
     )
 
     assert result.exit_code == 0, result.output
@@ -59,9 +60,12 @@ def test_submit_accepts_multiple_config_files(
     override_path.write_text(yaml.dump({"s3": {"access_key": "override-key"}}))
 
     result = _invoke_submit(
-        "--submission-dir", str(submission_dir),
-        "--config-file", str(s3_config_path),
-        "--config-file", str(override_path),
+        "--submission-dir",
+        str(submission_dir),
+        "--config-file",
+        str(s3_config_path),
+        "--config-file",
+        str(override_path),
     )
 
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
`grz-cli submit` crashed with `TypeError: expected str, bytes or os.PathLike object, not tuple` because the callback fed the tuple returned by the `--config-file` option (`multiple=True`) to `UploadConfig.from_path`, which expects a single path.

Switch `submit` to the `@grzcli.configuration` decorator (matching `validate`, `encrypt`, `upload`) so the already-merged config dict is injected and validated with `UploadConfig.model_validate`. Drop the explicit `config_file=` kwargs in the `ctx.invoke` calls; the child commands already read config files from the parent context.

Add integration tests covering both single and repeated `--config-file` invocations to lock the regression in.
