### PR TITLE
fix(grzctl,grz-cli): use correct argument name "mmap" in validate callback function

### DIFF
--- a/packages/grz-cli/src/grz_cli/commands/validate.py
+++ b/packages/grz-cli/src/grz_cli/commands/validate.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 @click.option(
     "--mmap/--no-mmap",
     "mmap",
-    default=True,
+    default=False,
     hidden=True,
     help="Whether to use mmap.",
 )

--- a/packages/grzctl/src/grzctl/commands/validate.py
+++ b/packages/grzctl/src/grzctl/commands/validate.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 @click.option(
     "--mmap/--no-mmap",
     "mmap",
-    default=True,
+    default=False,
     hidden=True,
     help="Whether to use mmap.",
 )

--- a/packages/grzctl/src/grzctl/commands/validate.py
+++ b/packages/grzctl/src/grzctl/commands/validate.py
@@ -66,6 +66,6 @@ def validate(  # noqa: PLR0913
             submission_dir=submission_dir,
             force=force,
             threads=threads,
-            no_mmap=not mmap,
+            mmap=mmap,
             **kwargs,
         )

--- a/packages/grzctl/tests/cli/test_validate.py
+++ b/packages/grzctl/tests/cli/test_validate.py
@@ -1,0 +1,37 @@
+"""Tests for the grzctl ``validate`` wrapper command."""
+
+import click.testing
+import grz_cli.commands.validate as grz_cli_validate
+import grzctl.cli
+import pytest
+
+
+@pytest.mark.parametrize(("flag", "expected"), [("--mmap", True), ("--no-mmap", False)])
+def test_validate_forwards_mmap_to_inner_callback(tmp_path, monkeypatch, flag, expected):
+    """The grzctl ``validate`` wrapper must forward the ``mmap`` flag to the inner
+    grz-cli ``validate`` callback under the parameter name it actually expects
+    (``mmap``), not ``no_mmap``.
+
+    Regression test for ``TypeError: validate() missing 1 required positional
+    argument: 'mmap'``: the wrapper invokes the inner callback directly (bypassing
+    Click's option parsing), so a wrong keyword name silently lands in ``**kwargs``
+    and leaves the required ``mmap`` parameter unbound.
+    """
+    received: dict[str, object] = {}
+
+    def fake_callback(*, configuration, submission_dir, force, threads, mmap, **kwargs):
+        # Mirror the real inner callback's signature so that passing a wrong keyword
+        # (e.g. ``no_mmap``) reproduces the same TypeError observed in production.
+        received["mmap"] = mmap
+
+    monkeypatch.setattr(grz_cli_validate.validate, "callback", fake_callback)
+
+    runner = click.testing.CliRunner()
+    cli = grzctl.cli.build_cli()
+    result = runner.invoke(
+        cli,
+        ["validate", "--submission-dir", str(tmp_path), "--no-update-db", flag],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert received["mmap"] is expected

--- a/packages/grzctl/tests/cli/test_validate.py
+++ b/packages/grzctl/tests/cli/test_validate.py
@@ -6,7 +6,14 @@ import grzctl.cli
 import pytest
 
 
-@pytest.mark.parametrize(("flag", "expected"), [("--mmap", True), ("--no-mmap", False)])
+@pytest.mark.parametrize(
+    ("flag", "expected"),
+    [
+        ("--mmap", True),
+        ("--no-mmap", False),
+        (None, False),  # default is no-mmap
+    ],
+)
 def test_validate_forwards_mmap_to_inner_callback(tmp_path, monkeypatch, flag, expected):
     """The grzctl ``validate`` wrapper must forward the ``mmap`` flag to the inner
     grz-cli ``validate`` callback under the parameter name it actually expects
@@ -26,12 +33,13 @@ def test_validate_forwards_mmap_to_inner_callback(tmp_path, monkeypatch, flag, e
 
     monkeypatch.setattr(grz_cli_validate.validate, "callback", fake_callback)
 
+    args = ["validate", "--submission-dir", str(tmp_path), "--no-update-db"]
+    if flag is not None:
+        args.append(flag)
+
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
-    result = runner.invoke(
-        cli,
-        ["validate", "--submission-dir", str(tmp_path), "--no-update-db", flag],
-    )
+    result = runner.invoke(cli, args)
 
     assert result.exit_code == 0, result.output
     assert received["mmap"] is expected


### PR DESCRIPTION
## Fix of argument name in validate.callback function

 grzctl validate crashes with TypeError: validate() missing 1 required positional argument: 'mmap'.
  
  The function calls the inner grz-cli validate callback (`validate_module.validate.callback`) with no_mmap=..., but the parameter is actually named mmap, so it never gets passed.
  One-line fix replacing `no_mmap=not mmap` with `mmap=mmap`

  Added a small test covering --mmap/--no-mmap (file tests/cli/test_validate.py)
  
  fix(grzctl,grz-cli): default to `--no-mmap`.
