### PR TITLE
fix(grz-db): correct tan_g population by raising sqlmodel floor

### DIFF
--- a/packages/grz-db/pyproject.toml
+++ b/packages/grz-db/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "alembic[tz] >=1.16.1",
     "cryptography >=45.0.3,<49",
-    "sqlmodel >=0.0.27",
+    "sqlmodel >=0.0.38",
     "grz-pydantic-models >=2.7,<3",
     "psycopg[binary] ~=3.2"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1010,7 +1010,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=45.0.3,<49" },
     { name = "grz-pydantic-models", editable = "packages/grz-pydantic-models" },
     { name = "psycopg", extras = ["binary"], specifier = "~=3.2" },
-    { name = "sqlmodel", specifier = ">=0.0.27" },
+    { name = "sqlmodel", specifier = ">=0.0.38" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Change

Changed minimum version floor of sqlmodel in grz-db/pyproject.toml from 0.027 to 0.0.38.
Rationale: the earlier version of the external sqlmodel package had broken handling of aliases . Since we use 'tanG' as alias for 'tan_g' attribute in the code, the tan_g value was not populated correctly and remained NULL, thus bypassing the uniqueness constraint for tan_g values.

