### PR TITLE
fix(grz-db): evaluate research consent at submission date, not today

### DIFF
--- a/packages/grz-db/src/grz_db/migrations/versions/66f36abbea34_rename_submission_date_to_submission_.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/66f36abbea34_rename_submission_date_to_submission_.py
@@ -1,0 +1,27 @@
+"""rename submission_date to submission_finished_date
+
+Revision ID: 66f36abbea34
+Revises: 09602efd9105
+Create Date: 2026-06-10 18:20:26.144612+00:00
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "66f36abbea34"
+down_revision: str | Sequence[str] | None = "09602efd9105"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column("submissions", "submission_date", new_column_name="submission_finished_date")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    raise RuntimeError("Downgrades not supported.")

--- a/packages/grz-db/src/grz_db/migrations/versions/66f36abbea34_rename_submission_date_to_submission_uploaded_date.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/66f36abbea34_rename_submission_date_to_submission_uploaded_date.py
@@ -1,4 +1,4 @@
-"""rename submission_date to submission_finished_date
+"""rename submission_date to submission_uploaded_date
 
 Revision ID: 66f36abbea34
 Revises: 09602efd9105
@@ -19,7 +19,7 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    op.alter_column("submissions", "submission_date", new_column_name="submission_finished_date")
+    op.alter_column("submissions", "submission_date", new_column_name="submission_uploaded_date")
 
 
 def downgrade() -> None:

--- a/packages/grz-db/src/grz_db/models/submission/__init__.py
+++ b/packages/grz-db/src/grz_db/models/submission/__init__.py
@@ -1181,14 +1181,14 @@ class SubmissionDb:
         self,
         submission_id: str,
         metadata: GrzSubmissionMetadata,
-        submission_date: datetime.date | None,
+        submission_finished_date: datetime.date,
         ignore_fields: set[str] | None = None,
     ) -> SubmissionDiffCollection:
         """Compare a submission's current database state against fresh metadata.
 
         :param submission_id: Submission ID to look up.
         :param metadata: Parsed metadata from the submission's ``metadata.json``.
-        :param submission_date: Explicit submission date; falls back to the value in *metadata* when ``None``.
+        :param submission_finished_date: Date of submission upload finish
         :param ignore_fields: Field names to skip entirely during the comparison.
         :returns: A :class:`SubmissionDiffCollection` instance summarising all detected differences.
         """
@@ -1199,7 +1199,10 @@ class SubmissionDb:
         if ignore_fields is None:
             ignore_fields = set()
 
-        new_submission = Submission.from_metadata(submission_id, metadata, submission_date)
+        if isinstance(submission_finished_date, datetime.datetime):
+            submission_finished_date = submission_finished_date.date()
+
+        new_submission = Submission.from_metadata(submission_id, metadata, submission_finished_date)
 
         return current_submission.diff(new_submission, ignore_fields)
 
@@ -1212,9 +1215,6 @@ class SubmissionDb:
 
         :param submission_id: Submission ID to look up donors for.
         :param metadata: Parsed metadata from the submission's ``metadata.json``.
-        :param submission_date: Explicit submission date used to evaluate research
-            consent at submission-completion time. Falls back to the value in
-            *metadata* when ``None``.
         :returns: A fully populated :class:`DonorDiff`.
         """
         metadata_submission_date = metadata.submission.submission_date
@@ -1242,11 +1242,34 @@ class SubmissionDb:
         self,
         submission_id: str,
         metadata: GrzSubmissionMetadata,
-        submission_date: datetime.date | None,
+        submission_finished_date: datetime.date | None,
         ignore_fields: set[str] | None = None,
     ) -> tuple[SubmissionDiffCollection, DonorsDiffCollection]:
-        submission_diff = self._diff_metadata(submission_id, metadata, submission_date, ignore_fields)
-        donor_diff = self._diff_donors(submission_id, metadata, submission_date)
+        """
+        Generates differences between the current and previous states of submission metadata
+        and donors data.
+
+        This function compares the provided metadata and donors data with the existing
+        state in the system for a specific submission ID and returns the differences in two
+        separate collections.
+
+        :param submission_id: The unique identifier of the submission to be compared.
+        :param metadata: The metadata of the submission to compare against.
+        :param submission_finished_date: The date when the submission process was finished.
+            If None, the field will not be included in the comparison.
+        :param ignore_fields: Optional set of field names to be ignored during the metadata comparison.
+        :returns: A tuple containing the differences in the submission metadata and the corresponding donor entries.
+        """
+        if submission_finished_date is None:
+            # set arbitrary date if not provided
+            submission_finished_date = metadata.submission.submission_date
+
+            # Add submission date to ignore fields
+            ignore_fields = ignore_fields or set()
+            ignore_fields.add("submission_date")
+
+        submission_diff = self._diff_metadata(submission_id, metadata, submission_finished_date, ignore_fields)
+        donor_diff = self._diff_donors(submission_id, metadata)
         return submission_diff, donor_diff
 
     def commit_changes(

--- a/packages/grz-db/src/grz_db/models/submission/__init__.py
+++ b/packages/grz-db/src/grz_db/models/submission/__init__.py
@@ -143,7 +143,7 @@ class SubmissionBase(SQLModel):
     pseudonym: str | None = Field(default=None, index=True)
 
     # fields from Prüfbericht
-    submission_date: datetime.date | None = None
+    submission_finished_date: datetime.date | None = None
     submission_type: SubmissionType | None = None
     submitter_id: SubmitterId | None = None
     data_node_id: GenomicDataCenterId | None = None
@@ -206,7 +206,7 @@ class Submission(SubmissionBase, table=True):
             new_value = getattr(other, key)
 
             # Ensure fields are cast to date
-            if key == "submission_date":
+            if key == "submission_finished_date":
                 if isinstance(old_value, datetime.datetime):
                     old_value = old_value.date()
                 if isinstance(new_value, datetime.datetime):
@@ -258,7 +258,7 @@ class Submission(SubmissionBase, table=True):
                 "data_node_id": metadata.submission.genomic_data_center_id,
                 "consented": metadata.consents_to_research(date=metadata_submission_date),
                 "submission_size": metadata.get_submission_size(),
-                "submission_date": submission_finished_date,
+                "submission_finished_date": submission_finished_date,
                 "submission_metadata": metadata.to_redacted_dict(),
             }
         )
@@ -735,7 +735,7 @@ class SubmissionDb:
                 .join(QCQueueEntry, QCQueueEntry.submission_id == Submission.id)  # type: ignore[arg-type]
                 .where(Submission.submission_type == SubmissionType.initial)
                 .where(Submission.basic_qc_passed)  # type: ignore[arg-type]
-                .where(Submission.submission_date.between(start_date, end_date))  # type: ignore[union-attr]
+                .where(Submission.submission_finished_date.between(start_date, end_date))  # type: ignore[union-attr]
                 .where(Submission.submitter_id == submitter_id)
                 .order_by(QCQueueEntry.basic_qc_passed_at, Submission.id)  # type: ignore[arg-type]
             ).all()
@@ -780,7 +780,7 @@ class SubmissionDb:
 
         block_size = math.floor(1 / target_proportion)
         block_index = absolute_index // block_size
-        submission_quarter, submission_year = date_to_quarter_year(submission.submission_date)  # type: ignore[arg-type]
+        submission_quarter, submission_year = date_to_quarter_year(submission.submission_finished_date)  # type: ignore[arg-type]
         seed = f"{submission.submitter_id}-{submission_year}-{submission_quarter}-{block_index}-{salt}"
         rng = random.Random(seed)  # noqa: S311
 
@@ -1033,7 +1033,7 @@ class SubmissionDb:
                     isouter=True,
                 )
                 .order_by(
-                    sqlfn.coalesce(latest_state_per_submission.c.timestamp, Submission.submission_date)
+                    sqlfn.coalesce(latest_state_per_submission.c.timestamp, Submission.submission_finished_date)
                     .desc()
                     .nulls_first()
                 )
@@ -1117,7 +1117,7 @@ class SubmissionDb:
 
         if submission is None:
             raise SubmissionNotFoundError(submission_id)
-        submission_date = submission.submission_date
+        submission_date = submission.submission_finished_date
         if submission_date is None:
             raise SubmissionDateIsNoneError()
         submission_type = submission.submission_type
@@ -1266,7 +1266,7 @@ class SubmissionDb:
 
             # Add submission date to ignore fields
             ignore_fields = ignore_fields or set()
-            ignore_fields.add("submission_date")
+            ignore_fields.add("submission_finished_date")
 
         submission_diff = self._diff_metadata(submission_id, metadata, submission_finished_date, ignore_fields)
         donor_diff = self._diff_donors(submission_id, metadata)

--- a/packages/grz-db/src/grz_db/models/submission/__init__.py
+++ b/packages/grz-db/src/grz_db/models/submission/__init__.py
@@ -244,6 +244,9 @@ class Submission(SubmissionBase, table=True):
         if isinstance(submission_date, datetime.datetime):
             submission_date = submission_date.date()
 
+        resolved_submission_date = submission_date if submission_date is not None else metadata_submission_date
+        consent_date = resolved_submission_date if resolved_submission_date is not None else datetime.date.today()
+
         return cls.model_validate(
             {
                 "id": submission_id,
@@ -256,9 +259,9 @@ class Submission(SubmissionBase, table=True):
                 "genomic_study_subtype": metadata.submission.genomic_study_subtype,
                 "pseudonym": metadata.submission.local_case_id,
                 "data_node_id": metadata.submission.genomic_data_center_id,
-                "consented": metadata.consents_to_research(date=datetime.date.today()),
+                "consented": metadata.consents_to_research(date=consent_date),
                 "submission_size": metadata.get_submission_size(),
-                "submission_date": submission_date if submission_date is not None else metadata_submission_date,
+                "submission_date": resolved_submission_date,
                 "submission_metadata": metadata.to_redacted_dict(),
             }
         )
@@ -456,7 +459,15 @@ class Donor(SQLModel, table=True):
         cls,
         submission_id: str,
         donor: MetadataDonor,
+        submission_date: datetime.date | None,
     ) -> Self:
+        """Construct a Donor populated from parsed metadata.
+
+        :param submission_date: Resolved submission date used to evaluate research
+            consent at the time the submission was completed. Falls back to
+            ``datetime.date.today()`` only when no submission date is known.
+        """
+        consent_date = submission_date if submission_date is not None else datetime.date.today()
         return cls.model_validate(
             dict(
                 submission_id=submission_id,
@@ -466,7 +477,7 @@ class Donor(SQLModel, table=True):
                 sequence_types={datum.sequence_type for datum in donor.lab_data},
                 sequence_subtypes={datum.sequence_subtype for datum in donor.lab_data},
                 mv_consented=donor.consents_to_mv(),
-                research_consented=donor.consents_to_research(date=datetime.date.today()),
+                research_consented=donor.consents_to_research(date=consent_date),
                 research_consent_missing_justifications={
                     consent.no_scope_justification
                     for consent in donor.research_consents
@@ -1199,16 +1210,28 @@ class SubmissionDb:
         self,
         submission_id: str,
         metadata: GrzSubmissionMetadata,
+        submission_date: datetime.date | None,
     ) -> DonorsDiffCollection:
         """Diff all donors in *metadata* against the current database state.
 
         :param submission_id: Submission ID to look up donors for.
         :param metadata: Parsed metadata from the submission's ``metadata.json``.
+        :param submission_date: Explicit submission date used to evaluate research
+            consent at submission-completion time. Falls back to the value in
+            *metadata* when ``None``.
         :returns: A fully populated :class:`DonorDiff`.
         """
+        metadata_submission_date = metadata.submission.submission_date
+        if isinstance(metadata_submission_date, datetime.datetime):
+            metadata_submission_date = metadata_submission_date.date()
+        if isinstance(submission_date, datetime.datetime):
+            submission_date = submission_date.date()
+        resolved_submission_date = submission_date if submission_date is not None else metadata_submission_date
+
         donors_in_db_submission = {donor.pseudonym: donor for donor in self.get_donors(submission_id=submission_id)}
         donors_in_metadata = {
-            (d := Donor.from_donor_metadata(submission_id, donor)).pseudonym: d for donor in metadata.donors
+            (d := Donor.from_donor_metadata(submission_id, donor, resolved_submission_date)).pseudonym: d
+            for donor in metadata.donors
         }
 
         result = DonorsDiffCollection()
@@ -1230,7 +1253,7 @@ class SubmissionDb:
         ignore_fields: set[str] | None = None,
     ) -> tuple[SubmissionDiffCollection, DonorsDiffCollection]:
         submission_diff = self._diff_metadata(submission_id, metadata, submission_date, ignore_fields)
-        donor_diff = self._diff_donors(submission_id, metadata)
+        donor_diff = self._diff_donors(submission_id, metadata, submission_date)
         return submission_diff, donor_diff
 
     def commit_changes(

--- a/packages/grz-db/src/grz_db/models/submission/__init__.py
+++ b/packages/grz-db/src/grz_db/models/submission/__init__.py
@@ -143,7 +143,7 @@ class SubmissionBase(SQLModel):
     pseudonym: str | None = Field(default=None, index=True)
 
     # fields from Prüfbericht
-    submission_finished_date: datetime.date | None = None
+    submission_uploaded_date: datetime.date | None = None
     submission_type: SubmissionType | None = None
     submitter_id: SubmitterId | None = None
     data_node_id: GenomicDataCenterId | None = None
@@ -206,7 +206,7 @@ class Submission(SubmissionBase, table=True):
             new_value = getattr(other, key)
 
             # Ensure fields are cast to date
-            if key == "submission_finished_date":
+            if key == "submission_uploaded_date":
                 if isinstance(old_value, datetime.datetime):
                     old_value = old_value.date()
                 if isinstance(new_value, datetime.datetime):
@@ -228,7 +228,7 @@ class Submission(SubmissionBase, table=True):
         cls,
         submission_id: str,
         metadata: GrzSubmissionMetadata,
-        submission_finished_date: datetime.date,
+        submission_uploaded_date: datetime.date,
     ) -> Self:
         """Construct a Submission populated with values derived from parsed metadata.
 
@@ -241,8 +241,8 @@ class Submission(SubmissionBase, table=True):
         if isinstance(metadata_submission_date, datetime.datetime):
             metadata_submission_date = metadata_submission_date.date()
 
-        if isinstance(submission_finished_date, datetime.datetime):
-            submission_finished_date = submission_finished_date.date()
+        if isinstance(submission_uploaded_date, datetime.datetime):
+            submission_uploaded_date = submission_uploaded_date.date()
 
         return cls.model_validate(
             {
@@ -258,7 +258,7 @@ class Submission(SubmissionBase, table=True):
                 "data_node_id": metadata.submission.genomic_data_center_id,
                 "consented": metadata.consents_to_research(date=metadata_submission_date),
                 "submission_size": metadata.get_submission_size(),
-                "submission_finished_date": submission_finished_date,
+                "submission_uploaded_date": submission_uploaded_date,
                 "submission_metadata": metadata.to_redacted_dict(),
             }
         )
@@ -735,7 +735,7 @@ class SubmissionDb:
                 .join(QCQueueEntry, QCQueueEntry.submission_id == Submission.id)  # type: ignore[arg-type]
                 .where(Submission.submission_type == SubmissionType.initial)
                 .where(Submission.basic_qc_passed)  # type: ignore[arg-type]
-                .where(Submission.submission_finished_date.between(start_date, end_date))  # type: ignore[union-attr]
+                .where(Submission.submission_uploaded_date.between(start_date, end_date))  # type: ignore[union-attr]
                 .where(Submission.submitter_id == submitter_id)
                 .order_by(QCQueueEntry.basic_qc_passed_at, Submission.id)  # type: ignore[arg-type]
             ).all()
@@ -780,7 +780,7 @@ class SubmissionDb:
 
         block_size = math.floor(1 / target_proportion)
         block_index = absolute_index // block_size
-        submission_quarter, submission_year = date_to_quarter_year(submission.submission_finished_date)  # type: ignore[arg-type]
+        submission_quarter, submission_year = date_to_quarter_year(submission.submission_uploaded_date)  # type: ignore[arg-type]
         seed = f"{submission.submitter_id}-{submission_year}-{submission_quarter}-{block_index}-{salt}"
         rng = random.Random(seed)  # noqa: S311
 
@@ -1033,7 +1033,7 @@ class SubmissionDb:
                     isouter=True,
                 )
                 .order_by(
-                    sqlfn.coalesce(latest_state_per_submission.c.timestamp, Submission.submission_finished_date)
+                    sqlfn.coalesce(latest_state_per_submission.c.timestamp, Submission.submission_uploaded_date)
                     .desc()
                     .nulls_first()
                 )
@@ -1117,7 +1117,7 @@ class SubmissionDb:
 
         if submission is None:
             raise SubmissionNotFoundError(submission_id)
-        submission_date = submission.submission_finished_date
+        submission_date = submission.submission_uploaded_date
         if submission_date is None:
             raise SubmissionDateIsNoneError()
         submission_type = submission.submission_type
@@ -1181,14 +1181,14 @@ class SubmissionDb:
         self,
         submission_id: str,
         metadata: GrzSubmissionMetadata,
-        submission_finished_date: datetime.date,
+        submission_uploaded_date: datetime.date,
         ignore_fields: set[str] | None = None,
     ) -> SubmissionDiffCollection:
         """Compare a submission's current database state against fresh metadata.
 
         :param submission_id: Submission ID to look up.
         :param metadata: Parsed metadata from the submission's ``metadata.json``.
-        :param submission_finished_date: Date of submission upload finish
+        :param submission_uploaded_date: Date of submission upload finish
         :param ignore_fields: Field names to skip entirely during the comparison.
         :returns: A :class:`SubmissionDiffCollection` instance summarising all detected differences.
         """
@@ -1199,10 +1199,10 @@ class SubmissionDb:
         if ignore_fields is None:
             ignore_fields = set()
 
-        if isinstance(submission_finished_date, datetime.datetime):
-            submission_finished_date = submission_finished_date.date()
+        if isinstance(submission_uploaded_date, datetime.datetime):
+            submission_uploaded_date = submission_uploaded_date.date()
 
-        new_submission = Submission.from_metadata(submission_id, metadata, submission_finished_date)
+        new_submission = Submission.from_metadata(submission_id, metadata, submission_uploaded_date)
 
         return current_submission.diff(new_submission, ignore_fields)
 
@@ -1242,7 +1242,7 @@ class SubmissionDb:
         self,
         submission_id: str,
         metadata: GrzSubmissionMetadata,
-        submission_finished_date: datetime.date | None,
+        submission_uploaded_date: datetime.date | None,
         ignore_fields: set[str] | None = None,
     ) -> tuple[SubmissionDiffCollection, DonorsDiffCollection]:
         """
@@ -1255,20 +1255,20 @@ class SubmissionDb:
 
         :param submission_id: The unique identifier of the submission to be compared.
         :param metadata: The metadata of the submission to compare against.
-        :param submission_finished_date: The date when the submission process was finished.
+        :param submission_uploaded_date: The date when the submission process was finished.
             If None, the field will not be included in the comparison.
         :param ignore_fields: Optional set of field names to be ignored during the metadata comparison.
         :returns: A tuple containing the differences in the submission metadata and the corresponding donor entries.
         """
-        if submission_finished_date is None:
+        if submission_uploaded_date is None:
             # set arbitrary date if not provided
-            submission_finished_date = metadata.submission.submission_date
+            submission_uploaded_date = metadata.submission.submission_date
 
             # Add submission date to ignore fields
             ignore_fields = ignore_fields or set()
-            ignore_fields.add("submission_finished_date")
+            ignore_fields.add("submission_uploaded_date")
 
-        submission_diff = self._diff_metadata(submission_id, metadata, submission_finished_date, ignore_fields)
+        submission_diff = self._diff_metadata(submission_id, metadata, submission_uploaded_date, ignore_fields)
         donor_diff = self._diff_donors(submission_id, metadata)
         return submission_diff, donor_diff
 

--- a/packages/grz-db/src/grz_db/models/submission/__init__.py
+++ b/packages/grz-db/src/grz_db/models/submission/__init__.py
@@ -228,7 +228,7 @@ class Submission(SubmissionBase, table=True):
         cls,
         submission_id: str,
         metadata: GrzSubmissionMetadata,
-        submission_date: datetime.date | None,
+        submission_finished_date: datetime.date,
     ) -> Self:
         """Construct a Submission populated with values derived from parsed metadata.
 
@@ -241,11 +241,8 @@ class Submission(SubmissionBase, table=True):
         if isinstance(metadata_submission_date, datetime.datetime):
             metadata_submission_date = metadata_submission_date.date()
 
-        if isinstance(submission_date, datetime.datetime):
-            submission_date = submission_date.date()
-
-        resolved_submission_date = submission_date if submission_date is not None else metadata_submission_date
-        consent_date = resolved_submission_date if resolved_submission_date is not None else datetime.date.today()
+        if isinstance(submission_finished_date, datetime.datetime):
+            submission_finished_date = submission_finished_date.date()
 
         return cls.model_validate(
             {
@@ -259,9 +256,9 @@ class Submission(SubmissionBase, table=True):
                 "genomic_study_subtype": metadata.submission.genomic_study_subtype,
                 "pseudonym": metadata.submission.local_case_id,
                 "data_node_id": metadata.submission.genomic_data_center_id,
-                "consented": metadata.consents_to_research(date=consent_date),
+                "consented": metadata.consents_to_research(date=metadata_submission_date),
                 "submission_size": metadata.get_submission_size(),
-                "submission_date": resolved_submission_date,
+                "submission_date": submission_finished_date,
                 "submission_metadata": metadata.to_redacted_dict(),
             }
         )
@@ -459,15 +456,15 @@ class Donor(SQLModel, table=True):
         cls,
         submission_id: str,
         donor: MetadataDonor,
-        submission_date: datetime.date | None,
+        metadata_submission_date: datetime.date,
     ) -> Self:
         """Construct a Donor populated from parsed metadata.
 
-        :param submission_date: Resolved submission date used to evaluate research
-            consent at the time the submission was completed. Falls back to
-            ``datetime.date.today()`` only when no submission date is known.
+        :param submission_id: Submission ID.
+        :param donor: Donor metadata.
+        :param metadata_submission_date: Submission date from metadata.
+            Used to evaluate research consent at the time the submission was created.
         """
-        consent_date = submission_date if submission_date is not None else datetime.date.today()
         return cls.model_validate(
             dict(
                 submission_id=submission_id,
@@ -477,7 +474,7 @@ class Donor(SQLModel, table=True):
                 sequence_types={datum.sequence_type for datum in donor.lab_data},
                 sequence_subtypes={datum.sequence_subtype for datum in donor.lab_data},
                 mv_consented=donor.consents_to_mv(),
-                research_consented=donor.consents_to_research(date=consent_date),
+                research_consented=donor.consents_to_research(date=metadata_submission_date),
                 research_consent_missing_justifications={
                     consent.no_scope_justification
                     for consent in donor.research_consents
@@ -1210,7 +1207,6 @@ class SubmissionDb:
         self,
         submission_id: str,
         metadata: GrzSubmissionMetadata,
-        submission_date: datetime.date | None,
     ) -> DonorsDiffCollection:
         """Diff all donors in *metadata* against the current database state.
 
@@ -1224,13 +1220,10 @@ class SubmissionDb:
         metadata_submission_date = metadata.submission.submission_date
         if isinstance(metadata_submission_date, datetime.datetime):
             metadata_submission_date = metadata_submission_date.date()
-        if isinstance(submission_date, datetime.datetime):
-            submission_date = submission_date.date()
-        resolved_submission_date = submission_date if submission_date is not None else metadata_submission_date
 
         donors_in_db_submission = {donor.pseudonym: donor for donor in self.get_donors(submission_id=submission_id)}
         donors_in_metadata = {
-            (d := Donor.from_donor_metadata(submission_id, donor, resolved_submission_date)).pseudonym: d
+            (d := Donor.from_donor_metadata(submission_id, donor, metadata_submission_date)).pseudonym: d
             for donor in metadata.donors
         }
 

--- a/packages/grz-db/tests/test_should_qc.py
+++ b/packages/grz-db/tests/test_should_qc.py
@@ -79,7 +79,7 @@ def _add_submission_with_history(
     """
     db.add_submission(submission_id)
 
-    db.modify_submission(submission_id, "submission_date", str(submission_date.isoformat()))
+    db.modify_submission(submission_id, "submission_finished_date", str(submission_date.isoformat()))
     db.modify_submission(submission_id, "submission_type", SubmissionType.initial)
     db.modify_submission(submission_id, "submitter_id", submitter_id)
     db.modify_submission(submission_id, "basic_qc_passed", "true")
@@ -488,7 +488,7 @@ class TestQcStrategy:
         """Verify SubmissionTypeIsNoneError when submission_type is None."""
         submission_id = f"{SUBMITTER_ID}_2025-12-01_00000000"
         db.add_submission(submission_id)
-        db.modify_submission(submission_id, "submission_date", "2025-12-01")
+        db.modify_submission(submission_id, "submission_finished_date", "2025-12-01")
         db.modify_submission(submission_id, "basic_qc_passed", "true")
 
         with pytest.raises(SubmissionTypeIsNoneError):

--- a/packages/grz-db/tests/test_should_qc.py
+++ b/packages/grz-db/tests/test_should_qc.py
@@ -79,7 +79,7 @@ def _add_submission_with_history(
     """
     db.add_submission(submission_id)
 
-    db.modify_submission(submission_id, "submission_finished_date", str(submission_date.isoformat()))
+    db.modify_submission(submission_id, "submission_uploaded_date", str(submission_date.isoformat()))
     db.modify_submission(submission_id, "submission_type", SubmissionType.initial)
     db.modify_submission(submission_id, "submitter_id", submitter_id)
     db.modify_submission(submission_id, "basic_qc_passed", "true")
@@ -488,7 +488,7 @@ class TestQcStrategy:
         """Verify SubmissionTypeIsNoneError when submission_type is None."""
         submission_id = f"{SUBMITTER_ID}_2025-12-01_00000000"
         db.add_submission(submission_id)
-        db.modify_submission(submission_id, "submission_finished_date", "2025-12-01")
+        db.modify_submission(submission_id, "submission_uploaded_date", "2025-12-01")
         db.modify_submission(submission_id, "basic_qc_passed", "true")
 
         with pytest.raises(SubmissionTypeIsNoneError):

--- a/packages/grz-db/tests/test_submission.py
+++ b/packages/grz-db/tests/test_submission.py
@@ -83,7 +83,7 @@ def test_from_metadata_sets_fields_from_metadata(metadata: GrzSubmissionMetadata
     assert submission.genomic_study_subtype == metadata.submission.genomic_study_subtype
     assert submission.pseudonym == metadata.submission.local_case_id
     assert submission.data_node_id == metadata.submission.genomic_data_center_id
-    assert submission.submission_finished_date == explicit_date  # explicit date takes precedence
+    assert submission.submission_uploaded_date == explicit_date  # explicit date takes precedence
     assert submission.submission_size == metadata.get_submission_size()
     assert submission.submission_metadata == metadata.to_redacted_dict()
 

--- a/packages/grz-db/tests/test_submission.py
+++ b/packages/grz-db/tests/test_submission.py
@@ -83,7 +83,7 @@ def test_from_metadata_sets_fields_from_metadata(metadata: GrzSubmissionMetadata
     assert submission.genomic_study_subtype == metadata.submission.genomic_study_subtype
     assert submission.pseudonym == metadata.submission.local_case_id
     assert submission.data_node_id == metadata.submission.genomic_data_center_id
-    assert submission.submission_date == explicit_date  # explicit date takes precedence
+    assert submission.submission_finished_date == explicit_date  # explicit date takes precedence
     assert submission.submission_size == metadata.get_submission_size()
     assert submission.submission_metadata == metadata.to_redacted_dict()
 

--- a/packages/grz-db/tests/test_submission.py
+++ b/packages/grz-db/tests/test_submission.py
@@ -87,10 +87,6 @@ def test_from_metadata_sets_fields_from_metadata(metadata: GrzSubmissionMetadata
     assert submission.submission_size == metadata.get_submission_size()
     assert submission.submission_metadata == metadata.to_redacted_dict()
 
-    # --- explicit date is preferred over the metadata date ---
-    submission_fallback = Submission.from_metadata(SUBMISSION_ID, metadata, None)
-    assert submission_fallback.submission_date == metadata.submission.submission_date
-
     # --- system-managed fields must not be in model_fields_set ---
     system_fields = {"basic_qc_passed", "detailed_qc_passed", "selected_for_qc"}
     assert system_fields.isdisjoint(submission.model_fields_set), (

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -182,6 +182,13 @@ class Submission(StrictBaseModel):
     Name of the sequencing lab.
     """
 
+    @field_validator("submission_date", mode="before")
+    @classmethod
+    def _coerce_datetime_to_date(cls, value: Any) -> Any:
+        if isinstance(value, datetime):
+            return value.date()
+        return value
+
 
 class Gender(StrEnum):
     """

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -54,7 +54,7 @@ from grz_pydantic_models.submission.metadata import (
     SequenceSubtype,
     SequenceType,
 )
-from pydantic import Field
+from pydantic import Field, ValidationError
 from tqdm.auto import tqdm
 
 from ... import get_versions
@@ -698,20 +698,20 @@ def populate(  # noqa: C901, PLR0913
             "or use 'grzctl db submission modify' directly."
         ) from e
 
-    submission_finished_date = (
-        submission_date.date() if submission_date is not None else submission.submission_finished_date
+    submission_uploaded_date = (
+        submission_date.date() if submission_date is not None else submission.submission_uploaded_date
     )
     if submission_date is None:
         log.warning(
             "No submission date provided and submission date is missing in the database. "
             "Will use submission date from metadata.json..."
         )
-        submission_finished_date = metadata.submission.submission_date
+        submission_uploaded_date = metadata.submission.submission_date
 
     submission_diff, donors_diff = db_service.diff(
         submission_id,
         metadata,
-        submission_finished_date=submission_finished_date,
+        submission_uploaded_date=submission_uploaded_date,
         ignore_fields=set(ignore_field),
     )
 
@@ -941,6 +941,69 @@ def change_request(ctx: click.Context, submission_id: str, change_str: str, data
         raise click.ClickException(f"Failed to update submission state: {e}") from e
 
 
+def _research_consented_today(submission: Submission) -> bool | None:
+    """Research consent for the submission re-evaluated as of today.
+
+    Unlike the persisted ``consented`` field (evaluated at the submission date),
+    this recomputes consent from the stored redacted metadata using today's date.
+
+    :param submission: Submission whose stored metadata to evaluate.
+    :returns: ``True``/``False`` for the consent decision today, or ``None`` when
+        no metadata is stored (e.g. rows migrated without backpopulated metadata)
+        or when the stored metadata cannot be parsed.
+    """
+    if not submission.submission_metadata:
+        return None
+    try:
+        metadata = GrzSubmissionMetadata.model_validate(submission.submission_metadata)
+    except ValidationError:
+        log.debug("Could not parse stored metadata for submission %s to evaluate consent today.", submission.id)
+        return None
+    return metadata.consents_to_research(date=date.today())
+
+
+def _build_attribute_table(submission: Submission, research_consented_today: bool | None) -> rich.table.Table:
+    """Build the attribute table shown by ``submission show``.
+
+    :param submission: Submission to render.
+    :param research_consented_today: Research consent re-evaluated as of today
+        (see :func:`_research_consented_today`), or ``None`` when unavailable.
+    :returns: A populated rich table of submission attributes.
+    """
+    attribute_table = rich.table.Table(box=None)
+    attribute_table.add_column("Attribute", justify="right")
+    attribute_table.add_column("Value")
+    for label, attr_name in (
+        ("tanG", "tan_g"),
+        ("Pseudonym", "pseudonym"),
+        ("Submission Uploaded Date", "submission_uploaded_date"),
+        ("Submission Size", "submission_size"),
+        ("Submission Type", "submission_type"),
+        ("Submitter ID", "submitter_id"),
+        ("Data Node ID", "data_node_id"),
+        ("Disease Type", "disease_type"),
+        ("Genomic Study Type", "genomic_study_type"),
+        ("Genomic Study Subtype", "genomic_study_subtype"),
+        ("Basic QC Passed", "basic_qc_passed"),
+        ("Research consent (at submission)", "consented"),
+        ("Selected For QC", "selected_for_qc"),
+        ("Detailed QC Passed", "detailed_qc_passed"),
+    ):
+        attr = getattr(submission, attr_name)
+        attribute_table.add_row(
+            rich.text.Text(f"{label}", style="cyan"), rich.text.Text(str(attr)) if attr is not None else _TEXT_MISSING
+        )
+        if attr_name == "consented":
+            # Adjacent row: research consent re-evaluated as of today (recomputed from stored metadata).
+            attribute_table.add_row(
+                rich.text.Text("Research consent (today)", style="cyan"),
+                rich.text.Text(str(research_consented_today))
+                if research_consented_today is not None
+                else _TEXT_MISSING,
+            )
+    return attribute_table
+
+
 @submission.command("show")
 @click.argument("submission_id", type=str)
 @output_json
@@ -956,8 +1019,11 @@ def show(ctx: click.Context, submission_id: str, output_json: bool):
         console_err.print(f"[red]Error: Submission with ID '{submission_id}' not found.[/red]")
         raise click.Abort()
 
+    research_consented_today = _research_consented_today(submission)
+
     if output_json:
         submission_dict = submission.model_dump(mode="json")
+        submission_dict["research_consented_today"] = research_consented_today
         submission_dict["states"] = []
 
         for state_log in sorted(submission.states, key=lambda s: s.timestamp):
@@ -977,29 +1043,7 @@ def show(ctx: click.Context, submission_id: str, output_json: bool):
         sys.stdout.write("\n")
         return
 
-    attribute_table = rich.table.Table(box=None)
-    attribute_table.add_column("Attribute", justify="right")
-    attribute_table.add_column("Value")
-    for label, attr_name in (
-        ("tanG", "tan_g"),
-        ("Pseudonym", "pseudonym"),
-        ("Submission Date", "submission_finished_date"),
-        ("Submission Size", "submission_size"),
-        ("Submission Type", "submission_type"),
-        ("Submitter ID", "submitter_id"),
-        ("Data Node ID", "data_node_id"),
-        ("Disease Type", "disease_type"),
-        ("Genomic Study Type", "genomic_study_type"),
-        ("Genomic Study Subtype", "genomic_study_subtype"),
-        ("Basic QC Passed", "basic_qc_passed"),
-        ("Consented", "consented"),
-        ("Selected For QC", "selected_for_qc"),
-        ("Detailed QC Passed", "detailed_qc_passed"),
-    ):
-        attr = getattr(submission, attr_name)
-        attribute_table.add_row(
-            rich.text.Text(f"{label}", style="cyan"), rich.text.Text(str(attr)) if attr is not None else _TEXT_MISSING
-        )
+    attribute_table = _build_attribute_table(submission, research_consented_today)
 
     renderables: list[rich.console.RenderableType] = [rich.padding.Padding(attribute_table, (1, 0))]
     if submission.states:
@@ -1110,18 +1154,18 @@ def _backfill_submission(  # noqa: PLR0911, PLR0913
         return _BackfillResult.ERROR
 
     try:
-        # If submission_finished_date is not set in the DB, replace it with the one from metadata.json.
+        # If submission_uploaded_date is not set in the DB, replace it with the one from metadata.json.
         # This case is expected for submissions that were created before the submission_date field was added.
-        submission_finished_date = (
-            current_submission.submission_finished_date
-            if current_submission.submission_finished_date
+        submission_uploaded_date = (
+            current_submission.submission_uploaded_date
+            if current_submission.submission_uploaded_date
             else metadata.submission.submission_date
         )
 
         submission_diff, donors_diff = db_service.diff(
             submission_id,
             metadata,
-            submission_finished_date=submission_finished_date,
+            submission_uploaded_date=submission_uploaded_date,
             ignore_fields=ignore_fields or None,
         )
     except Exception as exc:
@@ -1223,7 +1267,7 @@ def backfill(  # noqa: PLR0913
         raise click.UsageError("--submission-id and --start-date/--end-date are mutually exclusive.")
 
     ignore_fields = set(ignore_field) | {
-        "submission_finished_date",
+        "submission_uploaded_date",
         "tan_g",
         "local_case_id",
     }

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -997,9 +997,7 @@ def _build_attribute_table(submission: Submission, research_consented_now: bool 
             # Adjacent row: research consent re-evaluated as of now (recomputed from stored metadata).
             attribute_table.add_row(
                 rich.text.Text("Research consent (now)", style="cyan"),
-                rich.text.Text(str(research_consented_now))
-                if research_consented_now is not None
-                else _TEXT_MISSING,
+                rich.text.Text(str(research_consented_now)) if research_consented_now is not None else _TEXT_MISSING,
             )
     return attribute_table
 

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -698,10 +698,18 @@ def populate(  # noqa: C901, PLR0913
             "or use 'grzctl db submission modify' directly."
         ) from e
 
+    submission_finished_date = submission_date.date() if submission_date is not None else submission.submission_date
+    if submission_date is None:
+        log.warning(
+            "No submission date provided and submission date is missing in the database. "
+            "Will use submission date from metadata.json..."
+        )
+        submission_finished_date = metadata.submission.submission_date
+
     submission_diff, donors_diff = db_service.diff(
         submission_id,
         metadata,
-        submission_date,
+        submission_finished_date=submission_finished_date,
         ignore_fields=set(ignore_field),
     )
 

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -698,7 +698,9 @@ def populate(  # noqa: C901, PLR0913
             "or use 'grzctl db submission modify' directly."
         ) from e
 
-    submission_finished_date = submission_date.date() if submission_date is not None else submission.submission_date
+    submission_finished_date = (
+        submission_date.date() if submission_date is not None else submission.submission_finished_date
+    )
     if submission_date is None:
         log.warning(
             "No submission date provided and submission date is missing in the database. "
@@ -981,7 +983,7 @@ def show(ctx: click.Context, submission_id: str, output_json: bool):
     for label, attr_name in (
         ("tanG", "tan_g"),
         ("Pseudonym", "pseudonym"),
-        ("Submission Date", "submission_date"),
+        ("Submission Date", "submission_finished_date"),
         ("Submission Size", "submission_size"),
         ("Submission Type", "submission_type"),
         ("Submitter ID", "submitter_id"),
@@ -1111,8 +1113,8 @@ def _backfill_submission(  # noqa: PLR0911, PLR0913
         # If submission_finished_date is not set in the DB, replace it with the one from metadata.json.
         # This case is expected for submissions that were created before the submission_date field was added.
         submission_finished_date = (
-            current_submission.submission_date
-            if current_submission.submission_date
+            current_submission.submission_finished_date
+            if current_submission.submission_finished_date
             else metadata.submission.submission_date
         )
 
@@ -1221,7 +1223,7 @@ def backfill(  # noqa: PLR0913
         raise click.UsageError("--submission-id and --start-date/--end-date are mutually exclusive.")
 
     ignore_fields = set(ignore_field) | {
-        "submission_date",
+        "submission_finished_date",
         "tan_g",
         "local_case_id",
     }

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -1100,10 +1100,18 @@ def _backfill_submission(  # noqa: PLR0911, PLR0913
         return _BackfillResult.ERROR
 
     try:
+        # If submission_finished_date is not set in the DB, replace it with the one from metadata.json.
+        # This case is expected for submissions that were created before the submission_date field was added.
+        submission_finished_date = (
+            current_submission.submission_date
+            if current_submission.submission_date
+            else metadata.submission.submission_date
+        )
+
         submission_diff, donors_diff = db_service.diff(
             submission_id,
             metadata,
-            submission_date=None,
+            submission_finished_date=submission_finished_date,
             ignore_fields=ignore_fields or None,
         )
     except Exception as exc:

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -941,14 +941,14 @@ def change_request(ctx: click.Context, submission_id: str, change_str: str, data
         raise click.ClickException(f"Failed to update submission state: {e}") from e
 
 
-def _research_consented_today(submission: Submission) -> bool | None:
-    """Research consent for the submission re-evaluated as of today.
+def _research_consented_now(submission: Submission) -> bool | None:
+    """Research consent for the submission re-evaluated as of now.
 
     Unlike the persisted ``consented`` field (evaluated at the submission date),
-    this recomputes consent from the stored redacted metadata using today's date.
+    this recomputes consent from the stored redacted metadata using the current date.
 
     :param submission: Submission whose stored metadata to evaluate.
-    :returns: ``True``/``False`` for the consent decision today, or ``None`` when
+    :returns: ``True``/``False`` for the consent decision now, or ``None`` when
         no metadata is stored (e.g. rows migrated without backpopulated metadata)
         or when the stored metadata cannot be parsed.
     """
@@ -957,17 +957,17 @@ def _research_consented_today(submission: Submission) -> bool | None:
     try:
         metadata = GrzSubmissionMetadata.model_validate(submission.submission_metadata)
     except ValidationError:
-        log.debug("Could not parse stored metadata for submission %s to evaluate consent today.", submission.id)
+        log.debug("Could not parse stored metadata for submission %s to evaluate consent now.", submission.id)
         return None
     return metadata.consents_to_research(date=date.today())
 
 
-def _build_attribute_table(submission: Submission, research_consented_today: bool | None) -> rich.table.Table:
+def _build_attribute_table(submission: Submission, research_consented_now: bool | None) -> rich.table.Table:
     """Build the attribute table shown by ``submission show``.
 
     :param submission: Submission to render.
-    :param research_consented_today: Research consent re-evaluated as of today
-        (see :func:`_research_consented_today`), or ``None`` when unavailable.
+    :param research_consented_now: Research consent re-evaluated as of now
+        (see :func:`_research_consented_now`), or ``None`` when unavailable.
     :returns: A populated rich table of submission attributes.
     """
     attribute_table = rich.table.Table(box=None)
@@ -994,11 +994,11 @@ def _build_attribute_table(submission: Submission, research_consented_today: boo
             rich.text.Text(f"{label}", style="cyan"), rich.text.Text(str(attr)) if attr is not None else _TEXT_MISSING
         )
         if attr_name == "consented":
-            # Adjacent row: research consent re-evaluated as of today (recomputed from stored metadata).
+            # Adjacent row: research consent re-evaluated as of now (recomputed from stored metadata).
             attribute_table.add_row(
-                rich.text.Text("Research consent (today)", style="cyan"),
-                rich.text.Text(str(research_consented_today))
-                if research_consented_today is not None
+                rich.text.Text("Research consent (now)", style="cyan"),
+                rich.text.Text(str(research_consented_now))
+                if research_consented_now is not None
                 else _TEXT_MISSING,
             )
     return attribute_table
@@ -1019,11 +1019,11 @@ def show(ctx: click.Context, submission_id: str, output_json: bool):
         console_err.print(f"[red]Error: Submission with ID '{submission_id}' not found.[/red]")
         raise click.Abort()
 
-    research_consented_today = _research_consented_today(submission)
+    research_consented_now = _research_consented_now(submission)
 
     if output_json:
         submission_dict = submission.model_dump(mode="json")
-        submission_dict["research_consented_today"] = research_consented_today
+        submission_dict["research_consented_now"] = research_consented_now
         submission_dict["states"] = []
 
         for state_log in sorted(submission.states, key=lambda s: s.timestamp):
@@ -1043,7 +1043,7 @@ def show(ctx: click.Context, submission_id: str, output_json: bool):
         sys.stdout.write("\n")
         return
 
-    attribute_table = _build_attribute_table(submission, research_consented_today)
+    attribute_table = _build_attribute_table(submission, research_consented_now)
 
     renderables: list[rich.console.RenderableType] = [rich.padding.Padding(attribute_table, (1, 0))]
     if submission.states:

--- a/packages/grzctl/src/grzctl/commands/db/tui.py
+++ b/packages/grzctl/src/grzctl/commands/db/tui.py
@@ -120,7 +120,7 @@ class SubmissionCountByDetailedQCByLETable(Static):
         with database._get_session() as session:
             statement = (
                 select(  # type: ignore[type-var]
-                    Submission.submitter_id, Submission.submission_finished_date, Submission.detailed_qc_passed
+                    Submission.submitter_id, Submission.submission_uploaded_date, Submission.detailed_qc_passed
                 )
                 .where(Submission.submission_type == SubmissionType.initial)
                 .where(Submission.basic_qc_passed)  # type: ignore[arg-type]
@@ -238,7 +238,7 @@ class SearchResultsDataTable(DataTable):
                 Submission.id == latest_state_per_submission.c.submission_id,  # type: ignore[arg-type]
                 isouter=True,
             ).order_by(
-                sqlfn.coalesce(latest_state_per_submission.c.timestamp, Submission.submission_finished_date)
+                sqlfn.coalesce(latest_state_per_submission.c.timestamp, Submission.submission_uploaded_date)
                 .desc()
                 .nulls_first()
             )

--- a/packages/grzctl/src/grzctl/commands/db/tui.py
+++ b/packages/grzctl/src/grzctl/commands/db/tui.py
@@ -120,7 +120,7 @@ class SubmissionCountByDetailedQCByLETable(Static):
         with database._get_session() as session:
             statement = (
                 select(  # type: ignore[type-var]
-                    Submission.submitter_id, Submission.submission_date, Submission.detailed_qc_passed
+                    Submission.submitter_id, Submission.submission_finished_date, Submission.detailed_qc_passed
                 )
                 .where(Submission.submission_type == SubmissionType.initial)
                 .where(Submission.basic_qc_passed)  # type: ignore[arg-type]
@@ -238,7 +238,9 @@ class SearchResultsDataTable(DataTable):
                 Submission.id == latest_state_per_submission.c.submission_id,  # type: ignore[arg-type]
                 isouter=True,
             ).order_by(
-                sqlfn.coalesce(latest_state_per_submission.c.timestamp, Submission.submission_date).desc().nulls_first()
+                sqlfn.coalesce(latest_state_per_submission.c.timestamp, Submission.submission_finished_date)
+                .desc()
+                .nulls_first()
             )
             if isinstance(limit, int) and limit >= 0:
                 statement = statement.limit(limit)

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -106,7 +106,7 @@ def _generate_pruefbericht_from_database(
 
     # Check if submission has the required fields populated
     required_fields = [
-        "submission_date",
+        "submission_finished_date",
         "submission_type",
         "tan_g",
         "submitter_id",
@@ -137,7 +137,7 @@ def _generate_pruefbericht_from_database(
     # Generate the Prüfbericht
     return Pruefbericht(
         SubmittedCase=SubmittedCase(
-            submissionDate=submission.submission_date,
+            submissionDate=submission.submission_finished_date,
             submissionType=submission.submission_type,
             tan=submission.tan_g,
             submitterId=submission.submitter_id,

--- a/packages/grzctl/src/grzctl/commands/pruefbericht.py
+++ b/packages/grzctl/src/grzctl/commands/pruefbericht.py
@@ -106,7 +106,7 @@ def _generate_pruefbericht_from_database(
 
     # Check if submission has the required fields populated
     required_fields = [
-        "submission_finished_date",
+        "submission_uploaded_date",
         "submission_type",
         "tan_g",
         "submitter_id",
@@ -137,7 +137,7 @@ def _generate_pruefbericht_from_database(
     # Generate the Prüfbericht
     return Pruefbericht(
         SubmittedCase=SubmittedCase(
-            submissionDate=submission.submission_finished_date,
+            submissionDate=submission.submission_uploaded_date,
             submissionType=submission.submission_type,
             tan=submission.tan_g,
             submitterId=submission.submitter_id,

--- a/packages/grzctl/src/grzctl/commands/report.py
+++ b/packages/grzctl/src/grzctl/commands/report.py
@@ -127,7 +127,7 @@ def _get_consent_revocations(
     """
     subquery_quarter_submissions = (
         select(Submission)
-        .where(Submission.submission_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+        .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
         .subquery()
     )
     query_quarter_donors = (
@@ -138,7 +138,7 @@ def _get_consent_revocations(
             Donor,
         )
         .join(subquery_quarter_submissions, subquery_quarter_submissions.c.id == Donor.submission_id)
-        .order_by(subquery_quarter_submissions.c.submission_date)
+        .order_by(subquery_quarter_submissions.c.submission_finished_date)
     )
     quarter_donors = session.exec(query_quarter_donors).all()
 
@@ -168,7 +168,9 @@ def _get_consent_revocations(
         relation_by_donor[(data_node_id, submitter_id, pseudonym)] = donor.relation
 
     # now query before the current quarter
-    subquery_prior_submissions = select(Submission).where(Submission.submission_date < quarter_start_date).subquery()
+    subquery_prior_submissions = (
+        select(Submission).where(Submission.submission_finished_date < quarter_start_date).subquery()
+    )
     query_prior_donors = (
         select(
             subquery_prior_submissions.c.data_node_id,
@@ -177,7 +179,7 @@ def _get_consent_revocations(
             Donor,
         )
         .join(subquery_prior_submissions, subquery_prior_submissions.c.id == Donor.submission_id)
-        .order_by(subquery_prior_submissions.c.submission_date)
+        .order_by(subquery_prior_submissions.c.submission_finished_date)
     )
     prior_donors = session.exec(query_prior_donors).all()
 
@@ -234,7 +236,7 @@ def _dump_overview_report(output_path: Path, database: SubmissionDb, year: int, 
         # number_of_end-to-end_tests
         stmt_number_of_end_to_end_tests = (
             select(Submission.data_node_id, Submission.submitter_id, sqlfn.count(1))
-            .where(Submission.submission_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
             .where(Submission.submission_type == SubmissionType.test)
             .group_by(Submission.data_node_id, Submission.submitter_id)  # type: ignore[arg-type]
         )
@@ -246,7 +248,7 @@ def _dump_overview_report(output_path: Path, database: SubmissionDb, year: int, 
         # number_of_passed_end-to-end_tests
         stmt_number_of_passed_end_to_end_tests = (
             select(Submission.data_node_id, Submission.submitter_id, sqlfn.count(1))
-            .where(Submission.submission_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
             .where(Submission.submission_type == SubmissionType.test)
             .filter(Submission.basic_qc_passed)  # type: ignore[arg-type]
             .group_by(Submission.data_node_id, Submission.submitter_id)  # type: ignore[arg-type]
@@ -260,7 +262,7 @@ def _dump_overview_report(output_path: Path, database: SubmissionDb, year: int, 
         # number_of_submissions_*
         stmt_number_of_submissions = (
             select(Submission.data_node_id, Submission.submitter_id, Submission.genomic_study_type, sqlfn.count(1))
-            .where(Submission.submission_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
             .group_by(Submission.data_node_id, Submission.submitter_id, Submission.genomic_study_type)  # type: ignore[arg-type]
         )
         number_of_submissions_by_genomic_study_type = {
@@ -275,7 +277,7 @@ def _dump_overview_report(output_path: Path, database: SubmissionDb, year: int, 
         # number_of_failed_qcs
         stmt_number_of_failed_qcs = (
             select(Submission.data_node_id, Submission.submitter_id, sqlfn.count(1))
-            .where(Submission.submission_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
             .filter(sa.not_(Submission.detailed_qc_passed))  # type: ignore[call-overload]
             .group_by(Submission.data_node_id, Submission.submitter_id)  # type: ignore[arg-type]
         )
@@ -292,7 +294,7 @@ def _dump_overview_report(output_path: Path, database: SubmissionDb, year: int, 
         # number_of_deletions
         stmt_number_of_deletions = (
             select(Submission.data_node_id, Submission.submitter_id, sqlfn.count(1))
-            .where(Submission.submission_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
             .join(
                 select(ChangeRequestLog.submission_id)
                 .where(ChangeRequestLog.change == ChangeRequestEnum.DELETE)
@@ -377,7 +379,7 @@ def _dump_dataset_report(
 
     with database._get_session() as session:
         query_quarter_submissions = (
-            select(Submission).where(Submission.submission_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            select(Submission).where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
         )
         submissions = session.exec(query_quarter_submissions).all()
 
@@ -490,7 +492,7 @@ def _dump_qc_report(
     with database._get_session() as session:
         query_submissions_that_failed_detailed_qc = (
             select(Submission)
-            .where(Submission.submission_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
             .filter(sa.not_(Submission.detailed_qc_passed))  # type: ignore[call-overload]
         )
         submissions_that_failed_detailed_qc = session.exec(query_submissions_that_failed_detailed_qc).all()
@@ -557,7 +559,7 @@ def _dump_qc_report(
                     quarter,
                     year,
                     submission.submitter_id,
-                    submission.submission_date,
+                    submission.submission_finished_date,
                     submission.submission_type,
                     submission.disease_type,
                     submission.genomic_study_type,

--- a/packages/grzctl/src/grzctl/commands/report.py
+++ b/packages/grzctl/src/grzctl/commands/report.py
@@ -127,7 +127,7 @@ def _get_consent_revocations(
     """
     subquery_quarter_submissions = (
         select(Submission)
-        .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+        .where(Submission.submission_uploaded_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
         .subquery()
     )
     query_quarter_donors = (
@@ -138,7 +138,7 @@ def _get_consent_revocations(
             Donor,
         )
         .join(subquery_quarter_submissions, subquery_quarter_submissions.c.id == Donor.submission_id)
-        .order_by(subquery_quarter_submissions.c.submission_finished_date)
+        .order_by(subquery_quarter_submissions.c.submission_uploaded_date)
     )
     quarter_donors = session.exec(query_quarter_donors).all()
 
@@ -169,7 +169,7 @@ def _get_consent_revocations(
 
     # now query before the current quarter
     subquery_prior_submissions = (
-        select(Submission).where(Submission.submission_finished_date < quarter_start_date).subquery()
+        select(Submission).where(Submission.submission_uploaded_date < quarter_start_date).subquery()
     )
     query_prior_donors = (
         select(
@@ -179,7 +179,7 @@ def _get_consent_revocations(
             Donor,
         )
         .join(subquery_prior_submissions, subquery_prior_submissions.c.id == Donor.submission_id)
-        .order_by(subquery_prior_submissions.c.submission_finished_date)
+        .order_by(subquery_prior_submissions.c.submission_uploaded_date)
     )
     prior_donors = session.exec(query_prior_donors).all()
 
@@ -236,7 +236,7 @@ def _dump_overview_report(output_path: Path, database: SubmissionDb, year: int, 
         # number_of_end-to-end_tests
         stmt_number_of_end_to_end_tests = (
             select(Submission.data_node_id, Submission.submitter_id, sqlfn.count(1))
-            .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            .where(Submission.submission_uploaded_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
             .where(Submission.submission_type == SubmissionType.test)
             .group_by(Submission.data_node_id, Submission.submitter_id)  # type: ignore[arg-type]
         )
@@ -248,7 +248,7 @@ def _dump_overview_report(output_path: Path, database: SubmissionDb, year: int, 
         # number_of_passed_end-to-end_tests
         stmt_number_of_passed_end_to_end_tests = (
             select(Submission.data_node_id, Submission.submitter_id, sqlfn.count(1))
-            .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            .where(Submission.submission_uploaded_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
             .where(Submission.submission_type == SubmissionType.test)
             .filter(Submission.basic_qc_passed)  # type: ignore[arg-type]
             .group_by(Submission.data_node_id, Submission.submitter_id)  # type: ignore[arg-type]
@@ -262,7 +262,7 @@ def _dump_overview_report(output_path: Path, database: SubmissionDb, year: int, 
         # number_of_submissions_*
         stmt_number_of_submissions = (
             select(Submission.data_node_id, Submission.submitter_id, Submission.genomic_study_type, sqlfn.count(1))
-            .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            .where(Submission.submission_uploaded_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
             .group_by(Submission.data_node_id, Submission.submitter_id, Submission.genomic_study_type)  # type: ignore[arg-type]
         )
         number_of_submissions_by_genomic_study_type = {
@@ -277,7 +277,7 @@ def _dump_overview_report(output_path: Path, database: SubmissionDb, year: int, 
         # number_of_failed_qcs
         stmt_number_of_failed_qcs = (
             select(Submission.data_node_id, Submission.submitter_id, sqlfn.count(1))
-            .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            .where(Submission.submission_uploaded_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
             .filter(sa.not_(Submission.detailed_qc_passed))  # type: ignore[call-overload]
             .group_by(Submission.data_node_id, Submission.submitter_id)  # type: ignore[arg-type]
         )
@@ -294,7 +294,7 @@ def _dump_overview_report(output_path: Path, database: SubmissionDb, year: int, 
         # number_of_deletions
         stmt_number_of_deletions = (
             select(Submission.data_node_id, Submission.submitter_id, sqlfn.count(1))
-            .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            .where(Submission.submission_uploaded_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
             .join(
                 select(ChangeRequestLog.submission_id)
                 .where(ChangeRequestLog.change == ChangeRequestEnum.DELETE)
@@ -379,7 +379,7 @@ def _dump_dataset_report(
 
     with database._get_session() as session:
         query_quarter_submissions = (
-            select(Submission).where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            select(Submission).where(Submission.submission_uploaded_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
         )
         submissions = session.exec(query_quarter_submissions).all()
 
@@ -492,7 +492,7 @@ def _dump_qc_report(
     with database._get_session() as session:
         query_submissions_that_failed_detailed_qc = (
             select(Submission)
-            .where(Submission.submission_finished_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+            .where(Submission.submission_uploaded_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
             .filter(sa.not_(Submission.detailed_qc_passed))  # type: ignore[call-overload]
         )
         submissions_that_failed_detailed_qc = session.exec(query_submissions_that_failed_detailed_qc).all()
@@ -559,7 +559,7 @@ def _dump_qc_report(
                     quarter,
                     year,
                     submission.submitter_id,
-                    submission.submission_finished_date,
+                    submission.submission_uploaded_date,
                     submission.submission_type,
                     submission.disease_type,
                     submission.genomic_study_type,

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -26,7 +26,7 @@ from moto import mock_aws
 
 BUCKET = "test-backfill-bucket"
 REGION = "us-east-1"
-IGNORE_FIELDS = {"submission_finished_date", "tan_g", "pseudonym"}
+IGNORE_FIELDS = {"submission_uploaded_date", "tan_g", "pseudonym"}
 DIFFERENT_TAN_G = "b" * 64
 DIFFERENT_PSEUDONYM = "different-pseudonym"
 DIFFERENT_DATE = datetime.date(1999, 1, 1)
@@ -84,7 +84,7 @@ def _put_metadata(s3_client: Any, submission_id: str, metadata: GrzSubmissionMet
 def _populate_full_row(db: SubmissionDb, submission_id: str, metadata: GrzSubmissionMetadata) -> Submission:
     """Persist a fully-populated row by running the same diff/commit path the production code uses."""
     db.add_submission(submission_id)
-    submission_diff, donors_diff = db.diff(submission_id, metadata, submission_finished_date=None)
+    submission_diff, donors_diff = db.diff(submission_id, metadata, submission_uploaded_date=None)
     db.commit_changes(submission_id, submission_diff, donors_diff)
     return db.get_submission(submission_id)
 
@@ -239,7 +239,7 @@ def test_backfill_submission_force_does_not_overwrite_ignore_fields(
 ) -> None:
     """Even with --force, the hard-coded ignore_fields are not overwritten by re-derived metadata."""
     current = db.add_submission(submission_id)
-    current.submission_finished_date = DIFFERENT_DATE
+    current.submission_uploaded_date = DIFFERENT_DATE
     current.tan_g = DIFFERENT_TAN_G
     current.pseudonym = DIFFERENT_PSEUDONYM
     db.update_submission(current)
@@ -261,7 +261,7 @@ def test_backfill_submission_force_does_not_overwrite_ignore_fields(
 
     assert result == _BackfillResult.UPDATED
     persisted = db.get_submission(submission_id)
-    assert persisted.submission_finished_date == DIFFERENT_DATE
+    assert persisted.submission_uploaded_date == DIFFERENT_DATE
     assert persisted.tan_g == DIFFERENT_TAN_G
     assert persisted.pseudonym == DIFFERENT_PSEUDONYM
     assert persisted.submission_size == metadata.get_submission_size()

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -84,7 +84,7 @@ def _put_metadata(s3_client: Any, submission_id: str, metadata: GrzSubmissionMet
 def _populate_full_row(db: SubmissionDb, submission_id: str, metadata: GrzSubmissionMetadata) -> Submission:
     """Persist a fully-populated row by running the same diff/commit path the production code uses."""
     db.add_submission(submission_id)
-    submission_diff, donors_diff = db.diff(submission_id, metadata, submission_date=None)
+    submission_diff, donors_diff = db.diff(submission_id, metadata, submission_finished_date=None)
     db.commit_changes(submission_id, submission_diff, donors_diff)
     return db.get_submission(submission_id)
 

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -26,7 +26,7 @@ from moto import mock_aws
 
 BUCKET = "test-backfill-bucket"
 REGION = "us-east-1"
-IGNORE_FIELDS = {"submission_date", "tan_g", "pseudonym"}
+IGNORE_FIELDS = {"submission_finished_date", "tan_g", "pseudonym"}
 DIFFERENT_TAN_G = "b" * 64
 DIFFERENT_PSEUDONYM = "different-pseudonym"
 DIFFERENT_DATE = datetime.date(1999, 1, 1)
@@ -239,7 +239,7 @@ def test_backfill_submission_force_does_not_overwrite_ignore_fields(
 ) -> None:
     """Even with --force, the hard-coded ignore_fields are not overwritten by re-derived metadata."""
     current = db.add_submission(submission_id)
-    current.submission_date = DIFFERENT_DATE
+    current.submission_finished_date = DIFFERENT_DATE
     current.tan_g = DIFFERENT_TAN_G
     current.pseudonym = DIFFERENT_PSEUDONYM
     db.update_submission(current)
@@ -261,7 +261,7 @@ def test_backfill_submission_force_does_not_overwrite_ignore_fields(
 
     assert result == _BackfillResult.UPDATED
     persisted = db.get_submission(submission_id)
-    assert persisted.submission_date == DIFFERENT_DATE
+    assert persisted.submission_finished_date == DIFFERENT_DATE
     assert persisted.tan_g == DIFFERENT_TAN_G
     assert persisted.pseudonym == DIFFERENT_PSEUDONYM
     assert persisted.submission_size == metadata.get_submission_size()

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -120,7 +120,7 @@ def test_populate(blank_database_config_path: Path, test_metadata_path: Path):
 
     submission = db.get_submission(metadata.submission_id)
     assert submission.pseudonym == metadata.submission.local_case_id
-    assert submission.consented == metadata.consents_to_research(date(2026, 1, 1))
+    assert submission.consented == metadata.consents_to_research(metadata.submission.submission_date)
 
     # check that the consent records were populated
     meta_father = metadata.donors[1]
@@ -729,7 +729,7 @@ def test_submission_show_json(blank_database_config_path: Path, test_metadata_pa
         "coverage_type": metadata.submission.coverage_type,
         "disease_type": metadata.submission.disease_type,
         "basic_qc_passed": None,
-        "consented": metadata.consents_to_research(date=date.today()),
+        "consented": metadata.consents_to_research(date=metadata.submission.submission_date),
         "selected_for_qc": None,
         "detailed_qc_passed": None,
         "genomic_study_type": metadata.submission.genomic_study_type,

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -169,7 +169,7 @@ def test_populate_date(blank_database_config_path: Path, test_metadata_path: Pat
     db = SubmissionDb(db_url=config.db.database_url, author=None)
 
     submission = db.get_submission(metadata.submission_id)
-    assert submission.submission_date == changed_date
+    assert submission.submission_finished_date == changed_date
 
 
 def test_populate_redacted(tmp_path: Path, blank_database_config_path: Path, test_metadata_path: Path):
@@ -297,7 +297,7 @@ def test_repopulate(blank_database_config_path: Path, tmp_path: Path, test_metad
     assert donors_s1[1].research_consent_missing_justifications == {"other patient-related reason"}
 
     submission_s1 = db.get_submission(metadata_s1.submission_id)
-    assert submission_s1.submission_date == changed_date
+    assert submission_s1.submission_finished_date == changed_date
 
     donors_s2 = sorted(db.get_donors(metadata_s2.submission_id), key=attrgetter("pseudonym"))
     assert len(donors_s2) == 2, "Expected two donors in submission 2"
@@ -668,7 +668,8 @@ def test_list_sort(blank_database_config_path: Path):
 
         if (submission_date := submission.get("date", None)) is not None:
             result_modify = runner.invoke(
-                cli, [*args_common, "submission", "modify", submission["id"], "submission_date", submission_date]
+                cli,
+                [*args_common, "submission", "modify", submission["id"], "submission_finished_date", submission_date],
             )
             assert result_modify.exit_code == 0, result_modify.stderr
 
@@ -718,7 +719,7 @@ def test_submission_show_json(blank_database_config_path: Path, test_metadata_pa
         "id": metadata.submission_id,
         "tan_g": metadata.submission.tan_g,
         "pseudonym": metadata.submission.local_case_id,
-        "submission_date": metadata.submission.submission_date.isoformat()
+        "submission_finished_date": metadata.submission.submission_date.isoformat()
         if metadata.submission.submission_date
         else None,
         "submission_size": metadata.get_submission_size(),

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -169,7 +169,7 @@ def test_populate_date(blank_database_config_path: Path, test_metadata_path: Pat
     db = SubmissionDb(db_url=config.db.database_url, author=None)
 
     submission = db.get_submission(metadata.submission_id)
-    assert submission.submission_finished_date == changed_date
+    assert submission.submission_uploaded_date == changed_date
 
 
 def test_populate_redacted(tmp_path: Path, blank_database_config_path: Path, test_metadata_path: Path):
@@ -297,7 +297,7 @@ def test_repopulate(blank_database_config_path: Path, tmp_path: Path, test_metad
     assert donors_s1[1].research_consent_missing_justifications == {"other patient-related reason"}
 
     submission_s1 = db.get_submission(metadata_s1.submission_id)
-    assert submission_s1.submission_finished_date == changed_date
+    assert submission_s1.submission_uploaded_date == changed_date
 
     donors_s2 = sorted(db.get_donors(metadata_s2.submission_id), key=attrgetter("pseudonym"))
     assert len(donors_s2) == 2, "Expected two donors in submission 2"
@@ -669,7 +669,7 @@ def test_list_sort(blank_database_config_path: Path):
         if (submission_date := submission.get("date", None)) is not None:
             result_modify = runner.invoke(
                 cli,
-                [*args_common, "submission", "modify", submission["id"], "submission_finished_date", submission_date],
+                [*args_common, "submission", "modify", submission["id"], "submission_uploaded_date", submission_date],
             )
             assert result_modify.exit_code == 0, result_modify.stderr
 
@@ -719,7 +719,7 @@ def test_submission_show_json(blank_database_config_path: Path, test_metadata_pa
         "id": metadata.submission_id,
         "tan_g": metadata.submission.tan_g,
         "pseudonym": metadata.submission.local_case_id,
-        "submission_finished_date": metadata.submission.submission_date.isoformat()
+        "submission_uploaded_date": metadata.submission.submission_date.isoformat()
         if metadata.submission.submission_date
         else None,
         "submission_size": metadata.get_submission_size(),
@@ -731,6 +731,7 @@ def test_submission_show_json(blank_database_config_path: Path, test_metadata_pa
         "disease_type": metadata.submission.disease_type,
         "basic_qc_passed": None,
         "consented": metadata.consents_to_research(date=metadata.submission.submission_date),
+        "research_consented_today": metadata.consents_to_research(date=date.today()),
         "selected_for_qc": None,
         "detailed_qc_passed": None,
         "genomic_study_type": metadata.submission.genomic_study_type,
@@ -1113,3 +1114,5 @@ def test_submission_show_json_includes_failure_reason(blank_database_config_path
     parsed = json.loads(result_show.stdout)
     error_state = next(s for s in parsed["states"] if s["state"] == "Error")
     assert error_state["failure_reason"] == "decryption_error"
+    # No metadata stored for this submission -> today's research consent cannot be evaluated.
+    assert parsed["research_consented_today"] is None

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -731,7 +731,7 @@ def test_submission_show_json(blank_database_config_path: Path, test_metadata_pa
         "disease_type": metadata.submission.disease_type,
         "basic_qc_passed": None,
         "consented": metadata.consents_to_research(date=metadata.submission.submission_date),
-        "research_consented_today": metadata.consents_to_research(date=date.today()),
+        "research_consented_now": metadata.consents_to_research(date=date.today()),
         "selected_for_qc": None,
         "detailed_qc_passed": None,
         "genomic_study_type": metadata.submission.genomic_study_type,
@@ -1114,5 +1114,5 @@ def test_submission_show_json_includes_failure_reason(blank_database_config_path
     parsed = json.loads(result_show.stdout)
     error_state = next(s for s in parsed["states"] if s["state"] == "Error")
     assert error_state["failure_reason"] == "decryption_error"
-    # No metadata stored for this submission -> today's research consent cannot be evaluated.
-    assert parsed["research_consented_today"] is None
+    # No metadata stored for this submission -> current research consent cannot be evaluated.
+    assert parsed["research_consented_now"] is None

--- a/packages/grzctl/tests/cli/test_report.py
+++ b/packages/grzctl/tests/cli/test_report.py
@@ -413,7 +413,7 @@ def test_quarterly_migrated_database(blank_database_config_path: Path, tmp_path:
                 "tan_g": tan_g,
                 "pseudonym": pseudonym,
                 "id": submission_id,
-                "submission_finished_date": submission_date,
+                "submission_uploaded_date": submission_date,
                 "submission_type": "initial",
                 "submitter_id": submitter_id,
                 "data_node_id": "GRZXYZ123",

--- a/packages/grzctl/tests/cli/test_report.py
+++ b/packages/grzctl/tests/cli/test_report.py
@@ -413,7 +413,7 @@ def test_quarterly_migrated_database(blank_database_config_path: Path, tmp_path:
                 "tan_g": tan_g,
                 "pseudonym": pseudonym,
                 "id": submission_id,
-                "submission_date": submission_date,
+                "submission_finished_date": submission_date,
                 "submission_type": "initial",
                 "submitter_id": submitter_id,
                 "data_node_id": "GRZXYZ123",

--- a/tests/cli/test_pruefbericht.py
+++ b/tests/cli/test_pruefbericht.py
@@ -376,7 +376,7 @@ def test_generate_from_database(temp_pruefbericht_config_file_path, pruefbericht
 
     db.add_submission(TEST_SUBMISSION_ID)
     # Populate submission fields to match the mock data used in other tests
-    db.modify_submission(TEST_SUBMISSION_ID, "submission_date", datetime.date(2024, 7, 15))
+    db.modify_submission(TEST_SUBMISSION_ID, "submission_finished_date", datetime.date(2024, 7, 15))
     db.modify_submission(TEST_SUBMISSION_ID, "submission_type", SubmissionType.test)
     db.modify_submission(
         TEST_SUBMISSION_ID, "tan_g", "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000"
@@ -522,7 +522,7 @@ def test_generate_from_database_no_index_donor(pruefbericht_db_config):
     db.add_submission(TEST_SUBMISSION_ID)
 
     # Populate all required fields (matching the pattern from test_generate_from_database)
-    db.modify_submission(TEST_SUBMISSION_ID, "submission_date", datetime.date(2024, 7, 15))
+    db.modify_submission(TEST_SUBMISSION_ID, "submission_finished_date", datetime.date(2024, 7, 15))
     db.modify_submission(TEST_SUBMISSION_ID, "submission_type", SubmissionType.test)
     db.modify_submission(
         TEST_SUBMISSION_ID, "tan_g", "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000"

--- a/tests/cli/test_pruefbericht.py
+++ b/tests/cli/test_pruefbericht.py
@@ -376,7 +376,7 @@ def test_generate_from_database(temp_pruefbericht_config_file_path, pruefbericht
 
     db.add_submission(TEST_SUBMISSION_ID)
     # Populate submission fields to match the mock data used in other tests
-    db.modify_submission(TEST_SUBMISSION_ID, "submission_finished_date", datetime.date(2024, 7, 15))
+    db.modify_submission(TEST_SUBMISSION_ID, "submission_uploaded_date", datetime.date(2024, 7, 15))
     db.modify_submission(TEST_SUBMISSION_ID, "submission_type", SubmissionType.test)
     db.modify_submission(
         TEST_SUBMISSION_ID, "tan_g", "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000"
@@ -522,7 +522,7 @@ def test_generate_from_database_no_index_donor(pruefbericht_db_config):
     db.add_submission(TEST_SUBMISSION_ID)
 
     # Populate all required fields (matching the pattern from test_generate_from_database)
-    db.modify_submission(TEST_SUBMISSION_ID, "submission_finished_date", datetime.date(2024, 7, 15))
+    db.modify_submission(TEST_SUBMISSION_ID, "submission_uploaded_date", datetime.date(2024, 7, 15))
     db.modify_submission(TEST_SUBMISSION_ID, "submission_type", SubmissionType.test)
     db.modify_submission(
         TEST_SUBMISSION_ID, "tan_g", "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000"


### PR DESCRIPTION
`Submission.consented` and `Donor.research_consented` were computed via `consents_to_research(date=datetime.date.today())`, so consent evaluation depended on when an operator ran `grzctl db populate`/`db backfill` instead of when the submission was made. For consent provisions with `start`/`end` windows, this can flip the boolean between runs.

This fix sharpens the implementation: 
- Use the submission date provided from `metadata` to determine the research-consent boolean for the DB
- Ensure to re-use the submission-finished date from DB during backfill
- Migrate database: Rename `submission_date` column to `submission_finished_date` for clarification

This should not impact anything in practice as it is quite unlikely that there are already submissions running out of consent these days.

Fixes #522.
