### PR TITLE
fix(grz_common): handling of abort in multipart uploads

### DIFF
--- a/packages/grz-common/src/grz_common/pipeline/components/__init__.py
+++ b/packages/grz-common/src/grz_common/pipeline/components/__init__.py
@@ -117,9 +117,10 @@ class Pipeable:
         if not isinstance(self, Readable):
             raise TypeError(f"Cannot drive pipeline: {type(self)} is not Readable.")
 
-        # Drive the sink as a transaction: its __exit__ commits on clean exit and aborts on
-        # error. self.close() runs the deferred validators; if they raise, it surfaces inside
-        # the sink's __exit__ -> abort (no committed partial object, no dangling upload).
+        # Drive everything through the destination's context manager: it finalizes the write
+        # on a clean exit and aborts it on error. Close the source inside the block so that a
+        # validation failure there also triggers the abort, rather than leaving a half-uploaded
+        # object behind.
         with other:
             try:
                 shutil.copyfileobj(self, other, length=READ_CHUNK_SIZE)

--- a/packages/grz-common/src/grz_common/pipeline/components/__init__.py
+++ b/packages/grz-common/src/grz_common/pipeline/components/__init__.py
@@ -117,14 +117,14 @@ class Pipeable:
         if not isinstance(self, Readable):
             raise TypeError(f"Cannot drive pipeline: {type(self)} is not Readable.")
 
-        try:
-            shutil.copyfileobj(self, other, length=READ_CHUNK_SIZE)
-        finally:
-            # Ensure close propagates down the whole chain to join threads and flush buffers
-            if hasattr(self, "close"):
+        # Drive the sink as a transaction: its __exit__ commits on clean exit and aborts on
+        # error. self.close() runs the deferred validators; if they raise, it surfaces inside
+        # the sink's __exit__ -> abort (no committed partial object, no dangling upload).
+        with other:
+            try:
+                shutil.copyfileobj(self, other, length=READ_CHUNK_SIZE)
+            finally:
                 self.close()
-            # Sinks like open files or DevNullSink need closing to ensure flush
-            other.close()
         return other
 
 

--- a/packages/grz-common/src/grz_common/pipeline/components/__init__.py
+++ b/packages/grz-common/src/grz_common/pipeline/components/__init__.py
@@ -11,7 +11,8 @@ import queue
 import shutil
 import threading
 from collections.abc import Buffer
-from typing import Any, Protocol, runtime_checkable
+from types import TracebackType
+from typing import Any, Protocol, Self, runtime_checkable
 
 log = logging.getLogger(__name__)
 
@@ -74,6 +75,12 @@ class Writable(Protocol):
     @property
     def closed(self) -> bool: ...
     def close(self) -> None: ...
+    # Sinks are driven as context managers by '>>' so they can finalize or abort.
+    # Signature matches io.IOBase so io-based sinks satisfy the protocol cleanly.
+    def __enter__(self) -> Self: ...
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
+    ) -> None: ...
 
 
 class Pipeable:

--- a/packages/grz-common/src/grz_common/pipeline/components/s3.py
+++ b/packages/grz-common/src/grz_common/pipeline/components/s3.py
@@ -82,7 +82,7 @@ class S3MultipartUploader(Observer):
     def __exit__(self, exc_type, exc, tb) -> None:
         # Finish the upload on a clean exit; abort and discard staged parts on error.
         # Returns None (never True), so the original exception is never suppressed.
-        if exc_type is None:
+        if exc is None:
             self.close()
         else:
             self.abort()

--- a/packages/grz-common/src/grz_common/pipeline/components/s3.py
+++ b/packages/grz-common/src/grz_common/pipeline/components/s3.py
@@ -79,13 +79,13 @@ class S3MultipartUploader(Observer):
         self._part_number = 1
         self._closed = False
 
-    def __exit__(self, exc_type, exc, tb) -> bool:
-        # Commit on clean exit, abort (discard staged parts) on error.
+    def __exit__(self, exc_type, exc, tb) -> None:
+        # Finish the upload on a clean exit; abort and discard staged parts on error.
+        # Returns None (never True), so the original exception is never suppressed.
         if exc_type is None:
             self.close()
         else:
             self.abort()
-        return False  # never suppress the original exception
 
     def _start_multipart_upload(self):
         if self._upload_id:

--- a/packages/grz-common/src/grz_common/pipeline/components/s3.py
+++ b/packages/grz-common/src/grz_common/pipeline/components/s3.py
@@ -80,6 +80,14 @@ class S3MultipartUploader(Observer):
         self._part_number = 1
         self._closed = False
 
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        # Commit on clean exit, abort (discard staged parts) on error.
+        if exc_type is None:
+            self.close()
+        else:
+            self.abort()
+        return False  # never suppress the original exception
+
     def _start_multipart_upload(self):
         if self._upload_id:
             return
@@ -169,6 +177,7 @@ class S3MultipartUploader(Observer):
             with contextlib.suppress(Exception):
                 self.s3.abort_multipart_upload(Bucket=self.bucket, Key=self.key, UploadId=self._upload_id)
         self._cleanup()
+        self._closed = True  # prevent a later close()/finalizer from re-running on an aborted upload
 
     def _submit_part(self, data: bytes, part_num: int):
         if not self._executor:

--- a/packages/grz-common/src/grz_common/pipeline/components/s3.py
+++ b/packages/grz-common/src/grz_common/pipeline/components/s3.py
@@ -1,5 +1,4 @@
 import base64
-import contextlib
 import hashlib
 import logging
 import math
@@ -174,8 +173,13 @@ class S3MultipartUploader(Observer):
     def abort(self) -> None:
         """Abort the multipart upload on S3."""
         if self._upload_id:
-            with contextlib.suppress(Exception):
+            try:
                 self.s3.abort_multipart_upload(Bucket=self.bucket, Key=self.key, UploadId=self._upload_id)
+            except Exception as e:
+                # Don't let a failed abort hide the original error; just log it and move on.
+                # A likely cause is missing abort permission, in which case the staged parts
+                # stay in the bucket until a lifecycle rule or an admin removes them.
+                log.warning(f"Could not abort multipart upload for {self.key}: {e}. Incomplete parts may remain.")
         self._cleanup()
         self._closed = True  # prevent a later close()/finalizer from re-running on an aborted upload
 

--- a/packages/grz-common/tests/pipeline/test_crypt4gh_components.py
+++ b/packages/grz-common/tests/pipeline/test_crypt4gh_components.py
@@ -4,14 +4,24 @@ import os
 from io import BytesIO
 
 from crypt4gh import SEGMENT_SIZE
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 from grz_common.pipeline.components.crypt4gh import Crypt4GHDecryptor, Crypt4GHEncryptor
-from nacl.public import PrivateKey
 
 
 def generate_keypair() -> tuple[bytes, bytes]:
-    """Generate a Crypt4GH keypair (private, public)."""
-    private = PrivateKey.generate()
-    return bytes(private), bytes(private.public_key)
+    """Generate a Crypt4GH keypair (private, public) as raw X25519 keys."""
+    private = X25519PrivateKey.generate()
+    private_bytes = private.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_bytes = private.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return private_bytes, public_bytes
 
 
 class TestCrypt4GHEncryptor:

--- a/packages/grzctl/README.md
+++ b/packages/grzctl/README.md
@@ -11,3 +11,24 @@ Command-line tool for internal GRZ operations.
   - Alternatively, you can use `uv run --project path/to/repo grzctl <grzctl options here>` to run it from any directory.
     This is useful if your config uses relative paths and `grzctl` must therefore be run from a specific directory.
 
+## S3 permissions for `grzctl process`
+
+`grzctl process` uploads to the archive buckets using multipart uploads. The
+credentials you give it must be allowed to **abort** a multipart upload, not just
+to write — these are often separate permissions.
+
+This matters when an upload fails partway through: the tool tries to abort the
+upload so no partial object is left behind. If the credentials lack abort
+permission, the abort is skipped — processing still fails with the original
+error, but the already-uploaded parts stay in the bucket and you can't remove
+them yourself. Over time these orphaned parts pile up and cost storage.
+
+Confusingly, S3 providers split multipart permissions in non-obvious ways (AWS,
+for example, has both object-level and bucket-level multipart actions), and our
+archive backend is Ceph/RGW rather than AWS, so check your provider's own
+documentation for the exact action names. The practical point holds everywhere:
+it's easy to grant write while leaving abort ungranted (see
+[velero-io/velero#416](https://github.com/velero-io/velero/issues/416) for one
+instance), so verify abort works — or rely on a bucket lifecycle rule that
+deletes incomplete multipart uploads after a few days.
+

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -25,6 +25,9 @@ from grzctl.commands.db.cli import _backfill_submission, _BackfillResult
 from moto import mock_aws
 
 BUCKET = "test-backfill-bucket"
+# "us-east-1" is just a placeholder for the moto mock -- no real AWS or region is involved.
+# We pick it specifically because it's S3's default region, so create_bucket() works without
+# an extra CreateBucketConfiguration/LocationConstraint argument.
 REGION = "us-east-1"
 IGNORE_FIELDS = {"submission_date", "tan_g", "pseudonym"}
 DIFFERENT_TAN_G = "b" * 64

--- a/tests/test_abort_upload_on_failure.py
+++ b/tests/test_abort_upload_on_failure.py
@@ -1,0 +1,59 @@
+"""
+Regression test for failure-path upload handling in `Pipeable.__rshift__`.
+
+When the pipeline fails (here: a validator that only fails at ``close()``, mirroring the
+deferred FASTQ/BAM/checksum validators), the S3 multipart upload must be **aborted**:
+
+- no partial object may be committed to the archive, and
+- no incomplete multipart upload may be left dangling on the server.
+
+This is expected to FAIL until `__rshift__` aborts the sink on the failure path
+(currently `self.close()` raises in the `finally` and `other.close()` is skipped, so the
+upload is neither completed nor aborted).
+"""
+
+import io
+
+import boto3
+import pytest
+from grz_common.pipeline.components import Observer, ReadStream, Tee
+from grz_common.pipeline.components.s3 import S3MultipartUploader
+from moto import mock_aws
+
+BUCKET = "archive"
+KEY = "subA/files/f.c4gh"
+
+
+class _FailOnCloseObserver(Observer):
+    """Stand-in for a validator that accepts all data but only fails at close()."""
+
+    def observe(self, chunk: bytes) -> None:
+        pass
+
+    def close(self) -> None:
+        if not self.closed:
+            try:
+                raise RuntimeError("simulated validation failure at close()")
+            finally:
+                super().close()
+
+
+@mock_aws
+def test_failed_pipeline_aborts_upload():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=BUCKET)
+
+    source = ReadStream(io.BytesIO(b"x" * (1024 * 1024)))  # 1 MiB -> starts a multipart upload
+    chain = source | Tee(_FailOnCloseObserver())
+    uploader = S3MultipartUploader(s3, BUCKET, KEY)
+
+    with pytest.raises(RuntimeError):
+        chain >> uploader
+
+    # A failure must not commit a (partial) object.
+    objects = [o["Key"] for o in s3.list_objects_v2(Bucket=BUCKET).get("Contents", [])]
+    assert objects == [], f"failure must not commit an object, found: {objects}"
+
+    # A failure must not leave an incomplete multipart upload dangling on the server.
+    uploads = [u["Key"] for u in s3.list_multipart_uploads(Bucket=BUCKET).get("Uploads", [])]
+    assert uploads == [], f"failure must abort the upload, dangling multipart upload(s): {uploads}"

--- a/tests/test_abort_upload_on_failure.py
+++ b/tests/test_abort_upload_on_failure.py
@@ -57,13 +57,14 @@ def test_failed_pipeline_aborts_upload():
     with pytest.raises(RuntimeError):
         chain >> uploader
 
-    # A failure must not commit a (partial) object.
-    objects = [o["Key"] for o in s3.list_objects_v2(Bucket=BUCKET).get("Contents", [])]
-    assert objects == [], f"failure must not commit an object, found: {objects}"
+    # A failure must not commit a (partial) object. S3 omits "Contents" entirely for an empty
+    # bucket, so assert the key is absent rather than hiding it behind a default empty list.
+    objects = s3.list_objects_v2(Bucket=BUCKET)
+    assert "Contents" not in objects, f"failure must not commit an object, found: {objects.get('Contents')}"
 
     # A failure must not leave an incomplete multipart upload dangling on the server.
-    uploads = [u["Key"] for u in s3.list_multipart_uploads(Bucket=BUCKET).get("Uploads", [])]
-    assert uploads == [], f"failure must abort the upload, dangling multipart upload(s): {uploads}"
+    uploads = s3.list_multipart_uploads(Bucket=BUCKET)
+    assert "Uploads" not in uploads, f"failure must abort the upload, dangling: {uploads.get('Uploads')}"
 
 
 @mock_aws
@@ -97,5 +98,5 @@ def test_failed_pipeline_surfaces_original_error_when_abort_is_denied(caplog):
     assert any("Could not abort multipart upload" in r.message for r in caplog.records)
 
     # Even when abort is denied, no (partial) object may be committed.
-    objects = [o["Key"] for o in s3.list_objects_v2(Bucket=BUCKET).get("Contents", [])]
-    assert objects == [], f"failure must not commit an object, found: {objects}"
+    objects = s3.list_objects_v2(Bucket=BUCKET)
+    assert "Contents" not in objects, f"failure must not commit an object, found: {objects.get('Contents')}"

--- a/tests/test_abort_upload_on_failure.py
+++ b/tests/test_abort_upload_on_failure.py
@@ -13,9 +13,11 @@ upload is neither completed nor aborted).
 """
 
 import io
+import logging
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from grz_common.pipeline.components import Observer, ReadStream, Tee
 from grz_common.pipeline.components.s3 import S3MultipartUploader
 from moto import mock_aws
@@ -40,10 +42,15 @@ class _FailOnCloseObserver(Observer):
 
 @mock_aws
 def test_failed_pipeline_aborts_upload():
+    # "us-east-1" is just a placeholder for the moto mock -- no real AWS or region is involved.
+    # We pick it specifically because it's S3's default region, so create_bucket() below works
+    # without an extra CreateBucketConfiguration/LocationConstraint argument.
     s3 = boto3.client("s3", region_name="us-east-1")
     s3.create_bucket(Bucket=BUCKET)
 
-    source = ReadStream(io.BytesIO(b"x" * (1024 * 1024)))  # 1 MiB -> starts a multipart upload
+    # 9 MiB is larger than the default 8 MiB part size, so at least one part is actually
+    # uploaded before the failure -- not just the create_multipart_upload call.
+    source = ReadStream(io.BytesIO(b"x" * (9 * 1024 * 1024)))
     chain = source | Tee(_FailOnCloseObserver())
     uploader = S3MultipartUploader(s3, BUCKET, KEY)
 
@@ -57,3 +64,38 @@ def test_failed_pipeline_aborts_upload():
     # A failure must not leave an incomplete multipart upload dangling on the server.
     uploads = [u["Key"] for u in s3.list_multipart_uploads(Bucket=BUCKET).get("Uploads", [])]
     assert uploads == [], f"failure must abort the upload, dangling multipart upload(s): {uploads}"
+
+
+@mock_aws
+def test_failed_pipeline_surfaces_original_error_when_abort_is_denied(caplog):
+    """On a bucket where we may write parts but lack s3:AbortMultipartUpload, a failed abort
+    must not hide the real error: the original validation failure still has to surface, and the
+    denied abort is only logged as a warning. The dangling upload is then left for a bucket
+    lifecycle rule or an admin to reap.
+    """
+    s3 = boto3.client("s3", region_name="us-east-1")  # moto placeholder, see note above
+    s3.create_bucket(Bucket=BUCKET)
+
+    source = ReadStream(io.BytesIO(b"x" * (9 * 1024 * 1024)))
+    chain = source | Tee(_FailOnCloseObserver())
+    uploader = S3MultipartUploader(s3, BUCKET, KEY)
+
+    def _deny_abort(*args, **kwargs):
+        raise ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "abort not permitted"}},
+            "AbortMultipartUpload",
+        )
+
+    uploader.s3.abort_multipart_upload = _deny_abort
+
+    # The real validation failure must still surface -- a denied abort must not mask it.
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(RuntimeError, match="simulated validation failure"):
+            chain >> uploader
+
+    # The denied abort is reported, not raised.
+    assert any("Could not abort multipart upload" in r.message for r in caplog.records)
+
+    # Even when abort is denied, no (partial) object may be committed.
+    objects = [o["Key"] for o in s3.list_objects_v2(Bucket=BUCKET).get("Contents", [])]
+    assert objects == [], f"failure must not commit an object, found: {objects}"


### PR DESCRIPTION
Problem: When the process pipeline fails partway through writing a file to the archive, that file's S3 multipart upload was previously left open - its already-staged parts lingered as orphaned upload fragments that never became a usable object.

Fix: Now, on failure, that file's upload is aborted and its staged parts are discarded.

Test: A new unit test reproduces the original bug and verifies the fix.
