### PR TITLE
fix(grzctl): take QC workflow version from the report in populate-qc

### DIFF
--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -783,9 +783,8 @@ class QCReportRow(StrictBaseModel):
     required=False,
     default=None,
     envvar="GRZCTL_QC_WORKFLOW_VERSION",
-    help="Override the QC workflow version stored with the detailed QC results. By default the "
-    "version is taken from the report's 'grzQcWorkflowVersion' column. Can also be provided via "
-    "GRZCTL_QC_WORKFLOW_VERSION.",
+    help="QC workflow version to record when the report has no 'grzQcWorkflowVersion' column. "
+    "If the report carries one, it takes precedence. Env: GRZCTL_QC_WORKFLOW_VERSION.",
 )
 @click.option(
     "--confirm/--no-confirm",

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -768,6 +768,10 @@ class QCReportRow(StrictBaseModel):
     targeted_regions_above_min_coverage_required: float
     targeted_regions_above_min_coverage_deviation: float
     targeted_regions_above_min_coverage_qc_status: QCStatus = Field(alias="targetedRegionsAboveMinCoverageQCStatus")
+    # Written by GRZ_QC_Workflow >= v2.1.0. Optional so reports from older workflow
+    # versions (without the column) still parse. Auto-aliased to "grzQcWorkflowVersion"
+    # via StrictBaseModel's to_camel alias generator.
+    grz_qc_workflow_version: str | None = None
 
 
 @submission.command()
@@ -776,9 +780,12 @@ class QCReportRow(StrictBaseModel):
 @click.option(
     "--qc-workflow-version",
     type=str,
-    required=True,
+    required=False,
+    default=None,
     envvar="GRZCTL_QC_WORKFLOW_VERSION",
-    help="QC workflow version to store with detailed QC results. Can also be provided via GRZCTL_QC_WORKFLOW_VERSION.",
+    help="Override the QC workflow version stored with the detailed QC results. By default the "
+    "version is taken from the report's 'grzQcWorkflowVersion' column. Can also be provided via "
+    "GRZCTL_QC_WORKFLOW_VERSION.",
 )
 @click.option(
     "--confirm/--no-confirm",
@@ -786,7 +793,9 @@ class QCReportRow(StrictBaseModel):
     help="Whether to confirm changes before committing to database. (Default: confirm)",
 )
 @click.pass_context
-def populate_qc(ctx: click.Context, submission_id: str, report_csv_path: str, qc_workflow_version: str, confirm: bool):
+def populate_qc(
+    ctx: click.Context, submission_id: str, report_csv_path: str, qc_workflow_version: str | None, confirm: bool
+):
     """Populate the submission database from a detailed QC pipeline report."""
     db = ctx.obj["db_url"]
     db_service = get_submission_db_instance(db, author=ctx.obj["author"])
@@ -797,6 +806,28 @@ def populate_qc(ctx: click.Context, submission_id: str, report_csv_path: str, qc
         reports = []
         for row in reader:
             reports.append(QCReportRow(**dict(zip(header, row, strict=True))))
+
+    # The report (GRZ_QC_Workflow >= v2.1.0) carries its own version in the
+    # 'grzQcWorkflowVersion' column; treat that as the source of truth and only fall back to
+    # --qc-workflow-version for older reports that lack the column.
+    report_versions = {report.grz_qc_workflow_version for report in reports if report.grz_qc_workflow_version}
+    if len(report_versions) > 1:
+        raise click.ClickException(f"Inconsistent grzQcWorkflowVersion values in report: {sorted(report_versions)}")
+    report_version = report_versions.pop() if report_versions else None
+
+    if report_version and qc_workflow_version and report_version != qc_workflow_version:
+        raise click.ClickException(
+            f"--qc-workflow-version ({qc_workflow_version}) disagrees with the report's "
+            f"grzQcWorkflowVersion ({report_version}). Omit --qc-workflow-version to use the report "
+            "value, which is authoritative."
+        )
+
+    effective_qc_workflow_version = report_version or qc_workflow_version
+    if not effective_qc_workflow_version:
+        raise click.ClickException(
+            "No QC workflow version found: the report has no 'grzQcWorkflowVersion' column and "
+            "--qc-workflow-version was not provided."
+        )
 
     report_mtime = datetime.fromtimestamp(Path(report_csv_path).stat().st_mtime, tz=UTC)
     results = []
@@ -823,7 +854,7 @@ def populate_qc(ctx: click.Context, submission_id: str, report_csv_path: str, qc
                 targeted_regions_above_min_coverage_passed_qc=report.targeted_regions_above_min_coverage_qc_status
                 == QCStatus.PASS,
                 targeted_regions_above_min_coverage_percent_deviation=report.targeted_regions_above_min_coverage_deviation,
-                qc_workflow_version=qc_workflow_version,
+                qc_workflow_version=effective_qc_workflow_version,
             )
         )
     table = rich.table.Table(

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -512,7 +512,7 @@ def test_populate_qc_missing_qc_workflow_version(
             """)
         )
 
-    # Test without --qc-workflow-version flag and without env var (should fail)
+    # No --qc-workflow-version flag/env var and no grzQcWorkflowVersion column in the report → fail
     result_populate_qc = runner.invoke(
         cli,
         [
@@ -525,7 +525,99 @@ def test_populate_qc_missing_qc_workflow_version(
         ],
     )
     assert result_populate_qc.exit_code != 0
-    assert "Missing option '--qc-workflow-version'" in result_populate_qc.output
+    assert "No QC workflow version found" in result_populate_qc.output
+
+
+def test_populate_qc_version_from_report(blank_database_config_path: Path, tmp_path: Path, test_metadata_path: Path):
+    """populate-qc takes the version from the report's grzQcWorkflowVersion column when no flag is given."""
+    args_common = ["db", "--config-file", blank_database_config_path]
+    metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
+
+    runner = click.testing.CliRunner(catch_exceptions=False)
+    cli = grzctl.cli.build_cli()
+    result_add = runner.invoke(cli, [*args_common, "submission", "add", metadata.submission_id])
+    assert result_add.exit_code == 0, result_add.stderr
+
+    metadata_raw = json.loads(test_metadata_path.read_text())
+    metadata_dump_path = tmp_path / "metadata.json"
+    with open(metadata_dump_path, "w") as metadata_file:
+        json.dump(metadata_raw, metadata_file)
+
+    result_populate = runner.invoke(
+        cli,
+        [*args_common, "submission", "populate", metadata.submission_id, str(metadata_dump_path), "--no-confirm"],
+    )
+    assert result_populate.exit_code == 0, result_populate.stderr
+
+    report_csv_path = tmp_path / "report.csv"
+    with open(report_csv_path, "w") as report_csv_file:
+        report_csv_file.write(
+            dedent("""\
+            sampleId,donorPseudonym,labDataName,libraryType,sequenceSubtype,genomicStudySubtype,qualityControlStatus,meanDepthOfCoverage,meanDepthOfCoverageProvided,meanDepthOfCoverageRequired,meanDepthOfCoverageDeviation,meanDepthOfCoverageQCStatus,percentBasesAboveQualityThreshold,qualityThreshold,percentBasesAboveQualityThresholdProvided,percentBasesAboveQualityThresholdRequired,percentBasesAboveQualityThresholdDeviation,percentBasesAboveQualityThresholdQCStatus,targetedRegionsAboveMinCoverage,minCoverage,targetedRegionsAboveMinCoverageProvided,targetedRegionsAboveMinCoverageRequired,targetedRegionsAboveMinCoverageDeviation,targetedRegionsAboveMinCoverageQCStatus,grzQcWorkflowVersion
+            index0_germline0,index,Blut DNA normal,wes,germline,tumor+germline,PASS,49.84,50.0,30.0,-0.3199999999999932,PASS,90.65953529937444,30,88.0,85,3.022199203834591,PASS,1.0,20,1.0,0.8,0.0,PASS,2.1.0+nonredundant
+            """)
+        )
+
+    result_populate_qc = runner.invoke(
+        cli,
+        [*args_common, "submission", "populate-qc", metadata.submission_id, str(report_csv_path), "--no-confirm"],
+    )
+    assert result_populate_qc.exit_code == 0, result_populate_qc.stderr
+
+    with open(blank_database_config_path, encoding="utf-8") as blank_database_config_file:
+        config = yaml.load(blank_database_config_file, Loader=yaml.Loader)
+    db = SubmissionDb(db_url=config["db"]["database_url"], author=None)
+
+    results = db.get_detailed_qc_results(metadata.submission_id)
+    assert len(results) == 1
+    assert results[0].qc_workflow_version == "2.1.0+nonredundant"
+
+
+def test_populate_qc_flag_report_mismatch(blank_database_config_path: Path, tmp_path: Path, test_metadata_path: Path):
+    """populate-qc errors when --qc-workflow-version disagrees with the report's grzQcWorkflowVersion."""
+    args_common = ["db", "--config-file", blank_database_config_path]
+    metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
+
+    runner = click.testing.CliRunner(catch_exceptions=False)
+    cli = grzctl.cli.build_cli()
+    result_add = runner.invoke(cli, [*args_common, "submission", "add", metadata.submission_id])
+    assert result_add.exit_code == 0, result_add.stderr
+
+    metadata_raw = json.loads(test_metadata_path.read_text())
+    metadata_dump_path = tmp_path / "metadata.json"
+    with open(metadata_dump_path, "w") as metadata_file:
+        json.dump(metadata_raw, metadata_file)
+
+    result_populate = runner.invoke(
+        cli,
+        [*args_common, "submission", "populate", metadata.submission_id, str(metadata_dump_path), "--no-confirm"],
+    )
+    assert result_populate.exit_code == 0, result_populate.stderr
+
+    report_csv_path = tmp_path / "report.csv"
+    with open(report_csv_path, "w") as report_csv_file:
+        report_csv_file.write(
+            dedent("""\
+            sampleId,donorPseudonym,labDataName,libraryType,sequenceSubtype,genomicStudySubtype,qualityControlStatus,meanDepthOfCoverage,meanDepthOfCoverageProvided,meanDepthOfCoverageRequired,meanDepthOfCoverageDeviation,meanDepthOfCoverageQCStatus,percentBasesAboveQualityThreshold,qualityThreshold,percentBasesAboveQualityThresholdProvided,percentBasesAboveQualityThresholdRequired,percentBasesAboveQualityThresholdDeviation,percentBasesAboveQualityThresholdQCStatus,targetedRegionsAboveMinCoverage,minCoverage,targetedRegionsAboveMinCoverageProvided,targetedRegionsAboveMinCoverageRequired,targetedRegionsAboveMinCoverageDeviation,targetedRegionsAboveMinCoverageQCStatus,grzQcWorkflowVersion
+            index0_germline0,index,Blut DNA normal,wes,germline,tumor+germline,PASS,49.84,50.0,30.0,-0.3199999999999932,PASS,90.65953529937444,30,88.0,85,3.022199203834591,PASS,1.0,20,1.0,0.8,0.0,PASS,2.1.0+nonredundant
+            """)
+        )
+
+    result_populate_qc = runner.invoke(
+        cli,
+        [
+            *args_common,
+            "submission",
+            "populate-qc",
+            metadata.submission_id,
+            str(report_csv_path),
+            "--no-confirm",
+            "--qc-workflow-version",
+            "v9.9.9",
+        ],
+    )
+    assert result_populate_qc.exit_code != 0
+    assert "disagrees" in result_populate_qc.output
 
 
 def test_update_error_confirm(blank_database_config_path: Path, test_metadata_path: Path):


### PR DESCRIPTION
## Summary

`grzctl db submission populate-qc` cannot ingest a `report.csv` produced by
GRZ_QC_Workflow **≥ v2.1.0**, which added a `grzQcWorkflowVersion` column to the
report. This makes the report column the source of truth for the QC workflow
version and demotes `--qc-workflow-version` to an optional override.

## Problem

- `QCReportRow` is a `StrictBaseModel` (`extra="forbid"`) with no field for
  `grzQcWorkflowVersion`. Rows are parsed via `QCReportRow(**dict(zip(header, row)))`,
  so the unexpected column raises a `ValidationError` and `populate-qc` aborts
  before storing anything.
- Separately, the version now lives in two disconnected places: the report column
  the workflow writes, and the `--qc-workflow-version` flag grzctl requires. grzctl
  ignored the column and relied solely on the flag, so the same value had to be
  supplied twice and could silently diverge.

## Changes

- Add `grz_qc_workflow_version: str | None = None` to `QCReportRow` (auto-aliased
  to `grzQcWorkflowVersion`). `| None` keeps pre-v2.1.0 reports (without the column)
  parseable.
- `--qc-workflow-version` is now optional; the report column is authoritative.
- Resolution logic in `populate_qc`: error on inconsistent column values across
  rows, error if flag and report disagree, fall back to the flag when the report
  has no column, and error if neither provides a version.

## Backwards compatibility

Existing usage is unaffected: reports without the column plus the flag/env var
behave exactly as before. The only new failure mode (flag ≠ report) applies to
v2.1.0 reports that could not be processed at all previously, so it is not a
regression. No DB migration required.

## Testing

- Added `test_populate_qc_version_from_report` (version taken from the report).
- Added `test_populate_qc_flag_report_mismatch` (flag vs report disagreement errors).
- Updated `test_populate_qc_missing_qc_workflow_version` for the new error message.