### PR TITLE
feat(grzctl, grz-db, grz-common): Metadata schema version check via version.json

### DIFF
--- a/packages/grz-cli/src/grz_cli/commands/validate.py
+++ b/packages/grz-cli/src/grz_cli/commands/validate.py
@@ -11,8 +11,6 @@ from grz_common.workers.worker import Worker
 
 log = logging.getLogger(__name__)
 
-from grz_cli.utils.version_check import check_metadata_version_and_exit_if_needed
-
 
 @click.command()
 @grzcli.configuration
@@ -53,12 +51,6 @@ def validate(
         encrypted_files_dir=submission_dir / "encrypted_files",
         threads=threads,
     )
-
-    config = ValidateConfig.model_validate(configuration)
-    if config.s3 is not None:
-        submission = worker_inst.parse_submission()
-        metadata_schema_version = submission.metadata.content.get_schema_version()
-        check_metadata_version_and_exit_if_needed(config.s3, metadata_schema_version)
 
     worker_inst.validate(identifiers=config.identifiers, force=force, no_mmap=not mmap)
 

--- a/packages/grz-cli/src/grz_cli/commands/validate.py
+++ b/packages/grz-cli/src/grz_cli/commands/validate.py
@@ -11,6 +11,8 @@ from grz_common.workers.worker import Worker
 
 log = logging.getLogger(__name__)
 
+from grz_cli.utils.version_check import check_metadata_version_and_exit_if_needed
+
 
 @click.command()
 @grzcli.configuration
@@ -51,6 +53,13 @@ def validate(
         encrypted_files_dir=submission_dir / "encrypted_files",
         threads=threads,
     )
+
+    config = ValidateConfig.model_validate(configuration)
+    if config.s3 is not None:
+        submission = worker_inst.parse_submission()
+        metadata_schema_version = submission.metadata.content.get_schema_version()
+        check_metadata_version_and_exit_if_needed(config.s3, metadata_schema_version)
+
     worker_inst.validate(identifiers=config.identifiers, force=force, no_mmap=not mmap)
 
     log.info("Validation finished!")

--- a/packages/grz-cli/src/grz_cli/models/config.py
+++ b/packages/grz-cli/src/grz_cli/models/config.py
@@ -1,8 +1,10 @@
 import logging
+from typing import Annotated
 
 from grz_common.models.identifiers import IdentifiersConfigModel
 from grz_common.models.keys import KeyConfigModel
-from grz_common.models.s3 import S3ConfigModel
+from grz_common.models.s3 import S3ConfigModel, S3Options
+from pydantic import Field
 
 log = logging.getLogger(__name__)
 
@@ -16,4 +18,4 @@ class EncryptConfig(KeyConfigModel):
 
 
 class ValidateConfig(IdentifiersConfigModel):
-    pass
+    s3: Annotated[S3Options | None, Field(default=None)] = None

--- a/packages/grz-cli/src/grz_cli/models/config.py
+++ b/packages/grz-cli/src/grz_cli/models/config.py
@@ -1,10 +1,8 @@
 import logging
-from typing import Annotated
 
 from grz_common.models.identifiers import IdentifiersConfigModel
 from grz_common.models.keys import KeyConfigModel
-from grz_common.models.s3 import S3ConfigModel, S3Options
-from pydantic import Field
+from grz_common.models.s3 import S3ConfigModel
 
 log = logging.getLogger(__name__)
 
@@ -18,4 +16,4 @@ class EncryptConfig(KeyConfigModel):
 
 
 class ValidateConfig(IdentifiersConfigModel):
-    s3: Annotated[S3Options | None, Field(default=None)] = None
+    pass

--- a/packages/grz-cli/src/grz_cli/utils/version_check.py
+++ b/packages/grz-cli/src/grz_cli/utils/version_check.py
@@ -87,3 +87,57 @@ def check_version_and_exit_if_needed(
 
     # best case
     logger.info(f"grz-cli {current_version} is within the supported and tested range.")
+
+
+def check_metadata_version_and_exit_if_needed(
+    s3_options: S3Options,
+    metadata_schema_version: str,
+    version_file_key: str = "version.json",
+) -> None:
+    """Validate the metadata schema version against the policy defined in version.json."""
+    version_file = VersionFile.from_s3(s3_options, version_file_key)
+
+    current_version = pkg_version.Version(metadata_schema_version)
+    now = datetime.now(UTC)
+
+    policy = _select_active_policy(version_file.metadata_version, now)
+    if policy is None:
+        logger.debug("No active version policy found — skipping version check.")
+        return
+
+    minimal_version = policy.minimal_version
+    recommended_version = policy.recommended_version
+    max_version = policy.max_version
+    enforced_from = policy.enforced_from
+
+    logger.debug(f"Current metadata version: {current_version}")
+    logger.debug(
+        f"Active policy: "
+        f"minimal={minimal_version}, "
+        f"recommended={recommended_version}, "
+        f"max_version={max_version}, "
+        f"enforced_from={enforced_from}"
+    )
+
+    # old version
+    if current_version < minimal_version:
+        logger.error(
+            f"Your metadata version ({current_version}) is not supported. Minimum required version is {minimal_version}."
+        )
+        sys.exit(1)
+
+    # supported but behind recommended — skip if recommended_version not set
+    if recommended_version is not None and minimal_version <= current_version < recommended_version:
+        logger.warning(
+            f"You are using metadata {current_version}, but the recommended version is "
+            f"{recommended_version}. Upgrading is strongly recommended."
+        )
+        return
+
+    # too new — skip if max_version not set
+    if max_version is not None and current_version > max_version:
+        logger.error(f"metadata version {current_version} is newer than the maximum supported version ({max_version}).")
+        sys.exit(1)
+
+    # best case
+    logger.info(f"metadata {current_version} is within the supported and tested range.")

--- a/packages/grz-cli/src/grz_cli/utils/version_check.py
+++ b/packages/grz-cli/src/grz_cli/utils/version_check.py
@@ -43,50 +43,7 @@ def check_version_and_exit_if_needed(
     version_file = VersionFile.from_s3(s3_options, version_file_key)
 
     current_version = pkg_version.Version(version("grz-cli"))
-    now = datetime.now(UTC)
-
-    policy = _select_active_policy(version_file.grzcli_version, now)
-
-    if policy is None:
-        logger.debug("No active version policy found — skipping version check.")
-        return
-
-    minimal_version = policy.minimal_version
-    recommended_version = policy.recommended_version
-    max_version = policy.max_version
-    enforced_from = policy.enforced_from
-
-    logger.debug(f"Current grz-cli version: {current_version}")
-    logger.debug(
-        f"Active policy: "
-        f"minimal={minimal_version}, "
-        f"recommended={recommended_version}, "
-        f"max_version={max_version}, "
-        f"enforced_from={enforced_from}"
-    )
-
-    # old version
-    if current_version < minimal_version:
-        logger.error(
-            f"Your grz-cli version ({current_version}) is not supported. Minimum required version is {minimal_version}."
-        )
-        sys.exit(1)
-
-    # supported but behind recommended — skip if recommended_version not set
-    if recommended_version is not None and minimal_version <= current_version < recommended_version:
-        logger.warning(
-            f"You are using grz-cli {current_version}, but the recommended version is "
-            f"{recommended_version}. Upgrading is strongly recommended."
-        )
-        return
-
-    # too new — skip if max_version not set
-    if max_version is not None and current_version > max_version:
-        logger.error(f"grz-cli version {current_version} is newer than the maximum supported version ({max_version}).")
-        sys.exit(1)
-
-    # best case
-    logger.info(f"grz-cli {current_version} is within the supported and tested range.")
+    _check_policy_and_exit_if_needed("grz-cli", current_version, version_file.grzcli_version)
 
 
 def check_metadata_version_and_exit_if_needed(
@@ -98,9 +55,18 @@ def check_metadata_version_and_exit_if_needed(
     version_file = VersionFile.from_s3(s3_options, version_file_key)
 
     current_version = pkg_version.Version(metadata_schema_version)
+    _check_policy_and_exit_if_needed("metadata", current_version, version_file.metadata_version)
+
+
+def _check_policy_and_exit_if_needed(
+    subject: str,
+    current_version: pkg_version.Version,
+    policies: list[VersionInfo],
+) -> None:
+    """Validate a version against the active policy for a subject."""
     now = datetime.now(UTC)
 
-    policy = _select_active_policy(version_file.metadata_version, now)
+    policy = _select_active_policy(policies, now)
     if policy is None:
         logger.debug("No active version policy found — skipping version check.")
         return
@@ -110,7 +76,7 @@ def check_metadata_version_and_exit_if_needed(
     max_version = policy.max_version
     enforced_from = policy.enforced_from
 
-    logger.debug(f"Current metadata version: {current_version}")
+    logger.debug(f"Current {subject} version: {current_version}")
     logger.debug(
         f"Active policy: "
         f"minimal={minimal_version}, "
@@ -122,22 +88,24 @@ def check_metadata_version_and_exit_if_needed(
     # old version
     if current_version < minimal_version:
         logger.error(
-            f"Your metadata version ({current_version}) is not supported. Minimum required version is {minimal_version}."
+            f"Your {subject} version ({current_version}) is not supported. Minimum required version is {minimal_version}."
         )
         sys.exit(1)
 
     # supported but behind recommended — skip if recommended_version not set
     if recommended_version is not None and minimal_version <= current_version < recommended_version:
         logger.warning(
-            f"You are using metadata {current_version}, but the recommended version is "
+            f"You are using {subject} {current_version}, but the recommended version is "
             f"{recommended_version}. Upgrading is strongly recommended."
         )
         return
 
     # too new — skip if max_version not set
     if max_version is not None and current_version > max_version:
-        logger.error(f"metadata version {current_version} is newer than the maximum supported version ({max_version}).")
+        logger.error(
+            f"{subject} version {current_version} is newer than the maximum supported version ({max_version})."
+        )
         sys.exit(1)
 
     # best case
-    logger.info(f"metadata {current_version} is within the supported and tested range.")
+    logger.info(f"{subject} {current_version} is within the supported and tested range.")

--- a/packages/grz-common/src/grz_common/models/version.py
+++ b/packages/grz-common/src/grz_common/models/version.py
@@ -93,6 +93,9 @@ class VersionFile(BaseModel):
 
     # List allows staged future policies (empty list disables version checking)
     grzcli_version: list[VersionInfo] = Field(default_factory=list, description="List of version policies for grz-cli")
+    metadata_version: list[VersionInfo] = Field(
+        default_factory=list, description="List of version policies for metadata schema"
+    )
 
     @classmethod
     def from_s3(cls, s3_options: S3Options, version_file_key: str) -> Self:

--- a/packages/grz-common/src/grz_common/workers/worker.py
+++ b/packages/grz-common/src/grz_common/workers/worker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from os import PathLike
 from pathlib import Path
 
@@ -289,7 +290,13 @@ class Worker:
 
         upload_worker.archive(encrypted_submission)
 
-    def download(self, s3_options: S3Options, submission_id: str, force: bool = False):
+    def download(
+        self,
+        s3_options: S3Options,
+        submission_id: str,
+        force: bool = False,
+        metadata_version_check: Callable[[str], None] | None = None,
+    ):
         """
         Download an encrypted submission
         """
@@ -307,5 +314,10 @@ class Worker:
         self.__log.info("Downloading metadata...")
         download_worker.download_metadata(submission_id, self.metadata_dir, metadata_file_name="metadata.json")
 
+        encrypted_submission = EncryptedSubmission(self.metadata_dir, self.encrypted_files_dir)
+        if metadata_version_check is not None:
+            metadata_schema_version = encrypted_submission.metadata.content.get_schema_version()
+            metadata_version_check(metadata_schema_version)
+
         self.__log.info("Downloading encrypted files...")
-        download_worker.download(submission_id, EncryptedSubmission(self.metadata_dir, self.encrypted_files_dir))
+        download_worker.download(submission_id, encrypted_submission)

--- a/packages/grzctl/src/grzctl/commands/download.py
+++ b/packages/grzctl/src/grzctl/commands/download.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import click
 import grz_common.cli as grzcli
+from grz_cli.utils.version_check import check_metadata_version_and_exit_if_needed
 from grz_common.transfer import get_metadata_upload_timestamp, init_s3_client
 from grz_common.workers.worker import Worker
 from grz_db.models.submission import SubmissionStateEnum
@@ -68,7 +69,15 @@ def download(  # noqa: PLR0913
         end_state=SubmissionStateEnum.DOWNLOADED,
         enabled=update_db,
     ) as db_context:
-        worker_inst.download(config.s3, submission_id, force=force)
+        worker_inst.download(
+            config.s3,
+            submission_id,
+            force=force,
+            metadata_version_check=lambda metadata_schema_version: check_metadata_version_and_exit_if_needed(
+                config.s3,
+                metadata_schema_version,
+            ),
+        )
         if populate:
             if not db_context.db:
                 log.warning("Database context is not available, skipping population of submission metadata in DB.")

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -12,14 +12,11 @@ from grz_common.workers.submission import SubmissionValidationError
 @pytest.mark.parametrize("grz_check_mmap", ["--mmap", "--no-mmap"])
 def test_validate_submission(
     temp_identifiers_config_file_path,
-    temp_s3_config_file_path,  # <-- add this fixture
     working_dir_path,
     grz_check_mmap,
     caplog,
-    mocker,
 ):
     submission_dir = Path("tests/mock_files/submissions/valid_submission")
-    mocker.patch("grz_cli.commands.validate.check_metadata_version_and_exit_if_needed")
 
     shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
     shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
@@ -28,8 +25,6 @@ def test_validate_submission(
         "validate",
         "--config-file",
         temp_identifiers_config_file_path,
-        "--config-file",
-        temp_s3_config_file_path,
         "--submission-dir",
         str(working_dir_path),
         grz_check_mmap,
@@ -54,11 +49,9 @@ def test_validate_submission(
 def test_validate_submission_incorrect_grz_id(
     temp_identifiers_config_file_path,
     working_dir_path,
-    mocker,
 ):
     submission_dir = Path("tests/mock_files/submissions/valid_submission")
 
-    mocker.patch("grz_cli.commands.validate.check_metadata_version_and_exit_if_needed")
     shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
     shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
 
@@ -89,30 +82,3 @@ def test_validate_submission_incorrect_grz_id(
     assert "does not match genomic data center identifier" in str(exc)
 
     assert result.exit_code == 1, result.output
-
-
-def test_validate_submission_with_metadata_version_check(
-    temp_identifiers_config_file_path,
-    temp_s3_config_file_path,
-    remote_bucket_with_version,
-    working_dir_path,
-    caplog,
-):
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
-
-    testargs = [
-        "validate",
-        "--config-file",
-        temp_identifiers_config_file_path,
-        "--config-file",
-        temp_s3_config_file_path,  # <-- provides S3 config
-        "--submission-dir",
-        str(working_dir_path),
-    ]
-
-    runner = CliRunner()
-    cli = grz_cli.cli.build_cli()
-    result = runner.invoke(cli, testargs, catch_exceptions=False)
-    assert result.exit_code == 0, result.output

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -12,11 +12,14 @@ from grz_common.workers.submission import SubmissionValidationError
 @pytest.mark.parametrize("grz_check_mmap", ["--mmap", "--no-mmap"])
 def test_validate_submission(
     temp_identifiers_config_file_path,
+    temp_s3_config_file_path,  # <-- add this fixture
     working_dir_path,
     grz_check_mmap,
     caplog,
+    mocker,
 ):
     submission_dir = Path("tests/mock_files/submissions/valid_submission")
+    mocker.patch("grz_cli.commands.validate.check_metadata_version_and_exit_if_needed")
 
     shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
     shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
@@ -25,6 +28,8 @@ def test_validate_submission(
         "validate",
         "--config-file",
         temp_identifiers_config_file_path,
+        "--config-file",
+        temp_s3_config_file_path,
         "--submission-dir",
         str(working_dir_path),
         grz_check_mmap,
@@ -43,19 +48,17 @@ def test_validate_submission(
         result = runner.invoke(cli, testargs, catch_exceptions=False)
         assert "Starting file validation with `grz-check`..." in caplog.text
 
-    # test if command has correctly checked for:
-    # - mismatched md5sums
-    # - all files existing
-
     assert result.exit_code == 0, result.output
 
 
 def test_validate_submission_incorrect_grz_id(
     temp_identifiers_config_file_path,
     working_dir_path,
+    mocker,
 ):
     submission_dir = Path("tests/mock_files/submissions/valid_submission")
 
+    mocker.patch("grz_cli.commands.validate.check_metadata_version_and_exit_if_needed")
     shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
     shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
 
@@ -86,3 +89,30 @@ def test_validate_submission_incorrect_grz_id(
     assert "does not match genomic data center identifier" in str(exc)
 
     assert result.exit_code == 1, result.output
+
+
+def test_validate_submission_with_metadata_version_check(
+    temp_identifiers_config_file_path,
+    temp_s3_config_file_path,
+    remote_bucket_with_version,
+    working_dir_path,
+    caplog,
+):
+    submission_dir = Path("tests/mock_files/submissions/valid_submission")
+    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
+    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+
+    testargs = [
+        "validate",
+        "--config-file",
+        temp_identifiers_config_file_path,
+        "--config-file",
+        temp_s3_config_file_path,  # <-- provides S3 config
+        "--submission-dir",
+        str(working_dir_path),
+    ]
+
+    runner = CliRunner()
+    cli = grz_cli.cli.build_cli()
+    result = runner.invoke(cli, testargs, catch_exceptions=False)
+    assert result.exit_code == 0, result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,6 +172,14 @@ def remote_bucket_with_version(remote_bucket):
                 "enforced_from": datetime.now().isoformat(),
             }
         ],
+        "metadata_version": [
+            {
+                "minimal_version": "1.3.0",
+                "recommended_version": "1.3.0",
+                "max_version": None,
+                "enforced_from": datetime.now().isoformat(),
+            }
+        ],
     }
 
     remote_bucket.put_object(

--- a/tests/mock_files/submissions/valid_submission/metadata/metadata.json
+++ b/tests/mock_files/submissions/valid_submission/metadata/metadata.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq/refs/tags/v1.2.1/GRZ/grz-schema.json",
+  "$schema": "https://raw.githubusercontent.com/BfArM-MVH/MVGenomseq/refs/tags/v1.3.0/GRZ/grz-schema.json",
   "submission": {
     "submissionDate": "2024-07-15",
     "submissionType": "test",

--- a/tests/test_check_version.py
+++ b/tests/test_check_version.py
@@ -1,8 +1,9 @@
+import logging
 from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
-from grz_cli.utils.version_check import check_version_and_exit_if_needed
+from grz_cli.utils.version_check import check_metadata_version_and_exit_if_needed, check_version_and_exit_if_needed
 from packaging.version import Version
 
 
@@ -10,14 +11,15 @@ class DummyVersionInfo:
     def __init__(self, minimal_version, recommended_version, max_version, enforced_from):
         self.minimal_version = Version(minimal_version)
         self.recommended_version = Version(recommended_version)
-        self.max_version = Version(max_version)
+        self.max_version = Version(max_version) if max_version is not None else None
         self.enforced_from = enforced_from
 
 
 class DummyVersionFile:
-    def __init__(self, policies):
+    def __init__(self, policies, metadata_policies=None):
         self.schema_version = 1
         self.grzcli_version = policies
+        self.metadata_version = metadata_policies or []
 
 
 def test_too_old_after_enforcement():
@@ -55,11 +57,12 @@ def test_version_ok(caplog):
     policy = DummyVersionInfo("1.4.0", "1.5.0", "1.5.1", datetime(2020, 1, 1, tzinfo=UTC))
     vf = DummyVersionFile([policy])
 
-    with (
-        patch("grz_cli.utils.version_check.VersionFile.from_s3", return_value=vf),
-        patch("grz_cli.utils.version_check.version", return_value="1.5.0"),
-    ):
-        check_version_and_exit_if_needed(None)
+    with caplog.at_level(logging.INFO):
+        with (
+            patch("grz_cli.utils.version_check.VersionFile.from_s3", return_value=vf),
+            patch("grz_cli.utils.version_check.version", return_value="1.5.0"),
+        ):
+            check_version_and_exit_if_needed(None)
 
     assert "supported and tested range" in caplog.text
 
@@ -92,3 +95,18 @@ def test_selects_latest_active_policy():
         patch("grz_cli.utils.version_check.version", return_value="1.5.0"),
     ):
         check_version_and_exit_if_needed(None)
+
+
+def test_metadata_version_too_old_after_enforcement():
+    """The metadata schema version is old --> sys.exit."""
+    policy = DummyVersionInfo("1.3.0", "1.3.0", None, datetime(2020, 1, 1, tzinfo=UTC))
+    vf = DummyVersionFile([], metadata_policies=[policy])
+
+    with (
+        patch("grz_cli.utils.version_check.VersionFile.from_s3", return_value=vf),
+        patch("sys.exit", side_effect=SystemExit) as mock_exit,
+    ):
+        with pytest.raises(SystemExit):
+            check_metadata_version_and_exit_if_needed(None, "1.2.0")
+
+        mock_exit.assert_called_once_with(1)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from grz_common.utils.checksums import calculate_sha256
 from grz_common.workers.download import S3BotoDownloadWorker
+from grz_common.workers.worker import Worker
 
 
 @pytest.fixture(scope="module")
@@ -166,3 +167,40 @@ def test_download_redownloads_file_after_failed_download(
     assert mock_download.call_count == expected, (
         f"Expected {expected} failed files to be retried, but only {mock_download.call_count} were downloaded"
     )
+
+
+def test_worker_download_checks_metadata_version_before_files(
+    s3_config_model,
+    remote_bucket,
+    encrypted_submission,
+    tmp_path,
+):
+    """A failing metadata version check aborts before encrypted files are downloaded."""
+    metadata_path, metadata_key = encrypted_submission.get_metadata_file_path_and_object_id()
+    upload_file(remote_bucket, metadata_path, metadata_key)
+    for local_file_path, s3_key in encrypted_submission.get_encrypted_files_and_object_id().items():
+        upload_file(remote_bucket, local_file_path, s3_key)
+
+    worker = Worker(
+        metadata_dir=tmp_path / "metadata",
+        files_dir=tmp_path / "files",
+        log_dir=tmp_path / "logs",
+        encrypted_files_dir=tmp_path / "encrypted_files",
+    )
+
+    checked_versions = []
+
+    def fail_metadata_version_check(metadata_schema_version: str) -> None:
+        checked_versions.append(metadata_schema_version)
+        raise SystemExit(1)
+
+    with pytest.raises(SystemExit):
+        worker.download(
+            s3_config_model.s3,
+            encrypted_submission.submission_id,
+            metadata_version_check=fail_metadata_version_check,
+        )
+
+    assert checked_versions == [encrypted_submission.metadata.content.get_schema_version()]
+    assert (tmp_path / "metadata" / "metadata.json").exists()
+    assert not list((tmp_path / "encrypted_files").rglob("*.c4gh"))


### PR DESCRIPTION
**Metadata schema version check via version.json stored in the LE buckets**
Resolves #557 

Problem: Metadata schema version acceptance was hardcoded in get_accepted_versions() in grz-pydantic-models, requiring code updates to change which schema versions are accepted. 

Fix: Extended the existing version.json  (used for grz-cli version checks) to support metadata schema version enforcement:

i) Added metadata_version field to VersionFile model in grz-common
ii) Added check_metadata_version_and_exit_if_needed() function in grz-cli that fetches version.json from S3 and compares the submitted metadata's schema version against the policy
iii) Made s3 optional in ValidateConfig to support offline validation (check skipped when no S3 config provided)
iv) Called the metadata version check in the validate command after parsing the submission
v) Extended remote_bucket_with_version fixture to include metadata_version in test version.json
vi) Added integration test for metadata version check with S3 config
vii) Mocked the version check in existing validate tests that don't use S3 config

The metadata schema version is extracted from the submitted metadata.json via get_schema_version() on the GrzSubmissionMetadata model.