### PR TITLE
fix(grz-pydantic-models): handle datetime, FHIR extensions and verification in consent model (#610)Fix/consent field dtypes

### DIFF
--- a/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
@@ -88,6 +88,11 @@ class Patient(StrictIgnoringBaseModel):
     reference: str | None = None
 
 
+class Verification(StrictIgnoringBaseModel):
+    verified: bool
+    verification_date: datetime | None = None
+
+
 EXPECTED_SCOPE_CODING_SYSTEM = "http://terminology.hl7.org/CodeSystem/consentscope"
 EXPECTED_SCOPE_CODING_CODE = "research"
 EXPECTED_CATEGORIES = {
@@ -110,6 +115,7 @@ class Consent(StrictIgnoringBaseModel):
     patient: Patient
     date_time: datetime
     policy: Annotated[list[Policy], Field(min_length=1)]
+    verification: list[Verification] | None = None
     provision: RootConsentProvision | None = None
 
     @model_validator(mode="after")

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
@@ -11,6 +11,18 @@ class StrictIgnoringBaseModel(StrictBaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
+class Extension(StrictBaseModel):
+    # Extensions carry an open-ended value[x] payload, so extra keys are allowed here only.
+    model_config = ConfigDict(extra="allow")
+    url: str
+
+
+class FhirElement(StrictBaseModel):
+    # Every FHIR element may carry an id and extensions; any other unknown field stays forbidden.
+    id: str | None = None
+    extension: list[Extension] | None = None
+
+
 class ProvisionType(StrEnum):
     DENY = "deny"
     PERMIT = "permit"
@@ -25,7 +37,7 @@ class Status(StrEnum):
     ENTERED_IN_ERROR = "entered-in-error"
 
 
-class Period(StrictBaseModel):
+class Period(FhirElement):
     start: datetime
     end: datetime
 
@@ -48,7 +60,7 @@ class Policy(StrictIgnoringBaseModel):
     uri: str
 
 
-class Coding(StrictBaseModel):
+class Coding(FhirElement):
     system: str
     version: str | None = None
     code: str
@@ -56,7 +68,7 @@ class Coding(StrictBaseModel):
     user_selected: bool | None = None
 
 
-class CodeableConcept(StrictBaseModel):
+class CodeableConcept(FhirElement):
     coding: Annotated[list[Coding], Field(min_length=1)]
     text: str | None = None
 

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -348,6 +348,31 @@ def test_research_consent_tolerates_fhir_extensions():
     Consent.model_validate(consent_raw)
 
 
+def test_research_consent_parses_verification_date():
+    """A well-formed FHIR verification block (verified + verificationDate) must be parsed, not ignored."""
+    consent_raw = json.loads(
+        importlib.resources.files(example_research_consent).joinpath("mii_ig_consent_v2025_example1.json").read_text()
+    )
+    consent_raw["verification"] = [{"verified": True, "verificationDate": "2026-03-27T11:27:01+01:00"}]
+
+    consent = Consent.model_validate(consent_raw)
+
+    assert consent.verification is not None
+    assert consent.verification[0].verified is True
+    assert consent.verification[0].verification_date is not None
+
+
+def test_research_consent_rejects_verification_without_verified():
+    """`verified` is required (FHIR 1..1), so a verification entry missing it must be rejected."""
+    consent_raw = json.loads(
+        importlib.resources.files(example_research_consent).joinpath("mii_ig_consent_v2025_example1.json").read_text()
+    )
+    consent_raw["verification"] = [{"verificationDate": "2026-03-27T11:27:01+01:00"}]
+
+    with pytest.raises(ValidationError):
+        Consent.model_validate(consent_raw)
+
+
 def test_research_consent_still_rejects_unknown_fields():
     """Allowing id/extension must not turn into accepting arbitrary unknown fields."""
     consent_raw = json.loads(

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -333,6 +333,32 @@ def test_research_consent_parse(case: str, valid: bool):
         )
 
 
+def test_research_consent_tolerates_fhir_extensions():
+    """FHIR allows id/extension on every element, so they must not be rejected on codings, concepts, or periods."""
+    consent_raw = json.loads(
+        importlib.resources.files(example_research_consent).joinpath("mii_ig_consent_v2025_example1.json").read_text()
+    )
+
+    consent_raw["scope"]["coding"][0]["extension"] = [{"url": "http://example.org/ext", "valueString": "x"}]
+    consent_raw["scope"]["coding"][0]["id"] = "coding-1"
+    consent_raw["category"][0]["extension"] = [{"url": "http://example.org/ext"}]
+    consent_raw["provision"]["provision"][0]["period"]["extension"] = [{"url": "http://example.org/ext"}]
+    consent_raw["provision"]["provision"][0]["period"]["id"] = "period-1"
+
+    Consent.model_validate(consent_raw)
+
+
+def test_research_consent_still_rejects_unknown_fields():
+    """Allowing id/extension must not turn into accepting arbitrary unknown fields."""
+    consent_raw = json.loads(
+        importlib.resources.files(example_research_consent).joinpath("mii_ig_consent_v2025_example1.json").read_text()
+    )
+    consent_raw["scope"]["coding"][0]["pandorras-box"] = "I am in"
+
+    with pytest.raises(ValidationError):
+        Consent.model_validate(consent_raw)
+
+
 @pytest.mark.parametrize(
     "cases,consenting",
     (


### PR DESCRIPTION
Follow-up to #610. The original bug there (non-zero time in dateTime) was already fixed, but the issue also asked whether other fields were handled correctly.  Two things came out of it:

FHIR extensions. Real consent resources from LEs can carry id and extension on pretty much any element, but our Coding, CodeableConcept, and Period models used extra="forbid", so they'd reject an otherwise-valid resource just because it had an extension on a coding. Added a small FHIRElement base (optional id + extension) and had those three inherit from it. Unknown fields are still rejected. 

Verification. The verification element (and its verificationDate) wasn't modeled at all. Added a Verification model and an optional verification list on Consent. 