### PR TITLE
ci(repo): add refresh-lock job and aggregator check-runs

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -32,3 +32,20 @@ jobs:
           requireScope: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Aggregator job: a single, stable check-run name to use as the required
+  # status check in branch protection, independent of the underlying job name.
+  conventional-commit-pr:
+    name: Conventional commit PRs
+    needs: [main]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Verify PR title validation did not fail
+        run: |
+          # Fail only on failure/cancelled; a skipped run is allowed.
+          result="${{ needs.main.result }}"
+          if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+            echo "PR title validation did not pass: $result"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,3 +335,47 @@ jobs:
         env:
           GRZ_TOX_PACKAGE: ${{ steps.pkg_info.outputs.name }}
         run: uv run tox -e py${{ matrix.python-version }} -- ${{ matrix.package.path }}
+
+  # Aggregator job: a single, stable check-run name to use as the required
+  # status check in branch protection. Stays valid even when matrix jobs are
+  # skipped (nothing changed) or individual job names change. Lists every leaf
+  # job below - keep this in sync when adding or removing jobs.
+  ci:
+    name: CI
+    needs:
+      - determine-changes
+      - quality-checks-python
+      - quality-checks-rust
+      - build-grz-check-binary
+      - test-changed-packages-rust
+      - run-workspace-tests-python
+      - test-changed-packages-python
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Verify no upstream job failed
+        shell: bash
+        run: |
+          # Fail only on failure/cancelled. A skipped job is allowed.
+          declare -A results=(
+            [determine-changes]="${{ needs.determine-changes.result }}"
+            [quality-checks-python]="${{ needs.quality-checks-python.result }}"
+            [quality-checks-rust]="${{ needs.quality-checks-rust.result }}"
+            [build-grz-check-binary]="${{ needs.build-grz-check-binary.result }}"
+            [test-changed-packages-rust]="${{ needs.test-changed-packages-rust.result }}"
+            [run-workspace-tests-python]="${{ needs.run-workspace-tests-python.result }}"
+            [test-changed-packages-python]="${{ needs.test-changed-packages-python.result }}"
+          )
+          failed=0
+          for job in "${!results[@]}"; do
+            result="${results[$job]}"
+            echo "$job=$result"
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "::error::Upstream job did not pass: $job=$result"
+              failed=1
+            fi
+          done
+          if [ "$failed" -ne 0 ]; then
+            exit 1
+          fi
+          echo "All upstream jobs passed or were skipped."

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,10 @@ on:
       - main # Or your default branch
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -14,6 +18,8 @@ jobs:
       paths_released: ${{ steps.release.outputs.paths_released }}
       # releases_created is true if any release PR was created/updated
       releases_created: ${{ steps.release.outputs.releases_created }}
+      # JSON array of the open release PR objects (consumed by refresh-lock)
+      prs: ${{ steps.release.outputs.prs }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -26,13 +32,51 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.RELEASE_PLEASE_PAT }}
 
-  release-pr-check:
+  # release-please bumps package versions in the release PR but does not touch
+  # the workspace uv.lock, so `uv lock --check` in CI fails on that PR. This job
+  # refreshes uv.lock on the release PR branch and pushes it back. It checks out
+  # with the PAT (not GITHUB_TOKEN) so the pushed commit re-triggers CI.
+  refresh-lock:
+    name: Refresh uv.lock on release PR
     needs: release-please
-    if: needs.release-please.outputs.releases_created == 'true'
+    if: ${{ needs.release-please.outputs.prs != '' && needs.release-please.outputs.prs != '[]' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: Confirm Release PR
+      - name: Determine release PR branch
+        id: branch
         run: |
-          echo "A Release PR has been created or updated by release-please."
-          echo "Affected paths in this release cycle (before PR merge): ${{ needs.release-please.outputs.paths_released }}"
-          echo "Merge the 'chore: release ...' PR to trigger tagging and publishing."
+          BRANCH=$(echo '${{ needs.release-please.outputs.prs }}' | jq -r '.[0].headBranchName')
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.branch.outputs.name }}
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version-file: "pyproject.toml"
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Refresh uv.lock
+        run: |
+          uv lock
+          if git diff --quiet uv.lock; then
+            echo "uv.lock already in sync - nothing to commit."
+            exit 0
+          fi
+          # Attribute the lock refresh to the github-actions bot (41898282 is that
+          # account's stable user id). The push uses RELEASE_PLEASE_PAT so CI re-runs
+          # on the PR - the commit author is independent of the pushing token.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: refresh uv.lock for release"
+          git push


### PR DESCRIPTION
Auto-refresh the workspace `uv.lock` on release PRs, and expose stable aggregator status checks for branch
protection. All entries use the non-releasable `ci` type, so this PR produces no version bump or changelog entry.
I dropped `release-pr-check`, because it was a pure-echo job whose trigger (releases_created, post-merge) contradicted its own "go merge the PR" message.

ci(repo): refresh uv.lock on the release PR branch

Replace the echo-only `release-pr-check` job with a `refresh-lock` job.
release-please bumps package versions but not the workspace `uv.lock`, so
`uv lock --check` failed on every release PR. The job checks out the release PR
branch with `RELEASE_PLEASE_PAT` (so the pushed commit re-triggers CI), runs
`uv lock`, and commits + pushes any change. Also exposes the release-please
`prs` output.
Fixes #620.

ci(repo): add stable CI aggregator status checks

Add a `ci` and a `conventional-commit-pr` job that `needs` all leaf jobs, runs with `if: always()`, and fails
only on `failure`/`cancelled` (skipped is allowed).
Fixes #621 