### PR TITLE
feat(grz-db): add cases table and pluggable case resolver

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,16 @@ uv run tox
 Some packages have their own unit tests.
 Run `uv run tox` while inside a specific package directory to run that package's unit tests.
 
+### Database tests
+
+Database tests should use the fixtures from `grz_db.testing` (`db` is the usual entry point) rather
+than constructing their own engine. These fixtures parametrize each test over both sqlite and
+PostgreSQL, so a test that builds its own engine instead only ever exercises sqlite.
+
+The PostgreSQL half is skipped when `pg_config` is not on your `PATH`, and pytest reports this as
+skips rather than failures. A green run with a large skip count can therefore mean half the database
+tests never executed, so check the skip count rather than only the exit status.
+
 ## Code formatting and linting
 
 This project uses ruff for code formatting and linting.

--- a/packages/grz-db/pyproject.toml
+++ b/packages/grz-db/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "alembic[tz] >=1.16.1",
     "cryptography >=45.0.3,<49",
     "sqlmodel >=0.0.38",
-    "grz-pydantic-models >=3,<4",
+    "grz-pydantic-models >=3.1,<4",
     "psycopg[binary] ~=3.2"
 ]
 

--- a/packages/grz-db/src/grz_db/errors.py
+++ b/packages/grz-db/src/grz_db/errors.py
@@ -74,7 +74,7 @@ class DuplicatePsnError(CaseError):
     """Exception for when a case with the given RKI pseudonym already exists."""
 
     def __init__(self, psn: str):
-        super().__init__(f"A case with pseudonym '{psn}' already exists")
+        super().__init__(f"A case with RKI pseudonym '{psn}' already exists")
 
 
 class DuplicateCaseError(CaseError):
@@ -92,16 +92,16 @@ class CaseHasLinkedSubmissionsError(CaseError):
 
 
 class SubmissionTypeInvalidForCaseError(SubmissionError):
-    """Exception for when a submission's type is incompatible with its case state."""
+    """Exception for when a submission's type does not permit the case link being attempted."""
 
 
 class DuplicateInitialSubmissionError(SubmissionTypeInvalidForCaseError):
     """Exception for when a case would end up with a second initial submission that passed basic QC."""
 
     def __init__(self, case_id: int | None, winning_submission_id: str | None = None):
-        qc_passed = f" '{winning_submission_id}'" if winning_submission_id else ""
+        holder = f" ({winning_submission_id})" if winning_submission_id else ""
         super().__init__(
-            f"Case {case_id} already has an initial submission that passed basic QC{qc_passed}; "
+            f"Case {case_id} already has an initial submission that passed basic QC{holder}; "
             "at most one initial submission per case may pass basic QC."
         )
 

--- a/packages/grz-db/src/grz_db/errors.py
+++ b/packages/grz-db/src/grz_db/errors.py
@@ -1,3 +1,6 @@
+from collections.abc import Sequence
+
+
 class GrzDbError(Exception):
     """Base class for all grz_db errors."""
 
@@ -54,3 +57,61 @@ class SubmissionBasicQCNotPassedError(SubmissionError):
 
 class DatabaseConfigurationError(DatabaseError):
     """Exception for database configuration issues."""
+
+
+class CaseError(GrzDbError):
+    """Base class for errors related to cases."""
+
+
+class CaseNotFoundError(CaseError):
+    """Exception for when a case is not found in the database."""
+
+    def __init__(self, case_id: int):
+        super().__init__(f"Case not found for ID {case_id}")
+
+
+class DuplicatePsnError(CaseError):
+    """Exception for when a case with the given RKI pseudonym already exists."""
+
+    def __init__(self, psn: str):
+        super().__init__(f"A case with pseudonym '{psn}' already exists")
+
+
+class DuplicateCaseError(CaseError):
+    """Exception for when a case with the given submitter and local case ID already exists."""
+
+    def __init__(self, submitter_id: str | None, local_case_id: str | None):
+        super().__init__(f"A case for submitter '{submitter_id}' and local case '{local_case_id}' already exists")
+
+
+class CaseHasLinkedSubmissionsError(CaseError):
+    """Exception for when a case cannot be deleted because submissions are still linked to it."""
+
+    def __init__(self, case_id: int, count: int):
+        super().__init__(f"Case {case_id} still has {count} linked submission(s) and cannot be deleted")
+
+
+class SubmissionTypeInvalidForCaseError(SubmissionError):
+    """Exception for when a submission's type is incompatible with its case state."""
+
+
+class DuplicateInitialSubmissionError(SubmissionTypeInvalidForCaseError):
+    """Exception for when a case would end up with a second initial submission that passed basic QC."""
+
+    def __init__(self, case_id: int | None, winning_submission_id: str | None = None):
+        qc_passed = f" '{winning_submission_id}'" if winning_submission_id else ""
+        super().__init__(
+            f"Case {case_id} already has an initial submission that passed basic QC{qc_passed}; "
+            "at most one initial submission per case may pass basic QC."
+        )
+
+
+class AmbiguousCaseError(SubmissionError):
+    """Exception for when a case resolution key matches more than one case."""
+
+    def __init__(self, submitter_id: str | None, local_case_id: str | None, case_ids: Sequence[int]):
+        ids = ", ".join(str(case_id) for case_id in sorted(case_ids))
+        super().__init__(
+            f"Cases [{ids}] share (submitter '{submitter_id}', local case '{local_case_id}'); cannot resolve "
+            "automatically. Relink the cases' submissions and delete the duplicate cases to disambiguate."
+        )

--- a/packages/grz-db/src/grz_db/migrations/README.md
+++ b/packages/grz-db/src/grz_db/migrations/README.md
@@ -22,6 +22,7 @@ To easily find the appropriate SQLAlchemy column type for a migration operation,
 ```py
 import sqlmodel.main
 from grz_db.models.submission import SubmissionBase
+
 sqlmodel.main.get_column_from_field(SubmissionBase.model_fields["new_column_name"])
 ```
 

--- a/packages/grz-db/src/grz_db/migrations/versions/f8c1a4b7e2d9_add_cases_and_link_submissions.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/f8c1a4b7e2d9_add_cases_and_link_submissions.py
@@ -1,0 +1,195 @@
+"""add cases table and link submissions
+
+Revision ID: f8c1a4b7e2d9
+Revises: c8d4a7f2b1e6
+Create Date: 2026-07-08 00:00:00.000000+00:00
+
+Introduces the ``cases`` table and links each submission to its case via ``submissions.case_id``.
+
+A case's authoritative identity is ``psn`` (the RKI pseudonym), unique once assigned.
+``submitter_id`` and ``local_case_id`` are resolution keys (indexed, but not a uniqueness
+constraint) used to locate a case before a ``psn`` exists. Existing submissions are grouped by
+``(submitter_id, pseudonym)`` (the ``pseudonym`` column holds the submitter-local case id) and
+backfilled into cases. ``submissions.submitter_id`` is kept.
+
+Also extends ``failurereasonenum`` with ``duplicate_initial``, recorded on a duplicate initial
+submission: one being validated for a case whose initial submission already passed basic QC.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlmodel.sql.sqltypes import AutoString
+
+# revision identifiers, used by Alembic.
+revision: str = "f8c1a4b7e2d9"
+down_revision: str | Sequence[str] | None = "c8d4a7f2b1e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Mirrors grz_pydantic_models.submission.metadata.REDACTED_LOCAL_CASE_ID; hardcoded so the
+# migration stays frozen. Redaction placeholders (this literal, or the empty string used by
+# older archival code) are not case keys; SubmissionDb applies the same check at runtime.
+PSEUDONYM_NON_KEYS = ["", "REDACTED_LOCAL_CASE_ID"]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    bind = op.get_bind()
+    submissions = sa.Table("submissions", sa.MetaData(), autoload_with=bind)
+
+    # Fail fast only on genuinely unresolvable data: more than one QC-passed 'initial' submission
+    # with the same (submitter_id, local_case_id). Pending or failed duplicates are legal, since a
+    # case may have at most one initial submission that passed basic QC; they simply stay linked
+    # to their case. Rows that cannot form a key are left unlinked.
+    duplicate_initials = bind.execute(
+        sa.select(
+            submissions.c.submitter_id,
+            submissions.c.pseudonym,
+            sa.func.count().label("n"),
+        )
+        .where(
+            submissions.c.pseudonym.is_not(None),
+            submissions.c.pseudonym.not_in(PSEUDONYM_NON_KEYS),
+            submissions.c.submitter_id.is_not(None),
+            submissions.c.submission_type == "initial",
+            submissions.c.basic_qc_passed.is_(True),
+        )
+        .group_by(submissions.c.submitter_id, submissions.c.pseudonym)
+        .having(sa.func.count() > 1)
+    ).fetchall()
+
+    if duplicate_initials:
+        groups = ", ".join(f"({row[0]}, {row[1]}): {row[2]}" for row in duplicate_initials)
+        raise RuntimeError(
+            "Cannot backfill cases: more than one QC-passed 'initial' submission shares the same "
+            f"(submitter_id, local_case_id): {groups}"
+        )
+
+    # --- Create the cases table ---
+    op.create_table(
+        "cases",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("psn", AutoString(), nullable=True),
+        sa.Column("submitter_id", AutoString(), nullable=True),
+        sa.Column("local_case_id", AutoString(), nullable=True),
+    )
+    # psn is the authoritative identity: unique when present.
+    op.create_index(
+        "ux_cases_psn",
+        table_name="cases",
+        columns=["psn"],
+        unique=True,
+        postgresql_where=sa.text("psn IS NOT NULL"),
+        sqlite_where=sa.text("psn IS NOT NULL"),
+    )
+    # A submitter's local case ID identifies one patient, so it identifies one case. Unique only
+    # where both halves are present: a case resolved by psn alone carries neither, and any number
+    # of those may coexist. Without this two processes populating one patient's submissions both
+    # find no case and both create one, which leaves the key ambiguous for good.
+    op.create_index(
+        "ux_cases_submitter_local_case",
+        table_name="cases",
+        columns=["submitter_id", "local_case_id"],
+        unique=True,
+        postgresql_where=sa.text("submitter_id IS NOT NULL AND local_case_id IS NOT NULL"),
+        sqlite_where=sa.text("submitter_id IS NOT NULL AND local_case_id IS NOT NULL"),
+    )
+
+    # --- Link column on submissions ---
+    op.add_column("submissions", sa.Column("case_id", sa.Integer(), nullable=True))
+    op.create_index("ix_submissions_case_id", "submissions", ["case_id"])
+    if bind.dialect.name == "postgresql":
+        # SQLite cannot ALTER TABLE ADD CONSTRAINT; the ORM declares the FK regardless.
+        op.create_foreign_key(
+            "fk_submissions_case_id_cases",
+            source_table="submissions",
+            referent_table="cases",
+            local_cols=["case_id"],
+            remote_cols=["id"],
+        )
+
+    # --- Backfill: one case per distinct (submitter_id, pseudonym), storing the keys, then link ---
+    # Lightweight, standalone Table objects (not reflected) describing just the columns we
+    # need. A fresh MetaData per table avoids re-defining the ``submissions`` table reflected above.
+    cases = sa.Table(
+        "cases",
+        sa.MetaData(),
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("submitter_id", AutoString()),
+        sa.Column("local_case_id", AutoString()),
+    )
+    submissions_link = sa.Table(
+        "submissions",
+        sa.MetaData(),
+        sa.Column("case_id", sa.Integer()),
+        sa.Column("submitter_id", AutoString()),
+        sa.Column("pseudonym", AutoString()),
+        # declared as the existing native enum so comparisons render with the right type
+        sa.Column(
+            "submission_type",
+            sa.Enum("initial", "followup", "addition", "correction", "test", name="submissiontype"),
+        ),
+    )
+
+    # Only rows that can form a (submitter_id, pseudonym) key participate in the backfill.
+    # Test submissions are never case-tracked; the explicit NULL check keeps rows with an unknown
+    # type in the backfill, since SQL's three-valued logic would otherwise exclude them too.
+    has_keys = sa.and_(
+        submissions_link.c.pseudonym.is_not(None),
+        submissions_link.c.pseudonym.not_in(PSEUDONYM_NON_KEYS),
+        submissions_link.c.submitter_id.is_not(None),
+        sa.or_(
+            submissions_link.c.submission_type.is_(None),
+            submissions_link.c.submission_type != "test",
+        ),
+    )
+    # INSERT INTO cases (submitter_id, local_case_id)
+    # SELECT DISTINCT submitter_id, pseudonym FROM submissions WHERE has_keys
+    bind.execute(
+        sa.insert(cases).from_select(
+            ["submitter_id", "local_case_id"],
+            sa.select(submissions_link.c.submitter_id, submissions_link.c.pseudonym).where(has_keys).distinct(),
+        )
+    )
+    # Scalar subquery, one per submissions row, that looks up the matching case's id:
+    #   SELECT c.id FROM cases c
+    #   WHERE c.submitter_id = submissions.submitter_id AND c.local_case_id = submissions.pseudonym
+    matching_case_id = (
+        sa.select(cases.c.id)
+        .where(
+            cases.c.submitter_id == submissions_link.c.submitter_id,
+            cases.c.local_case_id == submissions_link.c.pseudonym,
+        )
+        # mark `submissions_link` as coming from the enclosing UPDATE
+        .correlate(submissions_link)
+        # mark the SELECT as a single-value expression usable in `SET case_id = ...`.
+        .scalar_subquery()
+    )
+    bind.execute(sa.update(submissions_link).values(case_id=matching_case_id).where(has_keys))
+
+    # --- Enforce at most one QC-passed initial submission per case ---
+    # Several initial submissions may be linked while pending basic QC (the data alone cannot
+    # tell competing uploads apart); whichever passes basic QC first becomes the case's
+    # QC-passed initial submission.
+    op.create_index(
+        "ux_submissions_one_initial_per_case",
+        table_name="submissions",
+        columns=["case_id"],
+        unique=True,
+        postgresql_where=sa.text("submission_type = 'initial' AND basic_qc_passed IS TRUE"),
+        sqlite_where=sa.text("submission_type = 'initial' AND basic_qc_passed IS TRUE"),
+    )
+
+    # --- Failure reason for the duplicate initial submission ---
+    # SQLite stores the enum as plain VARCHAR, so only PostgreSQL needs the type extended.
+    # ADD VALUE inside a transaction requires PostgreSQL 12+, and even then the new value
+    # cannot be used in the same transaction; this migration does not use it.
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TYPE failurereasonenum ADD VALUE IF NOT EXISTS 'duplicate_initial'")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    raise RuntimeError("Downgrades not supported.")

--- a/packages/grz-db/src/grz_db/migrations/versions/f8c1a4b7e2d9_add_cases_and_link_submissions.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/f8c1a4b7e2d9_add_cases_and_link_submissions.py
@@ -7,10 +7,12 @@ Create Date: 2026-07-08 00:00:00.000000+00:00
 Introduces the ``cases`` table and links each submission to its case via ``submissions.case_id``.
 
 A case's authoritative identity is ``psn`` (the RKI pseudonym), unique once assigned.
-``submitter_id`` and ``local_case_id`` are resolution keys (indexed, but not a uniqueness
-constraint) used to locate a case before a ``psn`` exists. Existing submissions are grouped by
-``(submitter_id, pseudonym)`` (the ``pseudonym`` column holds the submitter-local case id) and
-backfilled into cases. ``submissions.submitter_id`` is kept.
+``submitter_id`` and ``local_case_id`` are resolution keys used to locate a case before a ``psn``
+exists, not the authoritative identity themselves. The partial unique index
+``ux_cases_submitter_local_case`` keeps the pair unique wherever both halves are present; neither
+is required, since a future flow may resolve a case by ``psn`` alone. Existing submissions are
+grouped by ``(submitter_id, pseudonym)`` (the ``pseudonym`` column holds the submitter-local case
+id) and backfilled into cases. ``submissions.submitter_id`` is kept.
 
 Also extends ``failurereasonenum`` with ``duplicate_initial``, recorded on a duplicate initial
 submission: one being validated for a case whose initial submission already passed basic QC.

--- a/packages/grz-db/src/grz_db/migrations/versions/f8c1a4b7e2d9_add_cases_and_link_submissions.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/f8c1a4b7e2d9_add_cases_and_link_submissions.py
@@ -12,7 +12,12 @@ exists, not the authoritative identity themselves. The partial unique index
 ``ux_cases_submitter_local_case`` keeps the pair unique wherever both halves are present; neither
 is required, since a future flow may resolve a case by ``psn`` alone. Existing submissions are
 grouped by ``(submitter_id, pseudonym)`` (the ``pseudonym`` column holds the submitter-local case
-id) and backfilled into cases. ``submissions.submitter_id`` is kept.
+id) and backfilled into cases. ``submitter_id`` stays on the submission row as well as on the
+case.
+
+Refuses to run when the existing data cannot be grouped: two or more QC-passed ``initial``
+submissions sharing a ``(submitter_id, pseudonym)`` abort the upgrade, naming the groups. Resolve
+those rows first.
 
 Also extends ``failurereasonenum`` with ``duplicate_initial``, recorded on a duplicate initial
 submission: one being validated for a case whose initial submission already passed basic QC.
@@ -30,9 +35,9 @@ down_revision: str | Sequence[str] | None = "c8d4a7f2b1e6"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
-# Mirrors grz_pydantic_models.submission.metadata.REDACTED_LOCAL_CASE_ID; hardcoded so the
-# migration stays frozen. Redaction placeholders (this literal, or the empty string used by
-# older archival code) are not case keys; SubmissionDb applies the same check at runtime.
+# Mirrors grz_pydantic_models.submission.metadata.LOCAL_CASE_ID_PLACEHOLDERS; hardcoded so the
+# migration stays frozen. The archive contains both spellings as redaction placeholders; neither
+# identifies a patient, so neither is a case key. SubmissionDb applies the same check at runtime.
 PSEUDONYM_NON_KEYS = ["", "REDACTED_LOCAL_CASE_ID"]
 
 

--- a/packages/grz-db/src/grz_db/models/submission/__init__.py
+++ b/packages/grz-db/src/grz_db/models/submission/__init__.py
@@ -7,8 +7,9 @@ import random
 import re
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
+from enum import Enum as PyEnum
 from operator import attrgetter
-from typing import Any, ClassVar, Literal, Optional, Self
+from typing import Any, ClassVar, Literal, Optional, Protocol, Self, cast
 
 import sqlalchemy as sa
 import sqlalchemy.dialects.postgresql as sa_psql
@@ -18,7 +19,6 @@ from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory as AlembicScriptDirectory
 from grz_pydantic_models.dates import date_to_quarter_year, quarter_date_bounds
 from grz_pydantic_models.submission.metadata import (
-    REDACTED_LOCAL_CASE_ID,
     REDACTED_TAN,
     CoverageType,
     DiseaseType,
@@ -34,6 +34,7 @@ from grz_pydantic_models.submission.metadata import (
     SubmissionType,
     SubmitterId,
     Tan,
+    is_redacted_local_case_id,
 )
 from grz_pydantic_models.submission.metadata.v1 import Donor as MetadataDonor
 from pydantic import ConfigDict, field_serializer, field_validator, model_validator
@@ -49,21 +50,30 @@ from ...common import (
     serialize_datetime_to_iso_z,
 )
 from ...errors import (
+    AmbiguousCaseError,
+    CaseHasLinkedSubmissionsError,
+    CaseNotFoundError,
+    DuplicateCaseError,
+    DuplicateInitialSubmissionError,
+    DuplicatePsnError,
     DuplicateSubmissionError,
     DuplicateTanGError,
     SubmissionBasicQCNotPassedError,
     SubmissionDateIsNoneError,
     SubmissionNotFoundError,
+    SubmissionTypeInvalidForCaseError,
     SubmissionTypeIsNoneError,
 )
 from ..author import Author
 from ..base import BaseSignablePayload, VerifiableLog
 from .diff import (  # noqa: F401
+    CaseLinkDiff,
     Diff,
     DiffState,
     DonorDiff,
     DonorsDiffCollection,
     FieldDiff,
+    SubmissionChangeSet,
     SubmissionDiffCollection,
 )
 
@@ -169,6 +179,11 @@ class SubmissionBase(SQLModel):
     )
 
 
+# The submitter's local case ID is stored in the pseudonym column; the other redacted
+# metadata field is named the same on both sides.
+_METADATA_FIELD_TO_COLUMN = {"local_case_id": "pseudonym"}
+
+
 class Submission(SubmissionBase, table=True):
     """Submission table model."""
 
@@ -185,9 +200,15 @@ class Submission(SubmissionBase, table=True):
             raise ValueError(f"Submission ID '{v}' does not match the required pattern.")
         return v
 
+    # additionally constrained by the partial unique index ux_submissions_one_initial_per_case
+    # (created in the cases migration): at most one QC-passed 'initial' submission per case
+    case_id: int | None = Field(default=None, foreign_key="cases.id", index=True)
+
     states: list["SubmissionStateLog"] = Relationship(back_populates="submission")
 
     changes: list["ChangeRequestLog"] = Relationship(back_populates="submission")
+
+    case: Optional["Case"] = Relationship(back_populates="submissions")
 
     def diff(
         self,
@@ -264,11 +285,188 @@ class Submission(SubmissionBase, table=True):
             }
         )
 
+    def restore_redacted_fields(self, metadata: GrzSubmissionMetadata) -> frozenset[str]:
+        """Restore *metadata*'s redacted fields from this row, in place.
+
+        The counterpart to :meth:`from_metadata`: that builds a row from metadata, this
+        fills metadata back in from a row. A metadata.json read back from an archive bucket
+        carries redaction placeholders, while this row recorded the submitter's values when
+        the submission was populated from the local, unredacted copy.
+
+        :param metadata: Parsed metadata, mutated in place.
+        :returns: Column names still redacted because this row holds no value for them.
+            Pass these to :meth:`SubmissionDb.diff` as ``ignore_fields`` so that a
+            placeholder is never written.
+        """
+        unrestored = metadata.restore_redacted_fields(tan_g=self.tan_g, local_case_id=self.pseudonym)
+        return frozenset(_METADATA_FIELD_TO_COLUMN.get(field, field) for field in unrestored)
+
+
+class Case(SQLModel, table=True):
+    """Case table model.
+
+    Groups the submissions for one patient. The authoritative identity is
+    ``psn`` (the RKI pseudonym), unique once assigned. ``submitter_id`` and ``local_case_id`` are
+    lookup keys used to resolve the case before a ``psn`` exists; they are deliberately *not* a
+    uniqueness constraint, since a future flow may resolve a case by ``psn`` alone (with
+    ``local_case_id`` absent).
+    """
+
+    # Without this a table model takes any value its annotations forbid, so a mistyped
+    # `db case create` would store a submitter ID no submission can ever carry and the case
+    # would sit unresolvable and unlinked. SQLModel builds rows through __setattr__, so this
+    # covers construction as well as assignment. Loading is unaffected: SQLAlchemy populates
+    # attributes without validating, so a row written before this stays readable.
+    model_config = ConfigDict(validate_assignment=True)  # type: ignore[assignment]
+
+    __tablename__ = "cases"
+    __table_args__ = {"extend_existing": True}
+
+    immutable_fields: ClassVar[set[str]] = {"id"}
+
+    id: int | None = Field(default=None, primary_key=True)
+    # uniqueness is enforced by the partial unique index ux_cases_psn (see the cases migration),
+    # which SQLModel field arguments cannot express; declaring index=True here would advertise a
+    # plain non-unique index that does not exist.
+    psn: str | None = Field(default=None)
+    submitter_id: SubmitterId | None = Field(default=None)
+    local_case_id: str | None = Field(default=None)
+
+    submissions: list["Submission"] = Relationship(back_populates="case")
+
+    @classmethod
+    def mutable_fields(cls) -> set[str]:
+        """Field names that :meth:`SubmissionDb.modify_case` may change.
+
+        All model fields except those in :attr:`immutable_fields`. Relationship
+        attributes (e.g. ``submissions``) are not model fields, so they are
+        naturally excluded.
+
+        :returns: The set of modifiable field names.
+        """
+        return set(cls.model_fields.keys()) - cls.immutable_fields
+
+
+class _Index(PyEnum):
+    """A unique index of this schema, and how each backend says it was violated.
+
+    A rejected write arrives as one ``IntegrityError`` whatever it broke, so it has to be
+    classified: PostgreSQL names the index, SQLite names the indexed columns instead.
+    """
+
+    TAN_G = ("ix_submissions_tan_g", "submissions.tan_g")
+    ONE_INITIAL = ("ux_submissions_one_initial_per_case", "submissions.case_id")
+    CASE_KEY = ("ux_cases_submitter_local_case", "cases.submitter_id, cases.local_case_id")
+    CASE_PSN = ("ux_cases_psn", "cases.psn")
+
+    def __init__(self, index_name: str, sqlite_columns: str) -> None:
+        self.index_name = index_name
+        self.sqlite_columns = sqlite_columns
+
+
+def _rejected_by(e: IntegrityError) -> "_Index | None":
+    """Which of this schema's unique indices rejected the write, or ``None`` for anything else.
+
+    PostgreSQL puts the index in the driver's diagnostics, which is exact, so that is preferred
+    over reading the rendered message.
+    """
+    orig = getattr(e, "orig", None)
+    diag = getattr(orig, "diag", None) if orig is not None else None
+    named = getattr(diag, "constraint_name", None) if diag is not None else None
+    if named is not None:
+        return next((index for index in _Index if index.index_name == named), None)
+    message = str(e)
+    return next(
+        (
+            index
+            for index in _Index
+            if f"UNIQUE constraint failed: {index.sqlite_columns}" in message or index.index_name in message
+        ),
+        None,
+    )
+
+
+def _case_key_or_none(local_case_id: str | None) -> str | None:
+    """Return *local_case_id* when it can key a case, else ``None``.
+
+    Keying a case on a redaction placeholder would merge every redacted submission of a
+    submitter into a single case (see :func:`is_redacted_local_case_id`).
+    """
+    return None if is_redacted_local_case_id(local_case_id) else local_case_id
+
+
+class CaseResolver(Protocol):
+    """Strategy for locating the case a submission belongs to.
+
+    Different resolvers key on different identifiers, so the resolution rule can evolve
+    (currently ``(submitter_id, local_case_id)``; later the RKI ``psn``) without a schema change:
+    both keys are already columns on :class:`Case`. The seam is not the whole of such a switch,
+    though. Only :meth:`SubmissionDb.assign_case` and :meth:`SubmissionDb.resolve_case` take a
+    resolver; :meth:`SubmissionDb.diff` resolves through :data:`DEFAULT_CASE_RESOLVER`, so
+    metadata-driven linking would want one threaded through there and a ``psn`` on
+    :class:`CaseLinkDiff`.
+
+    Implementations raise :class:`AmbiguousCaseError` rather than guess when their key matches
+    more than one case.
+    """
+
+    def find_case(
+        self,
+        session: Session,
+        *,
+        submitter_id: str | None,
+        local_case_id: str | None,
+        psn: str | None,
+    ) -> "Case | None": ...
+
+
+class SubmitterLocalCaseResolver:
+    """Resolve a case by ``(submitter_id, local_case_id)``. The current default.
+
+    ``ux_cases_submitter_local_case`` makes the pair unique wherever both halves are present, so
+    a second match means that index is not in place. Picking one of the matches would link a
+    submission to another patient's case without saying so, and nothing in the key tells the
+    matches apart, so resolution raises instead of guessing.
+    """
+
+    def find_case(
+        self, session: Session, *, submitter_id: str | None, local_case_id: str | None, psn: str | None
+    ) -> "Case | None":
+        if not submitter_id or not local_case_id:
+            return None
+        matches = session.exec(
+            select(Case).where(Case.submitter_id == submitter_id, Case.local_case_id == local_case_id)
+        ).all()
+        if len(matches) > 1:
+            raise AmbiguousCaseError(submitter_id, local_case_id, [case.id for case in matches if case.id is not None])
+        return matches[0] if matches else None
+
+
+class PsnResolver:
+    """Resolve a case by RKI pseudonym. For future PSN-based linking.
+
+    Usable today by passing it to :meth:`SubmissionDb.assign_case` or
+    :meth:`SubmissionDb.resolve_case`, but not reached from ``diff``/``commit_changes``, and
+    nothing could feed it there yet: a psn comes from the tanG trade, not from the submitter's
+    metadata.
+    """
+
+    def find_case(
+        self, session: Session, *, submitter_id: str | None, local_case_id: str | None, psn: str | None
+    ) -> "Case | None":
+        if psn is None:
+            return None
+        return session.exec(select(Case).where(Case.psn == psn)).first()
+
+
+DEFAULT_CASE_RESOLVER: CaseResolver = SubmitterLocalCaseResolver()
+
 
 class FailureReasonEnum(CaseInsensitiveStrEnum, ListableEnum):  # type: ignore[misc]
     """Failure reason enum for submissions in ERROR state."""
 
     DUPLICATE_TANG = "duplicate_tang"
+    DUPLICATE_INITIAL = "duplicate_initial"
     INCOMPLETE_SUBMISSION = "incomplete_submission"
     DECRYPTION_ERROR = "decryption_error"
     NETWORK_ERROR = "network_error"
@@ -666,13 +864,11 @@ class SubmissionDb:
         only ever flushes, which is also what puts it in front of the indices while the
         handler that can name what they rejected is still in scope.
 
-        ``expire_on_commit=False`` keeps returned instances readable after the commit: the
-        flush has already fetched what the database assigns, such as autoincrement primary
-        keys, and nothing is computed later.
+        Instances stay usable after the commit, since nothing here is filled in by the
+        database itself.
 
         :param session: A session to join, or ``None`` to open one.
-        :raises OutdatedDatabaseSchemaError: if a session is opened here and the database is
-            not at the latest revision. A joined session is not re-checked.
+        :raises OutdatedDatabaseSchemaError: if the database is not at the latest revision.
         """
         if session is not None:
             yield session
@@ -698,7 +894,7 @@ class SubmissionDb:
         """Confirm, once, that the database is at the revision this code expects.
 
         Asking costs a scan of the migration directory and a connection of its own, and one
-        pass over a submission opens several sessions, so the answer is kept. Nothing makes
+        pass over a submission opens a session per write, so the answer is kept. Nothing makes
         it stale in a way that helps: migrating is an operator action, downgrades are not
         supported.
 
@@ -768,22 +964,64 @@ class SubmissionDb:
             session.flush()
             return db_submission
 
-    @staticmethod
-    def _is_tan_g_unique_violation(e: IntegrityError) -> bool:
-        # SQLite
-        if "UNIQUE constraint failed: submissions.tan_g" in str(e):
-            return True
-        # PostgreSQL (psycopg / psycopg2)
-        orig = getattr(e, "orig", None)
-        if orig is not None:
-            diag = getattr(orig, "diag", None)
-            if diag is not None:
-                return getattr(diag, "constraint_name", None) == "ix_submissions_tan_g"
-        return False
+    @contextmanager
+    def _translating_conflicts(
+        self,
+        session: Session,
+        *,
+        case_id: int | None = None,
+        case_key: tuple[str | None, str | None] | None = None,
+        psn: str | None = None,
+    ) -> Generator[None, None, None]:
+        """Turn a write this schema's indices rejected into the error that says what was rejected.
 
-    def modify_submission(  # noqa: C901
-        self, submission_id: str, key: str, value: Any, session: Session | None = None
-    ) -> Submission:
+        Every value is taken before the body runs, because the rollback expires the instances
+        they would otherwise be read from afterwards. That is why callers may pass an attribute
+        of a pending row straight in: an argument is evaluated at the ``with``, before the flush
+        that can be rejected.
+
+        :param session: Session to roll back, and to look the blocking submission up in.
+        :param case_id: Case whose one-initial slot the write targets.
+        :param case_key: ``(submitter_id, local_case_id)`` the write would give a case.
+        :param psn: Pseudonym the write would give a case.
+        :raises DuplicateTanGError: if a submission's ``tan_g`` is already stored.
+        :raises DuplicateInitialSubmissionError: if the case already has a QC-passed initial.
+        :raises DuplicateCaseError: if a case already holds ``case_key``.
+        :raises DuplicatePsnError: if a case already holds ``psn``.
+        """
+        try:
+            yield
+        except IntegrityError as e:
+            session.rollback()
+            match _rejected_by(e):
+                case _Index.TAN_G:
+                    raise DuplicateTanGError() from e
+                case _Index.ONE_INITIAL:
+                    raise self._duplicate_initial_error(session, case_id) from e
+                case _Index.CASE_KEY:
+                    raise DuplicateCaseError(*cast(tuple[str | None, str | None], case_key)) from e
+                case _Index.CASE_PSN:
+                    raise DuplicatePsnError(cast(str, psn)) from e
+                case None:
+                    raise
+        except Exception:
+            session.rollback()
+            raise
+
+    def _duplicate_initial_error(self, session: Session, case_id: int | None) -> DuplicateInitialSubmissionError:
+        """Build the domain error for a write the ``ux_submissions_one_initial_per_case`` index rejected.
+
+        The preceding rollback expires the session, so the submission that already passed basic QC
+        is queried again to name it in the message.
+
+        :param session: The session whose transaction was rolled back.
+        :param case_id: The case the rejected write targeted, read before the commit. A unique
+            index leaves NULLs unconstrained, so a rejected write always names a case.
+        """
+        qc_passed_initial = self._qc_passed_initial_of(session, case_id) if case_id is not None else None
+        return DuplicateInitialSubmissionError(case_id, qc_passed_initial.id if qc_passed_initial is not None else None)
+
+    def modify_submission(self, submission_id: str, key: str, value: Any, session: Session | None = None) -> Submission:
         """Set one column of a submission.
 
         :param session: Transaction to join; a fresh one is opened and committed when absent.
@@ -799,32 +1037,27 @@ class SubmissionDb:
                 raise SubmissionNotFoundError(submission_id)
 
             setattr(submission, key, value)
-            if key == "basic_qc_passed":
-                # Basic QC state changed -> Align the in-depth QC queue to the new state
-                queue_entry = active_session.get(QCQueueEntry, submission_id)
 
-                if submission.basic_qc_passed is True and queue_entry is None:
-                    # Basic QC passed -> Ensure that submission is tracked in the in-depth QC queue
-                    active_session.add(QCQueueEntry(submission_id=submission_id))
-                elif submission.basic_qc_passed is not True and queue_entry is not None:
-                    # Basic QC failed -> Ensure that submission is absent from the in-depth QC queue
-                    active_session.delete(queue_entry)
+            # The queue lookup below autoflushes the pending write, so the index can reject it
+            # there rather than at the commit; both paths must reach the handler.
+            with self._translating_conflicts(active_session, case_id=submission.case_id):
+                if key == "basic_qc_passed":
+                    # Basic QC state changed -> Align the in-depth QC queue to the new state
+                    queue_entry = active_session.get(QCQueueEntry, submission_id)
 
-                # Keep selection flag aligned with failed basic QC.
-                if submission.basic_qc_passed is False:
-                    submission.selected_for_qc = False
-            active_session.add(submission)
-            try:
+                    if submission.basic_qc_passed is True and queue_entry is None:
+                        # Basic QC passed -> Ensure that submission is tracked in the in-depth QC queue
+                        active_session.add(QCQueueEntry(submission_id=submission_id))
+                    elif submission.basic_qc_passed is not True and queue_entry is not None:
+                        # Basic QC failed -> Ensure that submission is absent from the in-depth QC queue
+                        active_session.delete(queue_entry)
+
+                    # Keep selection flag aligned with failed basic QC.
+                    if submission.basic_qc_passed is False:
+                        submission.selected_for_qc = False
+                active_session.add(submission)
                 active_session.flush()
-                return submission
-            except IntegrityError as e:
-                active_session.rollback()
-                if self._is_tan_g_unique_violation(e) and key == "tan_g":
-                    raise DuplicateTanGError() from e
-                raise
-            except Exception:
-                active_session.rollback()
-                raise
+            return submission
 
     def update_submission(self, submission: Submission) -> Submission:
         """
@@ -844,17 +1077,9 @@ class SubmissionDb:
                 setattr(db_submission, field, getattr(submission, field))
 
             session.add(db_submission)
-            try:
+            with self._translating_conflicts(session, case_id=db_submission.case_id):
                 session.flush()
-                return db_submission
-            except IntegrityError as e:
-                session.rollback()
-                if self._is_tan_g_unique_violation(e):
-                    raise DuplicateTanGError() from e
-                raise
-            except Exception:
-                session.rollback()
-                raise
+            return db_submission
 
     def set_selected_for_qc(self, submission_id: str, selected_for_qc: bool) -> Submission:
         value = "true" if selected_for_qc else "false"
@@ -1146,6 +1371,439 @@ class SubmissionDb:
             found = {s.id: s for s in session.exec(statement).all()}
         return [found.get(sid) for sid in submission_ids]
 
+    def get_case(self, case_id: int) -> Case | None:
+        """Retrieve a case by its primary key.
+
+        :param case_id: Primary key of the case.
+        :returns: The :class:`Case`, or ``None`` if no case has that ID.
+        """
+        with self.transaction() as session:
+            return session.get(Case, case_id)
+
+    def list_cases(self) -> list[tuple[Case, int]]:
+        """List all cases together with their linked-submission count.
+
+        Cases with no linked submissions are included with a count of ``0``.
+
+        :returns: A list of ``(case, linked_submission_count)`` tuples, ordered
+            by ascending case ID.
+        """
+        with self.transaction() as session:
+            rows = session.exec(
+                select(Case, sqlfn.count(Submission.id))  # type: ignore[arg-type]
+                .outerjoin(Submission, Submission.case_id == Case.id)  # type: ignore[arg-type]
+                .group_by(Case.id)  # type: ignore[arg-type]
+                .order_by(Case.id)  # type: ignore[arg-type]
+            ).all()
+            return list(rows)
+
+    def list_submissions_for_case(self, case_id: int) -> Sequence[Submission]:
+        """List all submissions linked to a case.
+
+        Each submission is returned with its ``states`` relationship eagerly
+        loaded. An unknown ``case_id`` yields an empty result rather than an error.
+
+        :param case_id: Primary key of the case whose submissions to list.
+        :returns: Submissions linked to the case, ordered by ascending
+            submission ID.
+        """
+        with self.transaction() as session:
+            return session.exec(
+                select(Submission)
+                .where(Submission.case_id == case_id)
+                .options(selectinload(Submission.states))  # type: ignore[arg-type]
+                .order_by(Submission.id)
+            ).all()
+
+    @staticmethod
+    def _qc_passed_initial_of(session: Session, case_id: int) -> Submission | None:
+        """Return the case's QC-passed ``initial`` submission, if any."""
+        return session.exec(
+            select(Submission).where(
+                Submission.case_id == case_id,
+                Submission.submission_type == SubmissionType.initial,
+                Submission.basic_qc_passed.is_(True),  # type: ignore[union-attr]
+            )
+        ).first()
+
+    def get_initial_submission(self, case_id: int) -> Submission | None:
+        """Return the ``initial`` submission of a case that passed basic QC.
+
+        Several competing initial submissions may be linked while pending basic QC; whichever
+        passes basic QC first becomes the case's QC-passed initial submission (enforced by a
+        partial unique index), so the result is unambiguous.
+
+        :param case_id: Primary key of the case.
+        :returns: The case's QC-passed ``initial`` submission, or ``None`` if no linked initial
+            submission has passed basic QC yet.
+        """
+        with self.transaction() as session:
+            return self._qc_passed_initial_of(session, case_id)
+
+    def create_case(
+        self, submitter_id: str | None = None, local_case_id: str | None = None, psn: str | None = None
+    ) -> Case:
+        """Create a case from the given identifiers.
+
+        The identifiers are the case's resolution keys: ``(submitter_id,
+        local_case_id)`` locate a case before a ``psn`` is assigned, while
+        ``psn`` (the RKI pseudonym) is the authoritative identity and must be
+        unique when present. All three are optional.
+
+        :param submitter_id: Submitter identifier resolution key.
+        :param local_case_id: Submitter-local case identifier resolution key.
+        :param psn: RKI pseudonym; must be unique across cases when set.
+        :returns: The newly created :class:`Case`, with its database-assigned ``id`` populated.
+        :raises DuplicateCaseError: if a case already has this ``(submitter_id, local_case_id)``.
+        :raises DuplicatePsnError: if ``psn`` is already assigned to another case.
+        """
+        with self.transaction() as session:
+            case = Case(submitter_id=submitter_id, local_case_id=local_case_id, psn=psn)
+            session.add(case)
+            # Both keys are enforced by an index, so asking first would only add a query that
+            # a concurrent write can invalidate between the answer and the insert.
+            with self._translating_conflicts(session, case_key=(submitter_id, local_case_id), psn=psn):
+                session.flush()
+            return case
+
+    def modify_case(self, case_id: int, key: str, value: Any) -> Case:
+        """Modify a single mutable field of a case.
+
+        Only mutable columns may be changed; ``id`` (and any other field listed
+        in :attr:`Case.immutable_fields`) is read-only.
+
+        :param case_id: Primary key of the case to modify.
+        :param key: Name of the column to set (e.g. ``"psn"``, ``"submitter_id"``,
+            ``"local_case_id"``).
+        :param value: New value for the column.
+        :returns: The updated :class:`Case`, reloaded from the database.
+        :raises ValueError: if ``key`` is not a column of ``cases`` or is read-only.
+        :raises CaseNotFoundError: if no case has the given ``case_id``.
+        :raises DuplicateCaseError: if the change would give two cases the same
+            ``(submitter_id, local_case_id)``.
+        :raises DuplicatePsnError: if ``key`` is ``"psn"`` and ``value`` is
+            already assigned to another case.
+        """
+        if key in Case.immutable_fields:
+            raise ValueError(f"Column '{key}' is read-only and cannot be modified.")
+        if key not in Case.mutable_fields():
+            raise ValueError(f"Unknown column key '{key}'")
+        with self.transaction() as session:
+            case = session.get(Case, case_id)
+            if case is None:
+                raise CaseNotFoundError(case_id)
+            setattr(case, key, value)
+            session.add(case)
+            # Which index rejected the write says what happened; the key being edited only says
+            # what was attempted, and a NOT NULL or check violation would wear the wrong name.
+            with self._translating_conflicts(session, case_key=(case.submitter_id, case.local_case_id), psn=str(value)):
+                session.flush()
+            return case
+
+    def delete_case(self, case_id: int) -> None:
+        """Delete a case, refusing when submissions are still linked to it.
+
+        :param case_id: Primary key of the case to delete.
+        :raises CaseNotFoundError: if no case has the given ``case_id``.
+        :raises CaseHasLinkedSubmissionsError: if one or more submissions are
+            still linked to the case.
+        """
+        with self.transaction() as session:
+            case = session.get(Case, case_id)
+            if case is None:
+                raise CaseNotFoundError(case_id)
+            count = session.exec(
+                select(sqlfn.count()).select_from(Submission).where(Submission.case_id == case_id)  # type: ignore[arg-type]
+            ).one()
+            if count:
+                raise CaseHasLinkedSubmissionsError(case_id, count)
+            session.delete(case)
+            session.flush()
+
+    def set_submission_case(self, submission_id: str, case_id: int) -> Submission:
+        """Link (or relink) a submission to an existing case.
+
+        A case may have at most one ``initial`` submission that passed basic QC. A partial unique
+        index enforces this at commit time, so a link that would break it raises instead.
+
+        :param submission_id: ID of the submission to link.
+        :param case_id: Primary key of the target case.
+        :returns: The updated :class:`Submission`, reloaded from the database.
+        :raises SubmissionNotFoundError: if no submission has the given
+            ``submission_id``.
+        :raises SubmissionTypeInvalidForCaseError: if the submission is a ``test``
+            submission, which is never case-tracked.
+        :raises CaseNotFoundError: if no case has the given ``case_id``.
+        :raises DuplicateInitialSubmissionError: if linking would give the case a second
+            QC-passed ``initial`` submission.
+        """
+        with self.transaction() as session:
+            submission = session.get(Submission, submission_id)
+            if submission is None:
+                raise SubmissionNotFoundError(submission_id)
+            self._assert_case_trackable(submission_id, submission.submission_type)
+            case = session.get(Case, case_id)
+            if case is None:
+                raise CaseNotFoundError(case_id)
+            submission.case_id = case_id
+            session.add(submission)
+            with self._translating_conflicts(session, case_id=case_id):
+                session.flush()
+            return submission
+
+    @staticmethod
+    def _assert_case_trackable(submission_id: str, submission_type: SubmissionType | None) -> None:
+        """Refuse a submission that cases do not cover, whichever door it arrived at.
+
+        Excluding ``test`` submissions is the only rule cases place on a submission's type, so
+        it has to hold for a link resolved from metadata and for one an operator names directly.
+
+        An unknown type is refused too, since it may yet turn out to be ``test``: a row that
+        has not been populated carries no type, and linking it would decide the question
+        before the metadata answers it. Populate resolves the link itself, so nothing is lost.
+
+        :raises SubmissionTypeInvalidForCaseError: if the submission is a ``test`` submission,
+            or if its type is not known yet.
+        """
+        if submission_type is None:
+            raise SubmissionTypeInvalidForCaseError(
+                f"submission '{submission_id}' has no submission type yet, so it cannot be "
+                "case-tracked; populate it first."
+            )
+        if submission_type == SubmissionType.test:
+            raise SubmissionTypeInvalidForCaseError(
+                f"'test' submission '{submission_id}' is not case-tracked; cases group clinical submissions only."
+            )
+
+    def _find_case_for_link(  # noqa: PLR0913
+        self,
+        session: Session,
+        submission_id: str,
+        *,
+        submitter_id: str | None,
+        local_case_id: str | None,
+        psn: str | None,
+        submission_type: SubmissionType,
+        resolver: CaseResolver,
+    ) -> tuple[Submission, "Case | None"]:
+        """Locate the case a submission may link to and validate the link. Performs no writes.
+
+        :returns: The submission and the existing matching :class:`Case`, or ``None`` in place
+            of the case if none matches and creating a new one is allowed.
+        :raises SubmissionNotFoundError: if no submission has the given
+            ``submission_id``.
+        :raises SubmissionTypeInvalidForCaseError: if the submission is a ``test``
+            submission, which is never case-tracked.
+        :raises AmbiguousCaseError: if the resolution key matches more than one case.
+        """
+        submission = session.get(Submission, submission_id)
+        if submission is None:
+            raise SubmissionNotFoundError(submission_id)
+
+        self._assert_case_trackable(submission_id, submission_type)
+
+        # No further rule by submission type. A case groups whatever arrived for one patient, so a
+        # followup whose initial never reached this GRZ opens the case itself: the submission is
+        # real, it is reported to BfArM on its own tanG, and refusing to link it would only keep it
+        # out of the record. Competing initial submissions coexist here too; the partial unique
+        # index is the sole case invariant, bounding how many may *pass* basic QC (see
+        # ``ux_submissions_one_initial_per_case``, classified by :func:`_rejected_by`).
+        return submission, resolver.find_case(session, submitter_id=submitter_id, local_case_id=local_case_id, psn=psn)
+
+    def assign_case(  # noqa: PLR0913
+        self,
+        submission_id: str,
+        *,
+        submitter_id: str | None = None,
+        local_case_id: str | None = None,
+        psn: str | None = None,
+        submission_type: SubmissionType,
+        resolver: CaseResolver | None = None,
+        session: Session | None = None,
+    ) -> Case:
+        """Resolve or create the case for a submission and link it.
+
+        A case may have at most one ``initial`` submission that passed basic QC. Once one passes,
+        no other ``initial`` submission of that case may pass.
+
+        The *resolver* strategy decides how an existing case is located (default:
+        ``(submitter_id, local_case_id)``). A brand-new case requires an ``initial`` submission.
+        Competing initial submissions may share a case while pending basic QC, since the data
+        alone cannot tell a re-upload from a duplicate; only one of them may ever pass basic QC.
+        A non-initial submission requires the case to have an initial submission that has not
+        failed basic QC.
+        ``test`` submissions are never case-tracked and are rejected. Re-running for an
+        already-linked submission makes no further change (safe to repeat).
+
+        :param submission_id: ID of the submission to assign.
+        :param submitter_id: Submitter identifier passed to the resolver and
+            stored on a newly created case.
+        :param local_case_id: Submitter-local case identifier passed to the
+            resolver and stored on a newly created case.
+        :param psn: RKI pseudonym passed to the resolver and stored on a newly
+            created case.
+        :param submission_type: Type of the submission. Any type may open a case,
+            since a patient's first submission to reach this GRZ need not be the
+            ``initial`` one; only ``test`` is rejected (never case-tracked).
+        :param resolver: Strategy used to locate an existing case; defaults to
+            :data:`DEFAULT_CASE_RESOLVER` (:class:`SubmitterLocalCaseResolver`).
+        :returns: The resolved or newly created :class:`Case` the submission is
+            now linked to.
+        :raises SubmissionNotFoundError: if no submission has the given
+            ``submission_id``.
+        :raises SubmissionTypeInvalidForCaseError: if the submission is a ``test``
+            submission, which is never case-tracked.
+        :raises DuplicateInitialSubmissionError: if the link would give the case a
+            second QC-passed initial submission.
+        :raises AmbiguousCaseError: if the resolution key matches more than one case.
+        """
+        resolver = resolver or DEFAULT_CASE_RESOLVER
+        with self.transaction(session) as active_session:
+            submission, case = self._find_case_for_link(
+                active_session,
+                submission_id,
+                submitter_id=submitter_id,
+                local_case_id=local_case_id,
+                psn=psn,
+                submission_type=submission_type,
+                resolver=resolver,
+            )
+            if case is None:
+                # The insert reaches the database at the flush, so that is inside the block: it
+                # is where a case another process created in the meantime rejects ours.
+                try:
+                    with self._translating_conflicts(active_session, case_key=(submitter_id, local_case_id), psn=psn):
+                        case = Case(submitter_id=submitter_id, local_case_id=local_case_id, psn=psn)
+                        active_session.add(case)
+                        active_session.flush()
+                except DuplicateCaseError:
+                    # Another process created this case between our lookup and our insert. Its row
+                    # is the case now, so join that one: losing the race is not a failure, and
+                    # letting it surface would fail a submission that did nothing wrong. A caller's
+                    # transaction loses nothing to the rollback, since the link below is the first
+                    # thing this applies.
+                    case = resolver.find_case(
+                        active_session, submitter_id=submitter_id, local_case_id=local_case_id, psn=psn
+                    )
+                    if case is None:  # pragma: no cover - the row that rejected our insert must exist
+                        raise
+                    # The rollback expired the submission the lookup handed back.
+                    submission = cast(Submission, active_session.get(Submission, submission_id))
+
+            # Linking is a write in its own right: whether the case was found or created by
+            # whoever won the race to create it, it may already hold the initial slot.
+            submission.case_id = case.id
+            active_session.add(submission)
+            with self._translating_conflicts(active_session, case_id=case.id):
+                active_session.flush()
+            return case
+
+    def resolve_case(  # noqa: PLR0913
+        self,
+        submission_id: str,
+        *,
+        submitter_id: str | None = None,
+        local_case_id: str | None = None,
+        psn: str | None = None,
+        submission_type: SubmissionType,
+        resolver: CaseResolver | None = None,
+        session: Session | None = None,
+    ) -> "Case | None":
+        """Preview the case :meth:`assign_case` would link, without writing.
+
+        Runs the same lookup and validation as :meth:`assign_case` but leaves
+        the database unchanged.
+
+        :param submission_id: ID of the submission to resolve a case for.
+        :param submitter_id: Submitter identifier passed to the resolver.
+        :param local_case_id: Submitter-local case identifier passed to the
+            resolver.
+        :param psn: RKI pseudonym passed to the resolver.
+        :param submission_type: Type of the submission. Any type may open a case,
+            since a patient's first submission to reach this GRZ need not be the
+            ``initial`` one; only ``test`` is rejected (never case-tracked).
+        :param resolver: Strategy used to locate an existing case; defaults to
+            :data:`DEFAULT_CASE_RESOLVER` (:class:`SubmitterLocalCaseResolver`).
+        :returns: The existing :class:`Case` the submission would be linked to,
+            or ``None`` if :meth:`assign_case` would create a new case.
+        :raises SubmissionNotFoundError: if no submission has the given
+            ``submission_id``.
+        :raises SubmissionTypeInvalidForCaseError: if the submission is a ``test``
+            submission, which is never case-tracked.
+        :raises AmbiguousCaseError: if the resolution key matches more than one case.
+        """
+        resolver = resolver or DEFAULT_CASE_RESOLVER
+        with self.transaction(session) as active_session:
+            _submission, case = self._find_case_for_link(
+                active_session,
+                submission_id,
+                submitter_id=submitter_id,
+                local_case_id=local_case_id,
+                psn=psn,
+                submission_type=submission_type,
+                resolver=resolver,
+            )
+            return case
+
+    def assert_no_duplicate_initial(  # noqa: PLR0913
+        self,
+        submission_id: str,
+        *,
+        submitter_id: str | None = None,
+        local_case_id: str | None = None,
+        psn: str | None = None,
+        submission_type: SubmissionType,
+        resolver: CaseResolver | None = None,
+    ) -> None:
+        """Ask, before writing anything, whether this would be a case's second QC-passed initial.
+
+        A case may have at most one ``initial`` submission that passed basic QC, and
+        ``ux_submissions_one_initial_per_case`` is what enforces it. Linking is deliberately
+        permissive, so :meth:`resolve_case` never flags a duplicate and the rejection lands only
+        when a second initial submission tries to *pass* basic QC. Finding out that late means
+        having validated a submission that cannot be accepted, so a caller about to spend that
+        effort can ask here instead.
+
+        The case and its QC-passed initial submission are read in one transaction, which is what
+        makes the answer one answer: asked separately, a competing initial can pass basic QC in
+        between and this would report a submission as clear that the index is about to reject.
+
+        Answering costs two queries, so callers that are going to write anyway should let the
+        index speak rather than ask twice.
+
+        :param submission_id: ID of the submission about to be validated. A case whose QC-passed
+            initial submission *is* this one is not a duplicate.
+        :param submitter_id: Submitter identifier passed to the resolver.
+        :param local_case_id: Submitter-local case identifier passed to the resolver. A redaction
+            placeholder cannot key a case (see :func:`_case_key_or_none`), so it is left alone.
+        :param psn: RKI pseudonym passed to the resolver.
+        :param submission_type: Type of the submission. Only ``initial`` can break this rule.
+        :param resolver: Strategy used to locate the case; defaults to
+            :data:`DEFAULT_CASE_RESOLVER`.
+        :raises DuplicateInitialSubmissionError: if the case already has a different ``initial``
+            submission that passed basic QC.
+        :raises SubmissionNotFoundError: if no submission has the given ``submission_id``.
+        :raises AmbiguousCaseError: if the resolution key matches more than one case.
+        """
+        if submission_type != SubmissionType.initial or _case_key_or_none(local_case_id) is None:
+            return
+
+        with self.transaction() as session:
+            case = self.resolve_case(
+                submission_id,
+                submitter_id=submitter_id,
+                local_case_id=local_case_id,
+                psn=psn,
+                submission_type=submission_type,
+                resolver=resolver,
+                session=session,
+            )
+            if case is None or case.id is None:
+                return
+            qc_passed_initial = self._qc_passed_initial_of(session, case.id)
+            if qc_passed_initial is not None and qc_passed_initial.id != submission_id:
+                raise DuplicateInitialSubmissionError(case.id, qc_passed_initial.id)
+
     def list_submissions(
         self,
         limit: int | None,
@@ -1322,42 +1980,89 @@ class SubmissionDb:
         self.set_selected_for_qc(submission_id, should_select)
         return should_select
 
+    @staticmethod
     def _diff_metadata(
-        self,
-        submission_id: str,
+        current_submission: Submission,
         metadata: GrzSubmissionMetadata,
         submission_uploaded_date: datetime.date,
         ignore_fields: set[str] | None = None,
     ) -> SubmissionDiffCollection:
         """Compare a submission's current database state against fresh metadata.
 
-        :param submission_id: Submission ID to look up.
+        :param current_submission: The submission's row, as :meth:`diff` read it.
         :param metadata: Parsed metadata from the submission's ``metadata.json``.
         :param submission_uploaded_date: Date of submission upload finish
         :param ignore_fields: Field names to skip entirely during the comparison.
-        :returns: A :class:`SubmissionDiffCollection` instance summarising all detected differences.
+        :returns: A :class:`SubmissionDiffCollection` instance summarising all detected
+            differences.
         """
-        current_submission = self.get_submission(submission_id)
-        if current_submission is None:
-            raise SubmissionNotFoundError(submission_id)
-
         if ignore_fields is None:
             ignore_fields = set()
 
         if isinstance(submission_uploaded_date, datetime.datetime):
             submission_uploaded_date = submission_uploaded_date.date()
 
-        new_submission = Submission.from_metadata(submission_id, metadata, submission_uploaded_date)
+        new_submission = Submission.from_metadata(current_submission.id, metadata, submission_uploaded_date)
 
         return current_submission.diff(new_submission, ignore_fields)
 
+    def _diff_case_link(
+        self,
+        session: Session,
+        current_submission: Submission,
+        metadata: GrzSubmissionMetadata,
+        ignore_fields: set[str],
+    ) -> CaseLinkDiff | None:
+        """Resolve whether committing *metadata* would change the submission's case link.
+
+        Case resolution is skipped when ``"case_id"`` is ignored, for ``test`` submissions
+        (never case-tracked), and when ``local_case_id`` is still a redaction placeholder
+        (see :func:`_case_key_or_none`); call :meth:`Submission.restore_redacted_fields` first when
+        *metadata* was read back from an archive bucket.
+
+        :param session: The transaction :meth:`diff` runs in.
+        :param current_submission: The submission's row, as :meth:`diff` read it.
+        :param metadata: Parsed metadata from the submission's ``metadata.json``.
+        :param ignore_fields: Field names skipped during the comparison.
+        :returns: A :class:`CaseLinkDiff` if the case assignment would change, else ``None``.
+        :raises AmbiguousCaseError: if the metadata's case key matches more than one case.
+        """
+        if (
+            "case_id" in ignore_fields
+            or metadata.submission.submission_type == SubmissionType.test
+            or _case_key_or_none(metadata.submission.local_case_id) is None
+        ):
+            return None
+
+        # Resolution re-reads the submission, which the session hands back from its identity
+        # map: *current_submission* is held here, so the row is not fetched a second time.
+        resolved = self.resolve_case(
+            current_submission.id,
+            submitter_id=metadata.submission.submitter_id,
+            local_case_id=metadata.submission.local_case_id,
+            submission_type=metadata.submission.submission_type,
+            session=session,
+        )
+        resolved_id = resolved.id if resolved is not None else None
+        if resolved is not None and resolved_id == current_submission.case_id:
+            return None
+        return CaseLinkDiff(
+            before=current_submission.case_id,
+            after=resolved_id,
+            submitter_id=metadata.submission.submitter_id,
+            local_case_id=metadata.submission.local_case_id,
+            submission_type=metadata.submission.submission_type,
+        )
+
     def _diff_donors(
         self,
+        session: Session,
         submission_id: str,
         metadata: GrzSubmissionMetadata,
     ) -> DonorsDiffCollection:
         """Diff all donors in *metadata* against the current database state.
 
+        :param session: The transaction :meth:`diff` runs in.
         :param submission_id: Submission ID to look up donors for.
         :param metadata: Parsed metadata from the submission's ``metadata.json``.
         :returns: A fully populated :class:`DonorDiff`.
@@ -1366,7 +2071,9 @@ class SubmissionDb:
         if isinstance(metadata_submission_date, datetime.datetime):
             metadata_submission_date = metadata_submission_date.date()
 
-        donors_in_db_submission = {donor.pseudonym: donor for donor in self.get_donors(submission_id=submission_id)}
+        donors_in_db_submission = {
+            donor.pseudonym: donor for donor in self.get_donors(submission_id=submission_id, session=session)
+        }
         donors_in_metadata = {
             (d := Donor.from_donor_metadata(submission_id, donor, metadata_submission_date)).pseudonym: d
             for donor in metadata.donors
@@ -1389,21 +2096,29 @@ class SubmissionDb:
         metadata: GrzSubmissionMetadata,
         submission_uploaded_date: datetime.date | None,
         ignore_fields: set[str] | None = None,
-    ) -> tuple[SubmissionDiffCollection, DonorsDiffCollection]:
+    ) -> SubmissionChangeSet:
         """
-        Generates differences between the current and previous states of submission metadata
-        and donors data.
+        Collects everything that committing *metadata* would change for a submission.
 
         This function compares the provided metadata and donors data with the existing
-        state in the system for a specific submission ID and returns the differences in two
-        separate collections.
+        state in the system for a specific submission ID. The returned change set carries
+        the submission-level field diffs, the donor diffs, and a pending case link (see
+        :attr:`SubmissionChangeSet.case_link`) when the metadata's case key resolves to a
+        different case than currently linked; :meth:`commit_changes` applies the link via
+        :meth:`assign_case`. ``test`` submissions are never case-tracked.
 
         :param submission_id: The unique identifier of the submission to be compared.
         :param metadata: The metadata of the submission to compare against.
         :param submission_uploaded_date: The date when the submission process was finished.
             If None, the field will not be included in the comparison.
-        :param ignore_fields: Optional set of field names to be ignored during the metadata comparison.
-        :returns: A tuple containing the differences in the submission metadata and the corresponding donor entries.
+        :param ignore_fields: Optional set of field names to be ignored during the metadata
+            comparison. ``"case_id"`` skips case-link resolution.
+        :raises SubmissionNotFoundError: if no submission has the given ``submission_id``.
+        :returns: A :class:`SubmissionChangeSet` with all detected differences. A case that
+            cannot be resolved is reported in
+            :attr:`SubmissionChangeSet.case_link_error` rather than raised, since it says
+            nothing about the other diffs; :meth:`resolve_case` still raises for a caller
+            that asked about the case alone.
         """
         if submission_uploaded_date is None:
             # set arbitrary date if not provided
@@ -1413,75 +2128,105 @@ class SubmissionDb:
             ignore_fields = ignore_fields or set()
             ignore_fields.add("submission_uploaded_date")
 
-        submission_diff = self._diff_metadata(submission_id, metadata, submission_uploaded_date, ignore_fields)
-        donor_diff = self._diff_donors(submission_id, metadata)
-        return submission_diff, donor_diff
+        # One transaction for the whole change set: the three parts describe one submission at
+        # one moment, and computing them against separate snapshots let them disagree. Reading
+        # the row here also means resolution and the field diff share it. ``get_submission``
+        # would eagerly load the state log, which nothing in a diff reads.
+        with self.transaction() as session:
+            current_submission = session.get(Submission, submission_id)
+            if current_submission is None:
+                raise SubmissionNotFoundError(submission_id)
 
-    def commit_changes(
-        self,
-        submission_id: str,
-        submission_diff: SubmissionDiffCollection | None = None,
-        donors_diff: DonorsDiffCollection | None = None,
-    ) -> None:
-        """Write all pending metadata and donor diffs to the database, as one transaction.
+            try:
+                case_link, case_link_error = (
+                    self._diff_case_link(session, current_submission, metadata, ignore_fields or set()),
+                    None,
+                )
+            except AmbiguousCaseError as exc:
+                case_link, case_link_error = None, exc
 
-        The diffs are one answer to one metadata file, so they are applied whole or not at all:
-        writing them piecemeal would leave a rejected write with the earlier parts stored, and
-        re-running would then preview a different starting state than the one just shown.
+            return SubmissionChangeSet(
+                fields=self._diff_metadata(current_submission, metadata, submission_uploaded_date, ignore_fields),
+                donors=self._diff_donors(session, submission_id, metadata),
+                case_link=case_link,
+                case_link_error=case_link_error,
+            )
+
+    def commit_changes(self, submission_id: str, changes: SubmissionChangeSet) -> None:
+        """Write all pending changes of a change set to the database, as one transaction.
+
+        A change set is one answer to one metadata file, so it is applied whole or not at all.
+        Writing it piecemeal left a rejected write with the earlier parts already stored, and
+        the operator was told only about the failure: re-running then previewed a different
+        starting state than the one just shown.
+
+        A pending case link in :attr:`SubmissionChangeSet.case_link` is applied via
+        :meth:`assign_case`, creating the case first if none exists yet. It goes first, so
+        that a case another process created in the meantime can be joined without discarding
+        work already done here.
 
         :param submission_id: ID of the submission being updated.
-        :param submission_diff: Diff result from :func:`diff_metadata`.
-        :param donors_diff: Diff result from :func:`build_donor_diff`.
+        :param changes: Change set from :meth:`diff`.
         """
         with self.transaction() as session:
-            if submission_diff is not None:
-                for field_diff in submission_diff.pending:
-                    self.modify_submission(submission_id, field_diff.key, field_diff.diff.after, session=session)
-            if donors_diff is not None:
-                for donor_diff in donors_diff.added:
-                    assert donor_diff.after is not None, "Added NoneType donor, this should not happen"  # noqa: S101
-                    self.add_donor(donor_diff.after, session=session)
-                for donor_diff in donors_diff.updated:
-                    assert donor_diff.after is not None, "Updated NoneType donor, this should not happen"  # noqa: S101
-                    self.update_donor(donor_diff.after, session=session)
-                for donor_diff in donors_diff.deleted:
-                    assert donor_diff.before is not None, "Removed NoneType donor, this should not happen"  # noqa: S101
-                    self.delete_donor(donor_diff.before, session=session)
+            if (link := changes.case_link) is not None:
+                self.assign_case(
+                    submission_id,
+                    submitter_id=link.submitter_id,
+                    local_case_id=link.local_case_id,
+                    submission_type=link.submission_type,
+                    session=session,
+                )
+            for field_diff in changes.fields.pending:
+                self.modify_submission(submission_id, field_diff.key, field_diff.diff.after, session=session)
+            # added/updated diffs carry a non-None `after`, deleted a non-None `before`,
+            # by construction in Diff.classify
+            for donor_diff in changes.donors.added:
+                self.add_donor(cast(Donor, donor_diff.after), session=session)
+            for donor_diff in changes.donors.updated:
+                self.update_donor(cast(Donor, donor_diff.after), session=session)
+            for donor_diff in changes.donors.deleted:
+                self.delete_donor(cast(Donor, donor_diff.before), session=session)
 
     @staticmethod
-    def _log_pending_changes(
-        submission_id: str,
-        submission_diff: SubmissionDiffCollection,
-        donors_diff: DonorsDiffCollection,
-    ) -> None:
+    def _log_pending_changes(submission_id: str, changes: SubmissionChangeSet) -> None:
         """Emit info-level log lines summarising what is about to be committed."""
         sid = f"Submission: {submission_id}"
 
-        pending_keys = [d.key for d in submission_diff.pending]
-        unchanged_keys = [d.key for d in submission_diff.unchanged]
+        pending_keys = [d.key for d in changes.fields.pending]
+        unchanged_keys = [d.key for d in changes.fields.unchanged]
         if pending_keys:
             logger.info("%s - Updating fields: %s in database", sid, ", ".join(f'"{k}"' for k in pending_keys))
         if unchanged_keys:
             logger.info("%s - Not updating fields: %s in database", sid, ", ".join(f'"{k}"' for k in unchanged_keys))
 
-        if donors_diff.unchanged:
+        if (link := changes.case_link) is not None:
+            target = f"existing case {link.after}" if link.after is not None else "a new case"
             logger.info(
-                "%s - Keep existing donor(s): %s", sid, ", ".join(f'"{d.pseudonym}"' for d in donors_diff.unchanged)
+                "%s - Linking to %s (submitter '%s', local case '%s')",
+                sid,
+                target,
+                link.submitter_id,
+                link.local_case_id,
             )
-        if donors_diff.added:
+
+        donors = changes.donors
+        if donors.unchanged:
+            logger.info("%s - Keep existing donor(s): %s", sid, ", ".join(f'"{d.pseudonym}"' for d in donors.unchanged))
+        if donors.added:
             logger.info(
                 "%s - Adding new donor(s): %s",
                 sid,
-                ", ".join(f'"{d.pseudonym}"' for d in donors_diff.added),
+                ", ".join(f'"{d.pseudonym}"' for d in donors.added),
             )
-        if donors_diff.updated:
+        if donors.updated:
             logger.info(
                 "%s - Modifying existing donor(s): %s",
                 sid,
-                ", ".join(f'"{d.pseudonym}"' for d in donors_diff.updated),
+                ", ".join(f'"{d.pseudonym}"' for d in donors.updated),
             )
-        if donors_diff.deleted:
-            logger.info("%s - Dropping donor(s): %s", sid, ", ".join(f'"{d.pseudonym}"' for d in donors_diff.deleted))
+        if donors.deleted:
+            logger.info("%s - Dropping donor(s): %s", sid, ", ".join(f'"{d.pseudonym}"' for d in donors.deleted))
 
     @staticmethod
     def assert_metadata_not_redacted(
@@ -1492,7 +2237,7 @@ class SubmissionDb:
         """Raise ``ValueError`` if ``metadata`` has redacted/missing required fields.
 
         Checks ``tan_g`` against :data:`REDACTED_TAN` and ``local_case_id``
-        against :data:`REDACTED_LOCAL_CASE_ID` / emptiness. Each check can be
+        against :func:`is_redacted_local_case_id`. Each check can be
         bypassed by including the corresponding key in ``ignore_fields``:
         ``"tan_g"`` bypasses the redacted-TAN check; ``"pseudonym"`` bypasses
         the missing/redacted-``local_case_id`` check.
@@ -1506,9 +2251,7 @@ class SubmissionDb:
         ignore_fields = ignore_fields or set()
         if metadata.submission.tan_g == REDACTED_TAN and "tan_g" not in ignore_fields:
             raise ValueError(f"Submission {submission_id} has redacted tan_g in metadata.")
-        if (
-            not metadata.submission.local_case_id or metadata.submission.local_case_id == REDACTED_LOCAL_CASE_ID
-        ) and "pseudonym" not in ignore_fields:
+        if is_redacted_local_case_id(metadata.submission.local_case_id) and "pseudonym" not in ignore_fields:
             raise ValueError(f"Submission {submission_id} has missing or redacted local_case_id in metadata.")
 
     def populate(  # noqa: PLR0913
@@ -1559,23 +2302,18 @@ class SubmissionDb:
 
         self.assert_metadata_not_redacted(metadata, submission_id, ignore_fields)
 
-        submission_diff, donors_diff = self.diff(submission_id, metadata, submission_date, ignore_fields=ignore_fields)
+        changes = self.diff(submission_id, metadata, submission_date, ignore_fields=ignore_fields)
 
-        if not force and submission_diff.has_pending_destructive:
+        if not force and changes.has_pending_destructive:
             raise RuntimeError(
-                f"Would update/delete existing submission data in the database, but `force` not set. "
-                f"submission_id={submission_id!r}, submission_diff={submission_diff!r}"
+                f"Would update/delete existing submission data "
+                f"({', '.join(changes.destructive_changes)}) in the database, "
+                f"but `force` not set. submission_id={submission_id!r}"
             )
 
-        if not force and donors_diff.has_pending_destructive:
-            raise RuntimeError(
-                f"Would update/delete existing donors in the database, but `force` not set. "
-                f"submission_id={submission_id!r}, donors_diff={donors_diff!r}"
-            )
-
-        if submission_diff.has_pending or donors_diff.has_pending:
+        if changes.has_pending:
             logger.info("Submission: %s - Updating...", submission_id)
-            self._log_pending_changes(submission_id, submission_diff, donors_diff)
-            self.commit_changes(submission_id, submission_diff, donors_diff)
+            self._log_pending_changes(submission_id, changes)
+            self.commit_changes(submission_id, changes)
         else:
             logger.info("Submission: %s - No updates necessary.", submission_id)

--- a/packages/grz-db/src/grz_db/models/submission/__init__.py
+++ b/packages/grz-db/src/grz_db/models/submission/__init__.py
@@ -389,15 +389,6 @@ def _rejected_by(e: IntegrityError) -> "_Index | None":
     )
 
 
-def _case_key_or_none(local_case_id: str | None) -> str | None:
-    """Return *local_case_id* when it can key a case, else ``None``.
-
-    Keying a case on a redaction placeholder would merge every redacted submission of a
-    submitter into a single case (see :func:`is_redacted_local_case_id`).
-    """
-    return None if is_redacted_local_case_id(local_case_id) else local_case_id
-
-
 class CaseResolver(Protocol):
     """Strategy for locating the case a submission belongs to.
 
@@ -405,14 +396,14 @@ class CaseResolver(Protocol):
     (currently ``(submitter_id, local_case_id)``; later the RKI ``psn``) without a schema change:
     both keys are already columns on :class:`Case`. The seam is not the whole of such a switch,
     though. Three methods take a resolver, :meth:`SubmissionDb.assign_case`,
-    :meth:`SubmissionDb.resolve_case` and :meth:`SubmissionDb.assert_no_duplicate_initial`, and
-    the last short-circuits on the default resolver's key before it consults the one it was
-    given; :meth:`SubmissionDb.diff` resolves through :data:`DEFAULT_CASE_RESOLVER`, so
-    metadata-driven linking would want one threaded through there and a ``psn`` on
-    :class:`CaseLinkDiff`.
+    :meth:`SubmissionDb.resolve_case` and :meth:`SubmissionDb.assert_no_duplicate_initial`, but
+    :meth:`SubmissionDb.diff` resolves through :data:`DEFAULT_CASE_RESOLVER`, so metadata-driven
+    linking would want one threaded through there and a ``psn`` on :class:`CaseLinkDiff`.
 
     Implementations raise :class:`AmbiguousCaseError` rather than guess when their key matches
-    more than one case. They must not write: resolution runs inside :meth:`SubmissionDb.diff`,
+    more than one case, and decide for themselves when their key cannot answer at all, returning
+    ``None``: callers do not pre-screen the identifiers, since only the resolver knows which of
+    them it reads. They must not write: resolution runs inside :meth:`SubmissionDb.diff`,
     which reports rather than changes. Returning ``None`` is an instruction, not an absence of
     one: :meth:`SubmissionDb.assign_case` creates a case from the identifiers it was passed.
     """
@@ -430,6 +421,9 @@ class CaseResolver(Protocol):
 class SubmitterLocalCaseResolver:
     """Resolve a case by ``(submitter_id, local_case_id)``. The current default.
 
+    A redaction placeholder is not a key (see :func:`is_redacted_local_case_id`), so a submission
+    carrying one matches no case rather than every other redacted submission of that submitter.
+
     ``ux_cases_submitter_local_case`` makes the pair unique wherever both halves are present, so
     a second match means that index is not in place. Picking one of the matches would link a
     submission to another patient's case without saying so, and nothing in the key tells the
@@ -439,7 +433,7 @@ class SubmitterLocalCaseResolver:
     def find_case(
         self, session: Session, *, submitter_id: str | None, local_case_id: str | None, psn: str | None
     ) -> "Case | None":
-        if not submitter_id or not local_case_id:
+        if not submitter_id or is_redacted_local_case_id(local_case_id):
             return None
         matches = session.exec(
             select(Case).where(Case.submitter_id == submitter_id, Case.local_case_id == local_case_id)
@@ -452,10 +446,10 @@ class SubmitterLocalCaseResolver:
 class PsnResolver:
     """Resolve a case by RKI pseudonym. For future PSN-based linking.
 
-    Usable today by passing it to :meth:`SubmissionDb.assign_case` or
-    :meth:`SubmissionDb.resolve_case`, but not reached from ``diff``/``commit_changes``, and
-    nothing could feed it there yet: a psn comes from the tanG trade, not from the submitter's
-    metadata.
+    Usable today by passing it to :meth:`SubmissionDb.assign_case`,
+    :meth:`SubmissionDb.resolve_case` or :meth:`SubmissionDb.assert_no_duplicate_initial`, but not
+    reached from ``diff``/``commit_changes``, and nothing could feed it there yet: a psn comes from
+    the tanG trade, not from the submitter's metadata.
     """
 
     def find_case(
@@ -1779,8 +1773,8 @@ class SubmissionDb:
         :param submission_id: ID of the submission about to be validated. A case whose QC-passed
             initial submission *is* this one is not a duplicate.
         :param submitter_id: Submitter identifier passed to the resolver.
-        :param local_case_id: Submitter-local case identifier passed to the resolver. A redaction
-            placeholder cannot key a case (see :func:`_case_key_or_none`), so it is left alone.
+        :param local_case_id: Submitter-local case identifier passed to the resolver, which
+            decides whether it can key a case.
         :param psn: RKI pseudonym passed to the resolver.
         :param submission_type: Type of the submission. Only ``initial`` can break this rule.
         :param resolver: Strategy used to locate the case; defaults to
@@ -1790,7 +1784,7 @@ class SubmissionDb:
         :raises SubmissionNotFoundError: if no submission has the given ``submission_id``.
         :raises AmbiguousCaseError: if the resolution key matches more than one case.
         """
-        if submission_type != SubmissionType.initial or _case_key_or_none(local_case_id) is None:
+        if submission_type != SubmissionType.initial:
             return
 
         with self.transaction() as session:
@@ -2022,7 +2016,7 @@ class SubmissionDb:
 
         Case resolution is skipped when ``"case_id"`` is ignored, for ``test`` submissions
         (never case-tracked), and when ``local_case_id`` is still a redaction placeholder
-        (see :func:`_case_key_or_none`); call :meth:`Submission.restore_redacted_fields` first when
+        (see :func:`is_redacted_local_case_id`); call :meth:`Submission.restore_redacted_fields` first when
         *metadata* was read back from an archive bucket.
 
         :param session: The transaction :meth:`diff` runs in.
@@ -2035,7 +2029,7 @@ class SubmissionDb:
         if (
             "case_id" in ignore_fields
             or metadata.submission.submission_type == SubmissionType.test
-            or _case_key_or_none(metadata.submission.local_case_id) is None
+            or is_redacted_local_case_id(metadata.submission.local_case_id)
         ):
             return None
 

--- a/packages/grz-db/src/grz_db/models/submission/__init__.py
+++ b/packages/grz-db/src/grz_db/models/submission/__init__.py
@@ -307,9 +307,10 @@ class Case(SQLModel, table=True):
 
     Groups the submissions for one patient. The authoritative identity is
     ``psn`` (the RKI pseudonym), unique once assigned. ``submitter_id`` and ``local_case_id`` are
-    lookup keys used to resolve the case before a ``psn`` exists; they are deliberately *not* a
-    uniqueness constraint, since a future flow may resolve a case by ``psn`` alone (with
-    ``local_case_id`` absent).
+    lookup keys used to resolve the case before a ``psn`` exists, not the authoritative identity
+    themselves. The partial unique index ``ux_cases_submitter_local_case`` keeps the pair unique
+    wherever both halves are present; neither is required, since a future flow may resolve a case
+    by ``psn`` alone (with ``local_case_id`` absent).
     """
 
     # Without this a table model takes any value its annotations forbid, so a mistyped
@@ -1627,11 +1628,12 @@ class SubmissionDb:
         no other ``initial`` submission of that case may pass.
 
         The *resolver* strategy decides how an existing case is located (default:
-        ``(submitter_id, local_case_id)``). A brand-new case requires an ``initial`` submission.
-        Competing initial submissions may share a case while pending basic QC, since the data
-        alone cannot tell a re-upload from a duplicate; only one of them may ever pass basic QC.
-        A non-initial submission requires the case to have an initial submission that has not
-        failed basic QC.
+        ``(submitter_id, local_case_id)``). Competing initial submissions may share a case while
+        pending basic QC, since the data alone cannot tell a re-upload from a duplicate; only one
+        of them may ever pass basic QC. A non-initial submission may also open a brand-new case:
+        a patient's ``initial`` submission may never reach this GRZ, and refusing to link a
+        ``followup`` in that situation would keep a real, BfArM-reported submission out of the
+        case record.
         ``test`` submissions are never case-tracked and are rejected. Re-running for an
         already-linked submission makes no further change (safe to repeat).
 

--- a/packages/grz-db/src/grz_db/models/submission/__init__.py
+++ b/packages/grz-db/src/grz_db/models/submission/__init__.py
@@ -179,8 +179,8 @@ class SubmissionBase(SQLModel):
     )
 
 
-# The submitter's local case ID is stored in the pseudonym column; the other redacted
-# metadata field is named the same on both sides.
+# The submitter's local case ID is stored in the pseudonym column; ``tan_g``, the other
+# redacted field, is named the same on both sides.
 _METADATA_FIELD_TO_COLUMN = {"local_case_id": "pseudonym"}
 
 
@@ -201,7 +201,9 @@ class Submission(SubmissionBase, table=True):
         return v
 
     # additionally constrained by the partial unique index ux_submissions_one_initial_per_case
-    # (created in the cases migration): at most one QC-passed 'initial' submission per case
+    # (created in the cases migration): at most one QC-passed 'initial' submission per case.
+    # NULL means not case-tracked (a 'test' submission) or not yet resolved; the partial
+    # unique index leaves NULLs unconstrained.
     case_id: int | None = Field(default=None, foreign_key="cases.id", index=True)
 
     states: list["SubmissionStateLog"] = Relationship(back_populates="submission")
@@ -307,7 +309,7 @@ class Case(SQLModel, table=True):
 
     Groups the submissions for one patient. The authoritative identity is
     ``psn`` (the RKI pseudonym), unique once assigned. ``submitter_id`` and ``local_case_id`` are
-    lookup keys used to resolve the case before a ``psn`` exists, not the authoritative identity
+    resolution keys used to locate the case before a ``psn`` exists, not the authoritative identity
     themselves. The partial unique index ``ux_cases_submitter_local_case`` keeps the pair unique
     wherever both halves are present; neither is required, since a future flow may resolve a case
     by ``psn`` alone (with ``local_case_id`` absent).
@@ -402,13 +404,17 @@ class CaseResolver(Protocol):
     Different resolvers key on different identifiers, so the resolution rule can evolve
     (currently ``(submitter_id, local_case_id)``; later the RKI ``psn``) without a schema change:
     both keys are already columns on :class:`Case`. The seam is not the whole of such a switch,
-    though. Only :meth:`SubmissionDb.assign_case` and :meth:`SubmissionDb.resolve_case` take a
-    resolver; :meth:`SubmissionDb.diff` resolves through :data:`DEFAULT_CASE_RESOLVER`, so
+    though. Three methods take a resolver, :meth:`SubmissionDb.assign_case`,
+    :meth:`SubmissionDb.resolve_case` and :meth:`SubmissionDb.assert_no_duplicate_initial`, and
+    the last short-circuits on the default resolver's key before it consults the one it was
+    given; :meth:`SubmissionDb.diff` resolves through :data:`DEFAULT_CASE_RESOLVER`, so
     metadata-driven linking would want one threaded through there and a ``psn`` on
     :class:`CaseLinkDiff`.
 
     Implementations raise :class:`AmbiguousCaseError` rather than guess when their key matches
-    more than one case.
+    more than one case. They must not write: resolution runs inside :meth:`SubmissionDb.diff`,
+    which reports rather than changes. Returning ``None`` is an instruction, not an absence of
+    one: :meth:`SubmissionDb.assign_case` creates a case from the identifiers it was passed.
     """
 
     def find_case(
@@ -578,7 +584,7 @@ _RAW_CONTENT_MAGIC: dict[RequestRawContentType, bytes] = {
 def detect_raw_content_type(content: bytes) -> RequestRawContentType | None:
     """Identify a raw attachment's type from its magic bytes.
 
-    Content is authoritative — the file extension is intentionally ignored. Returns
+    Content is authoritative: the file extension is intentionally ignored. Returns
     ``None`` if the bytes match no supported type. This is the same magic-byte table
     the model uses to verify ``request_raw_content`` against its declared type.
     """
@@ -660,7 +666,7 @@ class ChangeRequestLogBase(SQLModel):
             if expected_magic is not None and not self.request_raw_content.startswith(expected_magic):
                 raise ValueError(
                     f"request_raw_content does not start with the expected "
-                    f"{self.request_raw_content_type.value} magic bytes — file content does not "
+                    f"{self.request_raw_content_type.value} magic bytes: file content does not "
                     f"match the declared type."
                 )
         return self
@@ -865,11 +871,13 @@ class SubmissionDb:
         only ever flushes, which is also what puts it in front of the indices while the
         handler that can name what they rejected is still in scope.
 
-        Instances stay usable after the commit, since nothing here is filled in by the
-        database itself.
+        ``expire_on_commit=False`` keeps returned instances readable after the commit: the
+        flush has already fetched what the database assigns, such as autoincrement primary
+        keys, and nothing is computed later.
 
         :param session: A session to join, or ``None`` to open one.
-        :raises OutdatedDatabaseSchemaError: if the database is not at the latest revision.
+        :raises OutdatedDatabaseSchemaError: if a session is opened here and the database is
+            not at the latest revision. A joined session is not re-checked.
         """
         if session is not None:
             yield session
@@ -895,7 +903,7 @@ class SubmissionDb:
         """Confirm, once, that the database is at the revision this code expects.
 
         Asking costs a scan of the migration directory and a connection of its own, and one
-        pass over a submission opens a session per write, so the answer is kept. Nothing makes
+        pass over a submission opens several sessions, so the answer is kept. Nothing makes
         it stale in a way that helps: migrating is an operator action, downgrades are not
         supported.
 
@@ -1016,7 +1024,7 @@ class SubmissionDb:
         is queried again to name it in the message.
 
         :param session: The session whose transaction was rolled back.
-        :param case_id: The case the rejected write targeted, read before the commit. A unique
+        :param case_id: The case the rejected write targeted, read before the flush. A unique
             index leaves NULLs unconstrained, so a rejected write always names a case.
         """
         qc_passed_initial = self._qc_passed_initial_of(session, case_id) if case_id is not None else None
@@ -1455,7 +1463,8 @@ class SubmissionDb:
         :param local_case_id: Submitter-local case identifier resolution key.
         :param psn: RKI pseudonym; must be unique across cases when set.
         :returns: The newly created :class:`Case`, with its database-assigned ``id`` populated.
-        :raises DuplicateCaseError: if a case already has this ``(submitter_id, local_case_id)``.
+        :raises DuplicateCaseError: if another case already holds this ``(submitter_id,
+            local_case_id)``. Only enforced where both halves are present.
         :raises DuplicatePsnError: if ``psn`` is already assigned to another case.
         """
         with self.transaction() as session:
@@ -1481,7 +1490,7 @@ class SubmissionDb:
         :raises ValueError: if ``key`` is not a column of ``cases`` or is read-only.
         :raises CaseNotFoundError: if no case has the given ``case_id``.
         :raises DuplicateCaseError: if the change would give two cases the same
-            ``(submitter_id, local_case_id)``.
+            ``(submitter_id, local_case_id)``. Only enforced where both halves are present.
         :raises DuplicatePsnError: if ``key`` is ``"psn"`` and ``value`` is
             already assigned to another case.
         """
@@ -1525,7 +1534,8 @@ class SubmissionDb:
         """Link (or relink) a submission to an existing case.
 
         A case may have at most one ``initial`` submission that passed basic QC. A partial unique
-        index enforces this at commit time, so a link that would break it raises instead.
+        index enforces this; the flush inside the conflict handler is where a link that would
+        break it is rejected.
 
         :param submission_id: ID of the submission to link.
         :param case_id: Primary key of the target case.
@@ -1533,7 +1543,8 @@ class SubmissionDb:
         :raises SubmissionNotFoundError: if no submission has the given
             ``submission_id``.
         :raises SubmissionTypeInvalidForCaseError: if the submission is a ``test``
-            submission, which is never case-tracked.
+            submission, which is never case-tracked, or if it has not been populated yet
+            and so carries no type.
         :raises CaseNotFoundError: if no case has the given ``case_id``.
         :raises DuplicateInitialSubmissionError: if linking would give the case a second
             QC-passed ``initial`` submission.
@@ -1629,13 +1640,12 @@ class SubmissionDb:
 
         The *resolver* strategy decides how an existing case is located (default:
         ``(submitter_id, local_case_id)``). Competing initial submissions may share a case while
-        pending basic QC, since the data alone cannot tell a re-upload from a duplicate; only one
-        of them may ever pass basic QC. A non-initial submission may also open a brand-new case:
-        a patient's ``initial`` submission may never reach this GRZ, and refusing to link a
-        ``followup`` in that situation would keep a real, BfArM-reported submission out of the
-        case record.
-        ``test`` submissions are never case-tracked and are rejected. Re-running for an
-        already-linked submission makes no further change (safe to repeat).
+        pending basic QC, since the data alone cannot tell a re-upload from a duplicate. Any type
+        but ``test`` may open a case; see :meth:`_find_case_for_link` for why. ``test``
+        submissions are never case-tracked and are rejected.
+
+        Repeating the call with the same identifiers makes no further change; the resolver has
+        to find the same case, so a call whose key is incomplete creates a new one each time.
 
         :param submission_id: ID of the submission to assign.
         :param submitter_id: Submitter identifier passed to the resolver and
@@ -1644,9 +1654,7 @@ class SubmissionDb:
             resolver and stored on a newly created case.
         :param psn: RKI pseudonym passed to the resolver and stored on a newly
             created case.
-        :param submission_type: Type of the submission. Any type may open a case,
-            since a patient's first submission to reach this GRZ need not be the
-            ``initial`` one; only ``test`` is rejected (never case-tracked).
+        :param submission_type: Type of the submission. Only ``test`` is rejected.
         :param resolver: Strategy used to locate an existing case; defaults to
             :data:`DEFAULT_CASE_RESOLVER` (:class:`SubmitterLocalCaseResolver`).
         :returns: The resolved or newly created :class:`Case` the submission is
@@ -1713,17 +1721,12 @@ class SubmissionDb:
     ) -> "Case | None":
         """Preview the case :meth:`assign_case` would link, without writing.
 
-        Runs the same lookup and validation as :meth:`assign_case` but leaves
-        the database unchanged.
-
         :param submission_id: ID of the submission to resolve a case for.
         :param submitter_id: Submitter identifier passed to the resolver.
         :param local_case_id: Submitter-local case identifier passed to the
             resolver.
         :param psn: RKI pseudonym passed to the resolver.
-        :param submission_type: Type of the submission. Any type may open a case,
-            since a patient's first submission to reach this GRZ need not be the
-            ``initial`` one; only ``test`` is rejected (never case-tracked).
+        :param submission_type: Type of the submission. Only ``test`` is rejected.
         :param resolver: Strategy used to locate an existing case; defaults to
             :data:`DEFAULT_CASE_RESOLVER` (:class:`SubmitterLocalCaseResolver`).
         :returns: The existing :class:`Case` the submission would be linked to,
@@ -1770,8 +1773,8 @@ class SubmissionDb:
         makes the answer one answer: asked separately, a competing initial can pass basic QC in
         between and this would report a submission as clear that the index is about to reject.
 
-        Answering costs two queries, so callers that are going to write anyway should let the
-        index speak rather than ask twice.
+        Answering costs three queries, so callers that are going to write anyway should let the
+        index speak instead.
 
         :param submission_id: ID of the submission about to be validated. A case whose QC-passed
             initial submission *is* this one is not a duplicate.
@@ -2115,12 +2118,12 @@ class SubmissionDb:
             If None, the field will not be included in the comparison.
         :param ignore_fields: Optional set of field names to be ignored during the metadata
             comparison. ``"case_id"`` skips case-link resolution.
-        :raises SubmissionNotFoundError: if no submission has the given ``submission_id``.
         :returns: A :class:`SubmissionChangeSet` with all detected differences. A case that
             cannot be resolved is reported in
             :attr:`SubmissionChangeSet.case_link_error` rather than raised, since it says
             nothing about the other diffs; :meth:`resolve_case` still raises for a caller
             that asked about the case alone.
+        :raises SubmissionNotFoundError: if no submission has the given ``submission_id``.
         """
         if submission_uploaded_date is None:
             # set arbitrary date if not provided
@@ -2131,9 +2134,9 @@ class SubmissionDb:
             ignore_fields.add("submission_uploaded_date")
 
         # One transaction for the whole change set: the three parts describe one submission at
-        # one moment, and computing them against separate snapshots let them disagree. Reading
-        # the row here also means resolution and the field diff share it. ``get_submission``
-        # would eagerly load the state log, which nothing in a diff reads.
+        # one moment, and computing them against separate snapshots would let them disagree.
+        # Reading the row here also means resolution and the field diff share it.
+        # ``get_submission`` would eagerly load the state log, which nothing in a diff reads.
         with self.transaction() as session:
             current_submission = session.get(Submission, submission_id)
             if current_submission is None:
@@ -2157,10 +2160,9 @@ class SubmissionDb:
     def commit_changes(self, submission_id: str, changes: SubmissionChangeSet) -> None:
         """Write all pending changes of a change set to the database, as one transaction.
 
-        A change set is one answer to one metadata file, so it is applied whole or not at all.
-        Writing it piecemeal left a rejected write with the earlier parts already stored, and
-        the operator was told only about the failure: re-running then previewed a different
-        starting state than the one just shown.
+        A change set is one answer to one metadata file, so it is applied whole or not at all:
+        writing it piecemeal would leave a rejected write with the earlier parts stored, and
+        re-running would then preview a different starting state than the one just shown.
 
         A pending case link in :attr:`SubmissionChangeSet.case_link` is applied via
         :meth:`assign_case`, creating the case first if none exists yet. It goes first, so

--- a/packages/grz-db/src/grz_db/models/submission/diff.py
+++ b/packages/grz-db/src/grz_db/models/submission/diff.py
@@ -6,6 +6,9 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Self, cast
 
 if TYPE_CHECKING:
+    from grz_pydantic_models.submission.metadata import SubmissionType
+
+    from grz_db.errors import AmbiguousCaseError
     from grz_db.models.submission import Donor as DbDonor
 
 
@@ -82,6 +85,37 @@ class FieldDiff[T]:
 
 
 @dataclass
+class CaseLinkDiff:
+    """A pending change to a submission's case link, resolved during :meth:`SubmissionDb.diff`.
+
+    Only constructed when committing would change the link, so its mere presence on a
+    :class:`SubmissionChangeSet` means there is something to write.
+
+    :param before: ``case_id`` currently stored on the submission, if any.
+    :param after: Primary key of the matching existing case, or ``None`` if committing
+        will create a new case.
+    :param submitter_id: Submitter identifier used to resolve the case.
+    :param local_case_id: Submitter-local case identifier used to resolve the case.
+    :param submission_type: Type of the submission, validated against the case.
+    """
+
+    before: int | None
+    after: int | None
+    submitter_id: str | None
+    local_case_id: str | None
+    submission_type: SubmissionType
+
+    @property
+    def state(self) -> DiffState:
+        """NEW when the submission is not yet linked, UPDATED when an existing link would change.
+
+        DELETED cannot occur: a diff never proposes unlinking; ``after is None`` means a new
+        case would be created instead.
+        """
+        return DiffState.NEW if self.before is None else DiffState.UPDATED
+
+
+@dataclass
 class SubmissionDiffCollection:
     """Holds the result of diffing submission-level metadata against the database.
 
@@ -100,7 +134,7 @@ class SubmissionDiffCollection:
 
     @property
     def pending(self) -> Generator[FieldDiff, None, None]:
-        """All diffs that need to be written to the database (added + updated + deleted)."""
+        """All field diffs that need to be written to the database (added + updated + deleted)."""
         yield from self.added
         yield from self.updated
         yield from self.deleted
@@ -232,3 +266,58 @@ class DonorsDiffCollection:
                 self.deleted.append(donor_diff)
             case DiffState.UNCHANGED:
                 self.unchanged.append(donor_diff)
+
+
+@dataclass
+class SubmissionChangeSet:
+    """Everything committing a metadata file would change for one submission.
+
+    :param fields: Column-level diffs on the submission row.
+    :param donors: Donor rows to add, update, or delete.
+    :param case_link: Pending change to the submission's case link, or ``None`` if the
+        link is already in sync (or case resolution was skipped). Applied via
+        :meth:`SubmissionDb.assign_case`, not as a column write.
+    :param case_link_error: Why the case could not be resolved, when it could not be.
+        Whether a case can be identified says nothing about whether the rest of the
+        metadata should be recorded, so this is reported alongside the other diffs
+        rather than raised: the caller decides what an unlinkable submission is worth.
+        ``case_link`` is ``None`` whenever this is set, since there is nothing to write.
+    """
+
+    fields: SubmissionDiffCollection = field(default_factory=SubmissionDiffCollection)
+    donors: DonorsDiffCollection = field(default_factory=DonorsDiffCollection)
+    case_link: CaseLinkDiff | None = None
+    case_link_error: AmbiguousCaseError | None = None
+
+    @property
+    def has_pending(self) -> bool:
+        """True if committing would write anything to the database."""
+        return self.fields.has_pending or self.donors.has_pending or self.case_link is not None
+
+    @property
+    def pending_changes(self) -> list[str]:
+        """Names of every pending change: field diffs, donor diffs, and the case link."""
+        changes = [d.key for d in self.fields.pending]
+        changes += [f"donor '{d.pseudonym}'" for d in self.donors.pending]
+        if self.case_link is not None:
+            source = f"case {self.case_link.before}" if self.case_link.before is not None else "unlinked"
+            target = f"case {self.case_link.after}" if self.case_link.after is not None else "new case"
+            changes.append(f"case link ({source} -> {target})")
+        return changes
+
+    @property
+    def destructive_changes(self) -> list[str]:
+        """Names of the existing database values committing would overwrite or remove.
+
+        An existing case link counts: reverting it would undo a deliberate ``case relink``.
+        """
+        changes = [d.key for d in (*self.fields.updated, *self.fields.deleted)]
+        changes += [f"donor '{d.pseudonym}'" for d in (*self.donors.updated, *self.donors.deleted)]
+        if self.case_link is not None and self.case_link.state is DiffState.UPDATED:
+            changes.append(f"case link (case {self.case_link.before})")
+        return changes
+
+    @property
+    def has_pending_destructive(self) -> bool:
+        """True if committing would overwrite or remove any existing database value."""
+        return bool(self.destructive_changes)

--- a/packages/grz-db/src/grz_db/models/submission/diff.py
+++ b/packages/grz-db/src/grz_db/models/submission/diff.py
@@ -96,7 +96,8 @@ class CaseLinkDiff:
         will create a new case.
     :param submitter_id: Submitter identifier used to resolve the case.
     :param local_case_id: Submitter-local case identifier used to resolve the case.
-    :param submission_type: Type of the submission, validated against the case.
+    :param submission_type: Type of the submission. Checked for case-trackability (``test`` is
+        rejected), not against the case.
     """
 
     before: int | None
@@ -119,7 +120,7 @@ class CaseLinkDiff:
 class SubmissionDiffCollection:
     """Holds the result of diffing submission-level metadata against the database.
 
-    Fields are categorised the same way as :class:`DonorDiff`:
+    Fields are categorised the same way as :class:`DonorsDiffCollection`:
 
     :param added: Fields that were ``None`` in the database and now have a value.
     :param updated: Fields whose non-null database value differs from the new value.

--- a/packages/grz-db/src/grz_db/testing.py
+++ b/packages/grz-db/src/grz_db/testing.py
@@ -1,5 +1,10 @@
 """Pytest fixtures for provisioning :class:`~grz_db.models.submission.SubmissionDb` databases.
 
+Database tests should obtain their database through these fixtures, typically ``db`` (or
+``migrated_db_connection`` for a lower-level connection), rather than constructing their own
+engine. ``db_backend`` parametrizes over both sqlite and PostgreSQL, so a test built on ``db``
+runs against both backends; a test that builds its own engine instead only ever covers sqlite.
+
 Requires the ``testing`` extra. Import the fixtures into a ``conftest.py``::
 
     from grz_db.testing import (  # noqa: F401

--- a/packages/grz-db/tests/test_case.py
+++ b/packages/grz-db/tests/test_case.py
@@ -1,0 +1,1120 @@
+"""Tests for the case tracking layer: the ``Case`` model, the case service methods, the pluggable
+case resolver, and the rule limiting a case to one ``initial`` submission that passed basic QC.
+"""
+
+import json
+import re
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+
+import pytest
+import sqlalchemy
+from grz_db.errors import (
+    AmbiguousCaseError,
+    CaseHasLinkedSubmissionsError,
+    CaseNotFoundError,
+    DuplicateCaseError,
+    DuplicateInitialSubmissionError,
+    DuplicatePsnError,
+    SubmissionTypeInvalidForCaseError,
+)
+from grz_db.models.submission import PsnResolver, SubmissionDb, SubmissionType, _Index, _rejected_by
+from grz_pydantic_models.submission.metadata import REDACTED_LOCAL_CASE_ID, GrzSubmissionMetadata
+from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
+
+SUBMITTER_A = "111111111"
+SUBMITTER_B = "222222222"
+
+
+def _with_submission_type(metadata: GrzSubmissionMetadata, submission_type: str) -> GrzSubmissionMetadata:
+    """A copy of *metadata* with its ``submissionType`` replaced.
+
+    The shipped example is a ``test`` submission, which is never case-tracked, so tests
+    exercising case linking need an ``initial`` variant.
+    """
+    raw = json.loads(metadata.model_dump_json(by_alias=True))
+    raw["submission"]["submissionType"] = submission_type
+    return GrzSubmissionMetadata.model_validate(raw)
+
+
+def _sid(submitter_id: str, suffix: str) -> str:
+    return f"{submitter_id}_2025-01-01_{suffix}"
+
+
+def _add(db: SubmissionDb, submission_id: str, submission_type: SubmissionType) -> None:
+    db.add_submission(submission_id)
+    db.modify_submission(submission_id, "submission_type", submission_type.value)
+
+
+def _record_basic_qc(db: SubmissionDb, submission_id: str, passed: bool) -> None:
+    db.modify_submission(submission_id, "basic_qc_passed", passed)
+
+
+def _lose_the_race_to(monkeypatch: pytest.MonkeyPatch, win: Callable[[str, str], None]) -> None:
+    """Hand the key to *win* in the window between looking a case up and inserting one.
+
+    Threads cannot be made to interleave on demand, so the race is forced here instead. Only
+    the first pass through the window hands it over, so *win* may itself resolve a case.
+    """
+    original = SubmissionDb._find_case_for_link
+    won = False
+
+    def let_the_other_process_win(self, session, submission_id, **kwargs):
+        nonlocal won
+        submission, case = original(self, session, submission_id, **kwargs)
+        if case is None and not won:
+            won = True
+            win(kwargs["submitter_id"], kwargs["local_case_id"])
+        return submission, case
+
+    monkeypatch.setattr(SubmissionDb, "_find_case_for_link", let_the_other_process_win)
+
+
+def _second_case_for_the_same_key(db: SubmissionDb, submitter_id: str, local_case_id: str) -> None:
+    """Give one key a second case, which ``ux_cases_submitter_local_case`` forbids.
+
+    Only reachable by writing around the application, which is exactly the state the ambiguity
+    guard exists to survive: the index is dropped first so the row can be inserted at all.
+    """
+    with db.transaction() as session:
+        session.execute(sqlalchemy.text("DROP INDEX ux_cases_submitter_local_case"))
+        session.execute(
+            sqlalchemy.text("INSERT INTO cases (submitter_id, local_case_id) VALUES (:submitter, :local_case)"),
+            {"submitter": submitter_id, "local_case": local_case_id},
+        )
+        session.commit()
+
+
+def test_create_case_key_and_psn_are_both_unique(db: SubmissionDb):
+    # a submitter's local case ID identifies one patient, so it identifies one case
+    db.create_case(SUBMITTER_A, "caseX")
+    with pytest.raises(DuplicateCaseError):
+        db.create_case(SUBMITTER_A, "caseX")
+
+    # ... while the key stays unconstrained where either half is absent
+    db.create_case(SUBMITTER_A, None)
+    db.create_case(SUBMITTER_A, None)
+
+    # psn IS unique when set.
+    db.create_case(SUBMITTER_A, "caseY", psn="PSN-1")
+    with pytest.raises(DuplicatePsnError):
+        db.create_case(SUBMITTER_B, "caseZ", psn="PSN-1")
+
+
+def test_assign_case_initial_creates_and_links(db: SubmissionDb):
+    sid = _sid(SUBMITTER_A, "0000000a")
+    _add(db, sid, SubmissionType.initial)
+
+    case = db.assign_case(sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial)
+
+    assert db.get_submission(sid).case_id == case.id
+    assert case.submitter_id == SUBMITTER_A and case.local_case_id == "caseX" and case.psn is None
+
+    # get_initial_submission returns None until an initial submission of the case passes basic QC
+    assert db.get_initial_submission(case.id) is None
+    _record_basic_qc(db, sid, True)
+    assert db.get_initial_submission(case.id).id == sid
+
+
+def test_assign_case_addition_links_existing_case(db: SubmissionDb):
+    initial = _sid(SUBMITTER_A, "0000000a")
+    addition = _sid(SUBMITTER_A, "0000000b")
+    _add(db, initial, SubmissionType.initial)
+    _add(db, addition, SubmissionType.addition)
+
+    case = db.assign_case(
+        initial, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+    case2 = db.assign_case(
+        addition, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.addition
+    )
+
+    assert case2.id == case.id
+    assert {s.id for s in db.list_submissions_for_case(case.id)} == {initial, addition}
+
+
+@pytest.mark.parametrize(
+    "submission_type", [SubmissionType.followup, SubmissionType.addition, SubmissionType.correction]
+)
+def test_non_initial_opens_a_case_of_its_own(db: SubmissionDb, submission_type: SubmissionType):
+    """A patient's first submission to reach this GRZ need not be the initial one.
+
+    The submission is real, it is reported to BfArM on its own tanG, and refusing to link it
+    would only keep it out of the record.
+    """
+    sid = _sid(SUBMITTER_A, "0000000c")
+    _add(db, sid, submission_type)
+
+    assert (
+        db.resolve_case(sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=submission_type) is None
+    )
+    case = db.assign_case(sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=submission_type)
+
+    assert db.get_submission(sid).case_id == case.id
+    assert db.get_initial_submission(case.id) is None  # the case simply has no initial submission
+
+
+def test_a_later_initial_joins_the_case_its_followup_opened(db: SubmissionDb):
+    followup = _sid(SUBMITTER_A, "0000000c")
+    initial = _sid(SUBMITTER_A, "0000000a")
+    _add(db, followup, SubmissionType.followup)
+    _add(db, initial, SubmissionType.initial)
+
+    opened = db.assign_case(
+        followup, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.followup
+    )
+    joined = db.assign_case(
+        initial, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+
+    assert joined.id == opened.id
+    _record_basic_qc(db, initial, True)
+    assert db.get_initial_submission(opened.id).id == initial
+
+
+def test_second_initial_still_links_once_one_passed_qc(db: SubmissionDb):
+    """A rival initial submission stays on record, linked to the case it duplicates. The rule
+    binds when it tries to pass basic QC, not when it is linked.
+    """
+    qc_passed_id, case_id = _case_with_qc_passed_initial(db)
+    second = _sid(SUBMITTER_A, "0000000b")
+    _add(db, second, SubmissionType.initial)
+
+    preview = db.resolve_case(
+        second, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+    case = db.assign_case(
+        second, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+
+    assert preview is not None and preview.id == case_id and case.id == case_id
+    assert {s.id for s in db.list_submissions_for_case(case_id)} == {qc_passed_id, second}
+    # the case keeps its QC-passed initial submission, and the rival may never become a second one
+    assert db.get_initial_submission(case_id).id == qc_passed_id
+    with pytest.raises(DuplicateInitialSubmissionError):
+        _record_basic_qc(db, second, True)
+
+
+def test_duplicate_initial_that_already_failed_qc_links(db: SubmissionDb):
+    """The state ``grzctl validate`` leaves behind: basic QC already failed, nothing else known."""
+    qc_passed_id, case_id = _case_with_qc_passed_initial(db)
+    second = _sid(SUBMITTER_A, "0000000b")
+    _add(db, second, SubmissionType.initial)
+    _record_basic_qc(db, second, False)
+
+    case = db.assign_case(
+        second, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+
+    assert case.id == case_id
+    assert db.get_submission(second).case_id == case_id
+    assert db.get_initial_submission(case_id).id == qc_passed_id
+
+
+def test_assign_case_allows_competing_initials_while_qc_pending(db: SubmissionDb):
+    """The data alone cannot tell a re-upload from a duplicate, so competing initial submissions
+    may coexist while basic QC is pending.
+    """
+    first = _sid(SUBMITTER_A, "0000000a")
+    second = _sid(SUBMITTER_A, "0000000b")
+    _add(db, first, SubmissionType.initial)
+    _add(db, second, SubmissionType.initial)
+
+    case = db.assign_case(
+        first, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+    case2 = db.assign_case(
+        second, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+
+    assert case2.id == case.id
+    assert {s.id for s in db.list_submissions_for_case(case.id)} == {first, second}
+    assert db.get_initial_submission(case.id) is None  # basic QC is still pending
+
+
+def test_corrected_initial_replaces_failed_one_without_relinking(db: SubmissionDb):
+    """A corrected re-upload after failed basic QC becomes the case's QC-passed initial submission
+    with no operator steps.
+    """
+    bad = _sid(SUBMITTER_A, "0000000a")
+    corrected = _sid(SUBMITTER_A, "0000000b")
+    followup = _sid(SUBMITTER_A, "0000000c")
+    _add(db, bad, SubmissionType.initial)
+    _add(db, corrected, SubmissionType.initial)
+    _add(db, followup, SubmissionType.followup)
+
+    case = db.assign_case(bad, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial)
+    _record_basic_qc(db, bad, False)
+
+    case2 = db.assign_case(
+        corrected, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+    _record_basic_qc(db, corrected, True)
+
+    assert case2.id == case.id
+    assert db.get_initial_submission(case.id).id == corrected
+    # the failed upload stays linked for the record
+    assert {s.id for s in db.list_submissions_for_case(case.id)} == {bad, corrected}
+
+    case3 = db.assign_case(
+        followup, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.followup
+    )
+    assert case3.id == case.id
+
+
+def _pass_basic_qc_via_modify(db: SubmissionDb, submission_id: str) -> None:
+    db.modify_submission(submission_id, "basic_qc_passed", True)
+
+
+def _pass_basic_qc_via_update(db: SubmissionDb, submission_id: str) -> None:
+    submission = db.get_submission(submission_id)
+    submission.basic_qc_passed = True
+    db.update_submission(submission)
+
+
+@pytest.mark.parametrize(
+    "record_pass",
+    [_pass_basic_qc_via_modify, _pass_basic_qc_via_update],
+    ids=["modify_submission", "update_submission"],
+)
+def test_second_initial_to_pass_basic_qc_is_rejected(
+    db: SubmissionDb, record_pass: Callable[[SubmissionDb, str], None]
+):
+    """Once one initial submission has passed basic QC, recording a pass for a competing initial
+    submission of the same case raises instead of writing.
+    """
+    qc_passed_id, duplicate_id, case_id = _case_with_competing_initials(db)
+
+    _record_basic_qc(db, qc_passed_id, True)
+    with pytest.raises(DuplicateInitialSubmissionError, match=qc_passed_id):
+        record_pass(db, duplicate_id)
+
+    # a duplicate initial submission can still be recorded as failed; failure is a terminal basic QC outcome
+    _record_basic_qc(db, duplicate_id, False)
+    assert db.get_submission(duplicate_id).basic_qc_passed is False
+    assert db.get_initial_submission(case_id).id == qc_passed_id
+
+
+def test_followup_links_even_when_the_only_initial_failed_qc(db: SubmissionDb):
+    """Whether the case has a usable initial submission is a reimbursement question for BfArM,
+    which reads the Prüfbericht, not a reason to keep the followup out of the database.
+    """
+    initial = _sid(SUBMITTER_A, "0000000a")
+    followup = _sid(SUBMITTER_A, "0000000b")
+    _add(db, initial, SubmissionType.initial)
+    _add(db, followup, SubmissionType.followup)
+
+    case = db.assign_case(
+        initial, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+    _record_basic_qc(db, initial, False)
+
+    joined = db.assign_case(
+        followup, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.followup
+    )
+
+    assert joined.id == case.id
+    assert {s.id for s in db.list_submissions_for_case(case.id)} == {initial, followup}
+    assert db.get_initial_submission(case.id) is None
+
+
+def _case_with_qc_passed_initial(db: SubmissionDb) -> tuple[str, int]:
+    """A case whose initial submission has passed basic QC; returns (id of the case's QC-passed
+    initial submission, case id).
+    """
+    qc_passed_id = _sid(SUBMITTER_A, "0000000a")
+    _add(db, qc_passed_id, SubmissionType.initial)
+    case = db.assign_case(
+        qc_passed_id, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+    _record_basic_qc(db, qc_passed_id, True)
+    return qc_passed_id, case.id
+
+
+def _case_with_competing_initials(db: SubmissionDb) -> tuple[str, str, int]:
+    """A case with two competing initial submissions linked to it, basic QC still pending for
+    both; returns (id of the submission that will pass basic QC, id of the other initial
+    submission, case id).
+    """
+    qc_passed_id = _sid(SUBMITTER_A, "0000000a")
+    duplicate_id = _sid(SUBMITTER_A, "0000000b")
+    _add(db, qc_passed_id, SubmissionType.initial)
+    _add(db, duplicate_id, SubmissionType.initial)
+    case = db.assign_case(
+        qc_passed_id, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+    db.assign_case(
+        duplicate_id, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+    return qc_passed_id, duplicate_id, case.id
+
+
+def test_modify_submission_type_cannot_smuggle_in_a_second_initial(db: SubmissionDb):
+    """Changing submission_type to 'initial' on an already QC-passed submission must not create a
+    second initial submission that passed basic QC for the case.
+    """
+    _case_with_qc_passed_initial(db)
+    addition = _sid(SUBMITTER_A, "0000000b")
+    _add(db, addition, SubmissionType.addition)
+    db.assign_case(addition, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.addition)
+    _record_basic_qc(db, addition, True)  # fine: addition is not an initial submission
+
+    with pytest.raises(DuplicateInitialSubmissionError):
+        db.modify_submission(addition, "submission_type", SubmissionType.initial.value)
+    assert db.get_submission(addition).submission_type == SubmissionType.addition
+
+
+def test_one_initial_violation_is_recognized_in_the_backend_error(db: SubmissionDb):
+    """The partial unique index enforcing the rule must compile on every supported backend.
+
+    Raw SQL bypasses the ORM path, so the backend's own error reaches the test untranslated.
+    """
+    qc_passed_id, duplicate_id, _case_id = _case_with_competing_initials(db)
+    _record_basic_qc(db, qc_passed_id, True)
+
+    with pytest.raises(IntegrityError) as excinfo:
+        with db.transaction() as session:
+            session.execute(
+                sqlalchemy.text("UPDATE submissions SET basic_qc_passed = :passed WHERE id = :sid"),
+                {"passed": True, "sid": duplicate_id},
+            )
+            session.commit()
+
+    assert _rejected_by(excinfo.value) is _Index.ONE_INITIAL
+
+
+def test_assign_case_idempotent(db: SubmissionDb):
+    sid = _sid(SUBMITTER_A, "0000000a")
+    _add(db, sid, SubmissionType.initial)
+
+    case = db.assign_case(sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial)
+    case_again = db.assign_case(
+        sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+
+    assert case_again.id == case.id
+    assert [s.id for s in db.list_submissions_for_case(case.id)] == [sid]
+
+
+def test_two_submitters_same_local_case_id_are_distinct_cases(db: SubmissionDb):
+    sid_a = _sid(SUBMITTER_A, "0000000a")
+    sid_b = _sid(SUBMITTER_B, "0000000b")
+    _add(db, sid_a, SubmissionType.initial)
+    _add(db, sid_b, SubmissionType.initial)
+
+    case_a = db.assign_case(
+        sid_a, submitter_id=SUBMITTER_A, local_case_id="sharedLocalId", submission_type=SubmissionType.initial
+    )
+    case_b = db.assign_case(
+        sid_b, submitter_id=SUBMITTER_B, local_case_id="sharedLocalId", submission_type=SubmissionType.initial
+    )
+
+    assert case_a.id != case_b.id
+
+
+def test_assign_case_with_psn_resolver_links_by_pseudonym(db: SubmissionDb):
+    """The pluggable resolver can locate a case by psn (the future PSN-based flow)."""
+    pre = db.create_case(submitter_id=SUBMITTER_A, local_case_id="caseX", psn="PSN-1")
+    sid = _sid(SUBMITTER_A, "0000000a")
+    _add(db, sid, SubmissionType.initial)
+
+    linked = db.assign_case(sid, psn="PSN-1", submission_type=SubmissionType.initial, resolver=PsnResolver())
+
+    assert linked.id == pre.id
+    assert db.get_submission(sid).case_id == pre.id
+
+
+def test_modify_case_psn_duplicate_and_unknown_key(db: SubmissionDb):
+    case = db.create_case(SUBMITTER_A, "caseX")
+    db.modify_case(case.id, "psn", "RKI-PSN-1")
+    assert db.get_case(case.id).psn == "RKI-PSN-1"
+
+    other = db.create_case(SUBMITTER_B, "caseY")
+    with pytest.raises(DuplicatePsnError):
+        db.modify_case(other.id, "psn", "RKI-PSN-1")
+
+    with pytest.raises(ValueError, match="Unknown column key"):
+        db.modify_case(case.id, "not_a_column", "x")
+    with pytest.raises(CaseNotFoundError):
+        db.modify_case(9999, "psn", "x")
+
+
+def test_delete_case_empty_and_refuses_when_linked(db: SubmissionDb):
+    sid = _sid(SUBMITTER_A, "0000000a")
+    _add(db, sid, SubmissionType.initial)
+    case = db.assign_case(sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial)
+
+    with pytest.raises(CaseHasLinkedSubmissionsError):
+        db.delete_case(case.id)
+
+    empty = db.create_case(SUBMITTER_A, "emptyCase")
+    db.delete_case(empty.id)
+    assert db.get_case(empty.id) is None
+
+
+def test_relink_rejects_second_qc_passed_initial(db: SubmissionDb):
+    """Relinking must not give a case a second initial submission that passed basic QC; an initial
+    submission whose basic QC is still pending may still be relinked freely.
+    """
+    _qc_passed_id, case_a_id = _case_with_qc_passed_initial(db)
+    sid_b = _sid(SUBMITTER_B, "0000000b")
+    _add(db, sid_b, SubmissionType.initial)
+    case_b = db.assign_case(
+        sid_b, submitter_id=SUBMITTER_B, local_case_id="caseB", submission_type=SubmissionType.initial
+    )
+    _record_basic_qc(db, sid_b, True)
+
+    with pytest.raises(DuplicateInitialSubmissionError):
+        db.set_submission_case(sid_b, case_a_id)
+
+    # an initial submission whose basic QC is still pending is not yet a duplicate, so it may be relinked
+    sid_c = _sid(SUBMITTER_A, "0000000c")
+    _add(db, sid_c, SubmissionType.initial)
+    db.set_submission_case(sid_c, case_a_id)
+    assert db.get_submission(sid_c).case_id == case_a_id
+    assert db.get_initial_submission(case_b.id).id == sid_b
+
+
+def test_resolve_case_previews_without_linking(db: SubmissionDb):
+    sid = _sid(SUBMITTER_A, "000000aa")
+    _add(db, sid, SubmissionType.initial)
+
+    resolved = db.resolve_case(
+        sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+    assert resolved is None
+    # a second resolve still finds nothing, so the first one created no case
+    assert (
+        db.resolve_case(sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial)
+        is None
+    )
+    submission = db.get_submission(sid)
+    assert submission is not None and submission.case_id is None
+
+    case = db.assign_case(sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial)
+    resolved = db.resolve_case(
+        sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+    assert resolved is not None and resolved.id == case.id
+
+
+def test_diff_reports_pending_case_link_and_commit_applies_it(db: SubmissionDb, metadata: GrzSubmissionMetadata):
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submission_id = initial_metadata.submission_id
+    db.add_submission(submission_id)
+
+    changes = db.diff(submission_id, initial_metadata, submission_uploaded_date=None)
+    link = changes.case_link
+    assert link is not None and link.before is None and link.after is None  # would create a new case
+    submission = db.get_submission(submission_id)
+    assert submission is not None and submission.case_id is None  # diff performed no writes
+
+    db.commit_changes(submission_id, changes)
+    submission = db.get_submission(submission_id)
+    assert submission is not None and submission.case_id is not None
+
+    # link is now in sync, so a fresh diff carries no pending case link
+    changes = db.diff(submission_id, initial_metadata, submission_uploaded_date=None)
+    assert changes.case_link is None
+
+
+#: A read of the submissions table. SQLAlchemy renders SQL over several lines, so the
+#: statement is collapsed to one before matching.
+_SUBMISSION_READ = re.compile(r"^SELECT\b.*\bFROM submissions\b")
+
+
+@contextmanager
+def _counting_reads(engine: sqlalchemy.Engine) -> Iterator[dict[str, int]]:
+    """Count the transactions opened and the submission rows read on *engine* inside the block."""
+    counts = {"transactions": 0, "submission_reads": 0}
+
+    def on_begin(_connection) -> None:
+        counts["transactions"] += 1
+
+    def on_statement(_connection, _cursor, statement: str, _parameters, _context, _executemany) -> None:
+        if _SUBMISSION_READ.match(" ".join(statement.split())):
+            counts["submission_reads"] += 1
+
+    sqlalchemy.event.listen(engine, "begin", on_begin)
+    sqlalchemy.event.listen(engine, "before_cursor_execute", on_statement)
+    try:
+        yield counts
+    finally:
+        sqlalchemy.event.remove(engine, "begin", on_begin)
+        sqlalchemy.event.remove(engine, "before_cursor_execute", on_statement)
+
+
+def test_diff_reads_one_snapshot(db: SubmissionDb, metadata: GrzSubmissionMetadata):
+    """A change set answers for one submission at one moment, so it reads one.
+
+    Fields, donors and the case link were each resolved in a transaction of their own, which
+    let a write committed in between leave the three parts of one answer describing three
+    different states of the same submission. Reading the row once is that same fix seen from
+    the other side: a transaction of its own would have to fetch the row again.
+    """
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submission_id = initial_metadata.submission_id
+    db.add_submission(submission_id)
+
+    with _counting_reads(db.engine) as counts:
+        changes = db.diff(submission_id, initial_metadata, submission_uploaded_date=None)
+
+    assert changes.case_link is not None, "case resolution must have run, or this pins nothing"
+    assert changes.donors.added, "donor resolution must have run, or this pins nothing"
+    assert counts == {"transactions": 1, "submission_reads": 1}
+
+
+def test_diff_reports_relink_to_existing_case(db: SubmissionDb, metadata: GrzSubmissionMetadata):
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submission_id = initial_metadata.submission_id
+    db.add_submission(submission_id)
+    db.commit_changes(submission_id, db.diff(submission_id, initial_metadata, submission_uploaded_date=None))
+    submission = db.get_submission(submission_id)
+    assert submission is not None and submission.case_id is not None
+    original_case_id = submission.case_id
+
+    other = db.create_case(initial_metadata.submission.submitter_id, "some-other-case")
+    db.set_submission_case(submission_id, other.id)
+
+    link = db.diff(submission_id, initial_metadata, submission_uploaded_date=None).case_link
+    assert link is not None and link.before == other.id and link.after == original_case_id
+
+
+def test_populate_does_not_revert_a_relink_without_force(db: SubmissionDb, metadata: GrzSubmissionMetadata):
+    """Undoing a deliberate relink to another case is destructive, so populate must refuse it without force."""
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submission_id = initial_metadata.submission_id
+    db.add_submission(submission_id)
+    db.commit_changes(submission_id, db.diff(submission_id, initial_metadata, submission_uploaded_date=None))
+    original_case_id = db.get_submission(submission_id).case_id
+
+    other = db.create_case(initial_metadata.submission.submitter_id, "some-other-case")
+    db.set_submission_case(submission_id, other.id)
+
+    with pytest.raises(RuntimeError, match="force"):
+        db.populate(submission_id, initial_metadata, submission_date=None)
+    assert db.get_submission(submission_id).case_id == other.id, "the relink must survive"
+
+    db.populate(submission_id, initial_metadata, submission_date=None, force=True)
+    assert db.get_submission(submission_id).case_id == original_case_id
+
+
+def test_diff_records_a_duplicate_initial_against_its_case(db: SubmissionDb, metadata: GrzSubmissionMetadata):
+    """A duplicate initial submission is recorded in full, linked to the case it duplicates,
+    rather than nothing being written at all.
+    """
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submission_id = initial_metadata.submission_id
+    db.add_submission(submission_id)
+    db.commit_changes(submission_id, db.diff(submission_id, initial_metadata, submission_uploaded_date=None))
+    db.modify_submission(submission_id, "basic_qc_passed", True)
+    case_id = db.get_submission(submission_id).case_id
+
+    second = _sid(initial_metadata.submission.submitter_id, "000000fe")
+    db.add_submission(second)
+    # the rival carries the same tanG in this fixture, which is a separate uniqueness rule
+    changes = db.diff(second, initial_metadata, submission_uploaded_date=None, ignore_fields={"tan_g"})
+    db.commit_changes(second, changes)
+
+    row = db.get_submission(second)
+    assert row.case_id == case_id
+    assert row.submission_type == SubmissionType.initial
+    assert row.submission_size is not None and row.submission_metadata is not None
+    assert db.get_donors(second)
+    # the case still has exactly one QC-passed initial submission
+    assert db.get_initial_submission(case_id).id == submission_id
+
+
+def test_resolution_rejects_ambiguous_case_key(db: SubmissionDb):
+    # duplicate (submitter, local case id) pairs are storable, but resolving through them must
+    # refuse rather than silently pick one patient's case
+    case_a = db.create_case(SUBMITTER_A, "caseX")
+    _second_case_for_the_same_key(db, SUBMITTER_A, "caseX")
+    case_b = next(case for case, _n in db.list_cases() if case.id != case_a.id)
+    sid = _sid(SUBMITTER_A, "000000b0")
+    _add(db, sid, SubmissionType.initial)
+
+    # the error names the offending cases so the operator knows what to clean up
+    id_lo, id_hi = sorted([case_a.id, case_b.id])
+    expected = rf"(?s)\b{id_lo}\b.*\b{id_hi}\b"
+    with pytest.raises(AmbiguousCaseError, match=expected):
+        db.resolve_case(sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial)
+    with pytest.raises(AmbiguousCaseError, match=expected):
+        db.assign_case(sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial)
+
+
+def test_diff_skips_case_link_when_case_id_ignored(db: SubmissionDb, metadata: GrzSubmissionMetadata):
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submission_id = initial_metadata.submission_id
+    db.add_submission(submission_id)
+
+    changes = db.diff(submission_id, initial_metadata, submission_uploaded_date=None, ignore_fields={"case_id"})
+    assert changes.case_link is None
+
+
+def test_diff_links_case_while_pseudonym_column_stays_ignored(db: SubmissionDb, metadata: GrzSubmissionMetadata):
+    """Ignoring the pseudonym skips the column write but not case resolution."""
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submission_id = initial_metadata.submission_id
+    db.add_submission(submission_id)
+
+    changes = db.diff(submission_id, initial_metadata, submission_uploaded_date=None, ignore_fields={"pseudonym"})
+    assert changes.case_link is not None
+    assert all(d.key != "pseudonym" for d in changes.fields.pending)
+
+    db.commit_changes(submission_id, changes)
+    submission = db.get_submission(submission_id)
+    assert submission is not None and submission.case_id is not None
+    assert submission.pseudonym is None
+
+
+def test_linked_failed_initial_resolves_without_error(db: SubmissionDb):
+    """A duplicate initial submission already linked to the case keeps its link when resolved
+    again: resolve_case is a no-op for a submission already linked to the target case, not a
+    fresh attempt to link it.
+    """
+    qc_passed_id, duplicate_id, _case_id = _case_with_competing_initials(db)
+    _record_basic_qc(db, qc_passed_id, True)
+
+    case = db.resolve_case(
+        duplicate_id, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+    assert case is not None and db.get_submission(duplicate_id).case_id == case.id
+
+
+def test_case_tracking_rejects_test_submission(db: SubmissionDb):
+    sid = _sid(SUBMITTER_A, "000000b1")
+    _add(db, sid, SubmissionType.test)
+
+    with pytest.raises(SubmissionTypeInvalidForCaseError):
+        db.resolve_case(sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.test)
+    with pytest.raises(SubmissionTypeInvalidForCaseError):
+        db.assign_case(sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.test)
+    assert db.list_cases() == []
+
+
+def test_diff_skips_case_link_for_test_submission(db: SubmissionDb, metadata: GrzSubmissionMetadata):
+    # the shipped example is a test submission; populate must not case-track it
+    submission_id = metadata.submission_id
+    db.add_submission(submission_id)
+
+    changes = db.diff(submission_id, metadata, submission_uploaded_date=None)
+    assert changes.case_link is None
+
+    db.commit_changes(submission_id, changes)
+    submission = db.get_submission(submission_id)
+    assert submission is not None and submission.case_id is None
+    assert db.list_cases() == []
+
+
+@pytest.mark.parametrize("placeholder", ["", REDACTED_LOCAL_CASE_ID], ids=["empty", "sentinel"])
+def test_diff_skips_case_link_for_a_redacted_local_case_id(
+    db: SubmissionDb, metadata: GrzSubmissionMetadata, placeholder: str
+):
+    """A redaction placeholder identifies no patient, so it must never key a case."""
+    initial_metadata = _with_submission_type(metadata, "initial")
+    raw = json.loads(initial_metadata.model_dump_json(by_alias=True))
+    raw["submission"]["localCaseId"] = placeholder
+    redacted = GrzSubmissionMetadata.model_validate(raw)
+
+    submission_id = initial_metadata.submission_id
+    db.add_submission(submission_id)
+
+    assert db.diff(submission_id, redacted, submission_uploaded_date=None).case_link is None
+    assert db.list_cases() == []
+
+
+def test_two_submissions_with_a_redacted_local_case_id_do_not_merge(db: SubmissionDb, metadata: GrzSubmissionMetadata):
+    """Without the guard, every redacted submission of a submitter shares the key ("", submitter)
+    and collapses onto one case, so the second patient's initial is rejected as a duplicate.
+    """
+    initial_metadata = _with_submission_type(metadata, "initial")
+    raw = json.loads(initial_metadata.model_dump_json(by_alias=True))
+    raw["submission"]["localCaseId"] = ""
+    redacted = GrzSubmissionMetadata.model_validate(raw)
+
+    for suffix in ("000000d1", "000000d2"):
+        sid = _sid(initial_metadata.submission.submitter_id, suffix)
+        db.add_submission(sid)
+        changes = db.diff(sid, redacted, submission_uploaded_date=None, ignore_fields={"tan_g"})
+        assert changes.case_link is None
+        db.commit_changes(sid, changes)
+        _record_basic_qc(db, sid, True)
+
+    assert db.list_cases() == []
+
+
+def test_resolver_ignores_an_empty_case_key(db: SubmissionDb):
+    """``db case create`` accepts an empty local case ID, but resolution must never match it."""
+    db.create_case(SUBMITTER_A, "")
+    sid = _sid(SUBMITTER_A, "000000d3")
+    _add(db, sid, SubmissionType.initial)
+
+    assert (
+        db.resolve_case(sid, submitter_id=SUBMITTER_A, local_case_id="", submission_type=SubmissionType.initial) is None
+    )
+
+
+def test_diff_reports_an_ambiguous_case_key_instead_of_raising(db: SubmissionDb, metadata: GrzSubmissionMetadata):
+    """Whether a case can be identified says nothing about the other diffs, so diff reports it.
+
+    ``resolve_case`` still raises, since a caller that asked only about the case has no answer.
+    """
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submitter = initial_metadata.submission.submitter_id
+    local_case_id = initial_metadata.submission.local_case_id
+    db.create_case(submitter, local_case_id)
+    _second_case_for_the_same_key(db, submitter, local_case_id)
+    submission_id = initial_metadata.submission_id
+    db.add_submission(submission_id)
+
+    changes = db.diff(submission_id, initial_metadata, submission_uploaded_date=None)
+
+    assert isinstance(changes.case_link_error, AmbiguousCaseError)
+    assert changes.case_link is None
+    assert changes.has_pending, "every other diff survives an unresolvable case"
+
+    db.commit_changes(submission_id, changes)
+    row = db.get_submission(submission_id)
+    assert row.case_id is None
+    assert row.submission_size is not None and row.submission_metadata is not None
+
+
+def test_create_case_rejects_a_malformed_submitter_id(db: SubmissionDb):
+    """A submitter ID no submission can carry would leave the case permanently unresolvable."""
+    with pytest.raises(ValidationError):
+        db.create_case("not-a-submitter-id", "caseX")
+    assert db.list_cases() == []
+
+
+def test_modify_case_rejects_a_malformed_submitter_id(db: SubmissionDb):
+    case = db.create_case(SUBMITTER_A, "caseX")
+
+    with pytest.raises(ValidationError):
+        db.modify_case(case.id, "submitter_id", "nope")
+
+    stored = db.get_case(case.id)
+    assert stored.submitter_id == SUBMITTER_A
+
+
+def test_relink_refuses_a_test_submission(db: SubmissionDb):
+    """Relinking is the one door an operator drives by hand, so it needs the rule most."""
+    initial = _sid(SUBMITTER_A, "0000000a")
+    test_submission = _sid(SUBMITTER_A, "0000000e")
+    _add(db, initial, SubmissionType.initial)
+    _add(db, test_submission, SubmissionType.test)
+    case = db.assign_case(
+        initial, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+
+    with pytest.raises(SubmissionTypeInvalidForCaseError):
+        db.set_submission_case(test_submission, case.id)
+
+    assert db.get_submission(test_submission).case_id is None
+    assert {s.id for s in db.list_submissions_for_case(case.id)} == {initial}
+
+
+def test_relink_refuses_a_submission_whose_type_is_unknown(db: SubmissionDb):
+    """An unpopulated row may yet turn out to be a test submission.
+
+    Linking it would decide that before the metadata does, and populate resolves the link
+    itself, so there is nothing to gain by allowing it.
+    """
+    initial = _sid(SUBMITTER_A, "0000000a")
+    _add(db, initial, SubmissionType.initial)
+    case = db.assign_case(
+        initial, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+    )
+    unpopulated = _sid(SUBMITTER_A, "0000000e")
+    db.add_submission(unpopulated)
+
+    with pytest.raises(SubmissionTypeInvalidForCaseError):
+        db.set_submission_case(unpopulated, case.id)
+
+    assert db.get_submission(unpopulated).case_id is None
+
+
+def test_concurrent_assign_case_settles_on_one_case(db: SubmissionDb, migrated_db_connection, test_author):
+    """Two processes populating one patient's submissions must not mint two cases.
+
+    Both look the case up before either commits, so both try to create one. The loser joins the
+    winner's case instead of leaving the key ambiguous for good.
+    """
+    sids = [_sid(SUBMITTER_A, f"0000000{suffix}") for suffix in "ab"]
+    for sid in sids:
+        _add(db, sid, SubmissionType.initial)
+
+    services = [SubmissionDb(db_url=migrated_db_connection, author=test_author, debug=False) for _ in sids]
+    start = threading.Barrier(len(sids))
+    outcomes: dict[str, object] = {}
+
+    def link(service: SubmissionDb, sid: str) -> None:
+        start.wait(timeout=10)
+        try:
+            outcomes[sid] = service.assign_case(
+                sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+            ).id
+        except Exception as exc:
+            outcomes[sid] = f"{type(exc).__name__}: {exc}"
+
+    threads = [threading.Thread(target=link, args=(service, sid)) for service, sid in zip(services, sids, strict=True)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+    for service in services:
+        service.engine.dispose()
+
+    assert len(db.list_cases()) == 1, f"one patient, one case: {outcomes}"
+    case_id = db.list_cases()[0][0].id
+    assert set(outcomes.values()) == {case_id}, outcomes
+    assert {s.id for s in db.list_submissions_for_case(case_id)} == set(sids)
+
+
+def test_assign_case_joins_a_case_that_appeared_mid_flight(
+    db: SubmissionDb, migrated_db_connection, test_author, monkeypatch: pytest.MonkeyPatch
+):
+    """The threaded test above cannot guarantee the two actually interleave, so force it."""
+    sid = _sid(SUBMITTER_A, "0000000a")
+    _add(db, sid, SubmissionType.initial)
+    other = SubmissionDb(db_url=migrated_db_connection, author=test_author, debug=False)
+    _lose_the_race_to(monkeypatch, other.create_case)
+    try:
+        case = db.assign_case(
+            sid, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+        )
+    finally:
+        other.engine.dispose()
+
+    assert [c.id for c, _n in db.list_cases()] == [case.id], "the loser must join, not create a second case"
+    assert db.get_submission(sid).case_id == case.id
+
+
+def test_modify_case_names_the_index_that_rejected_the_write(db: SubmissionDb):
+    """The key being edited says what was attempted; the index says what happened."""
+    kept = db.create_case(SUBMITTER_A, "caseX", psn="PSN-1")
+    other = db.create_case(SUBMITTER_A, "caseY", psn="PSN-2")
+
+    with pytest.raises(DuplicatePsnError):
+        db.modify_case(other.id, "psn", "PSN-1")
+    with pytest.raises(DuplicateCaseError):
+        db.modify_case(other.id, "local_case_id", "caseX")
+
+    assert db.get_case(other.id).psn == "PSN-2"
+    assert db.get_case(other.id).local_case_id == "caseY"
+    assert db.get_case(kept.id).local_case_id == "caseX"
+
+
+def test_every_unique_index_is_classified(db: SubmissionDb):
+    """The classifier matches names the migrations own, so drift would otherwise be silent.
+
+    A renamed index simply stops being recognised, and a rejected write surfaces as a raw
+    IntegrityError instead of the error saying what happened. A new unique index nobody
+    classified fails here too, which is the moment to decide what it should say.
+    """
+    inspector = sqlalchemy.inspect(db.engine)
+    in_the_schema = {
+        index["name"]: ", ".join(f"{table}.{column}" for column in index["column_names"])
+        for table in ("cases", "submissions")
+        for index in inspector.get_indexes(table)
+        if index.get("unique")
+    }
+
+    assert {index.index_name: index.sqlite_columns for index in _Index} == in_the_schema
+
+
+def test_a_rejected_change_set_writes_nothing(db: SubmissionDb, metadata: GrzSubmissionMetadata):
+    """A change set is one answer to one metadata file, so it is applied whole or not at all.
+
+    The link used to be committed before the fields, so a rejected field left the submission
+    linked, and the next preview started from somewhere the operator had never seen.
+    """
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submitter = initial_metadata.submission.submitter_id
+    local_case_id = initial_metadata.submission.local_case_id
+
+    winner = _sid(submitter, "0000000a")
+    _add(db, winner, SubmissionType.initial)
+    db.assign_case(winner, submitter_id=submitter, local_case_id=local_case_id, submission_type=SubmissionType.initial)
+    _record_basic_qc(db, winner, True)
+
+    # a rival that already passed basic QC, but whose type is not recorded yet: it links, and
+    # only writing submission_type brings it under the one-initial index
+    rival = _sid(submitter, "0000000b")
+    db.add_submission(rival)
+    _record_basic_qc(db, rival, True)
+
+    changes = db.diff(rival, initial_metadata, submission_uploaded_date=None, ignore_fields={"tan_g"})
+    assert changes.case_link is not None and any(d.key == "submission_type" for d in changes.fields.pending)
+
+    with pytest.raises(DuplicateInitialSubmissionError):
+        db.commit_changes(rival, changes)
+
+    row = db.get_submission(rival)
+    assert row.case_id is None, "the case link must not survive a rejected change set"
+    assert row.submission_type is None and row.submission_size is None
+    assert db.get_donors(rival) == ()
+
+
+def test_a_change_set_survives_a_case_that_appeared_mid_flight(
+    db: SubmissionDb,
+    migrated_db_connection,
+    test_author,
+    metadata: GrzSubmissionMetadata,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Joining a case that appeared mid-flight rolls the change set's transaction back.
+
+    That is survivable only because the link is applied before anything else: anything written
+    ahead of it would be discarded by that rollback and the change set would commit anyway,
+    which is the partial write the ordering exists to prevent.
+    """
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submitter = initial_metadata.submission.submitter_id
+
+    sid = _sid(submitter, "0000000a")
+    db.add_submission(sid)
+    changes = db.diff(sid, initial_metadata, submission_uploaded_date=None, ignore_fields={"tan_g"})
+    assert changes.case_link is not None and changes.donors.added, "the rollback needs something to lose"
+
+    other = SubmissionDb(db_url=migrated_db_connection, author=test_author, debug=False)
+    _lose_the_race_to(monkeypatch, other.create_case)
+    try:
+        db.commit_changes(sid, changes)
+    finally:
+        other.engine.dispose()
+
+    row = db.get_submission(sid)
+    assert [c.id for c, _n in db.list_cases()] == [row.case_id], "the loser must join, not create a second case"
+    assert row.submission_type == SubmissionType.initial, "the writes after the link must survive"
+    assert db.get_donors(sid) != ()
+
+
+def test_joining_a_full_case_names_the_index_that_rejected_the_link(
+    db: SubmissionDb, migrated_db_connection, test_author, monkeypatch: pytest.MonkeyPatch
+):
+    """Losing the race to create a case does not mean the case will take the submission.
+
+    The winner links its own QC-passed initial alongside the case it creates, so the case is
+    already full when the loser joins it, and that rejection has a name of its own.
+    """
+    winner = _sid(SUBMITTER_A, "0000000a")
+    _add(db, winner, SubmissionType.initial)
+    _record_basic_qc(db, winner, True)
+
+    loser = _sid(SUBMITTER_A, "0000000b")
+    _add(db, loser, SubmissionType.initial)
+    _record_basic_qc(db, loser, True)
+
+    other = SubmissionDb(db_url=migrated_db_connection, author=test_author, debug=False)
+    _lose_the_race_to(
+        monkeypatch,
+        lambda submitter_id, local_case_id: other.assign_case(
+            winner,
+            submitter_id=submitter_id,
+            local_case_id=local_case_id,
+            submission_type=SubmissionType.initial,
+        ),
+    )
+    try:
+        with pytest.raises(DuplicateInitialSubmissionError):
+            db.assign_case(
+                loser, submitter_id=SUBMITTER_A, local_case_id="caseX", submission_type=SubmissionType.initial
+            )
+    finally:
+        other.engine.dispose()
+
+    assert db.get_submission(loser).case_id is None, "a rejected link must not be stored"
+
+
+def test_assign_case_names_the_psn_that_rejected_the_case_it_opened(db: SubmissionDb):
+    """Opening a case carries the pseudonym, so the psn index can reject the write that opens it.
+
+    Only the insert can break that index; the link that follows writes ``submissions.case_id``
+    and nothing a case is keyed on.
+    """
+    db.create_case(SUBMITTER_B, "caseY", psn="RKI-PSN-1")
+
+    sid = _sid(SUBMITTER_A, "0000000a")
+    _add(db, sid, SubmissionType.initial)
+
+    with pytest.raises(DuplicatePsnError):
+        db.assign_case(
+            sid,
+            submitter_id=SUBMITTER_A,
+            local_case_id="caseX",
+            psn="RKI-PSN-1",
+            submission_type=SubmissionType.initial,
+        )
+
+    assert [c.local_case_id for c, _n in db.list_cases()] == ["caseY"], "a rejected case must not be stored"
+    assert db.get_submission(sid).case_id is None, "and must not leave the submission linked"
+
+
+def test_assert_no_duplicate_initial_leaves_a_redacted_case_key_alone(db: SubmissionDb, metadata):
+    """A redaction placeholder cannot key a case, so the question is never put to the database."""
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submission_id = initial_metadata.submission_id
+    _add(db, submission_id, SubmissionType.initial)
+
+    with _counting_reads(db.engine) as counts:
+        db.assert_no_duplicate_initial(
+            submission_id,
+            submitter_id=initial_metadata.submission.submitter_id,
+            local_case_id=REDACTED_LOCAL_CASE_ID,
+            submission_type=SubmissionType.initial,
+        )
+
+    assert counts["transactions"] == 0, "the guard must fire before the database is touched"
+
+
+def test_assert_no_duplicate_initial_names_the_submission_holding_the_slot(db: SubmissionDb, metadata):
+    """The rival is told which submission already holds the case's one QC-passed initial slot.
+
+    The holder is not a duplicate of itself, which is what lets a submission be re-validated.
+    """
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submitter = initial_metadata.submission.submitter_id
+    local_case_id = initial_metadata.submission.local_case_id
+
+    holder = _sid(submitter, "0000dd01")
+    _add(db, holder, SubmissionType.initial)
+    db.assign_case(holder, submitter_id=submitter, local_case_id=local_case_id, submission_type=SubmissionType.initial)
+    _record_basic_qc(db, holder, True)
+
+    db.assert_no_duplicate_initial(
+        holder, submitter_id=submitter, local_case_id=local_case_id, submission_type=SubmissionType.initial
+    )
+
+    rival = _sid(submitter, "0000dd02")
+    _add(db, rival, SubmissionType.initial)
+    with pytest.raises(DuplicateInitialSubmissionError) as excinfo:
+        db.assert_no_duplicate_initial(
+            rival, submitter_id=submitter, local_case_id=local_case_id, submission_type=SubmissionType.initial
+        )
+    assert holder in str(excinfo.value)
+
+
+def test_assert_no_duplicate_initial_does_not_swallow_a_resolution_failure(db: SubmissionDb, metadata):
+    """Answering "not a duplicate" when the question could not be answered is how one gets through.
+
+    Nothing downstream treats an unresolvable case as an error any more, so a swallow here
+    would be the last chance to notice.
+    """
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submitter = initial_metadata.submission.submitter_id
+    local_case_id = initial_metadata.submission.local_case_id
+    db.create_case(submitter, local_case_id)
+    _second_case_for_the_same_key(db, submitter, local_case_id)
+    submission_id = initial_metadata.submission_id
+    _add(db, submission_id, SubmissionType.initial)
+
+    with pytest.raises(AmbiguousCaseError):
+        db.assert_no_duplicate_initial(
+            submission_id,
+            submitter_id=submitter,
+            local_case_id=local_case_id,
+            submission_type=SubmissionType.initial,
+        )

--- a/packages/grz-db/tests/test_case.py
+++ b/packages/grz-db/tests/test_case.py
@@ -547,12 +547,9 @@ def _counting_reads(engine: sqlalchemy.Engine) -> Iterator[dict[str, int]]:
 
 
 def test_diff_reads_one_snapshot(db: SubmissionDb, metadata: GrzSubmissionMetadata):
-    """A change set answers for one submission at one moment, so it reads one.
-
-    Fields, donors and the case link were each resolved in a transaction of their own, which
-    let a write committed in between leave the three parts of one answer describing three
-    different states of the same submission. Reading the row once is that same fix seen from
-    the other side: a transaction of its own would have to fetch the row again.
+    """A change set must answer for one submission at one moment: it opens one transaction and
+    reads the submission row once, so a write committed mid-diff cannot leave fields, donors
+    and the case link describing three different snapshots.
     """
     initial_metadata = _with_submission_type(metadata, "initial")
     submission_id = initial_metadata.submission_id
@@ -876,7 +873,9 @@ def test_concurrent_assign_case_settles_on_one_case(db: SubmissionDb, migrated_d
 def test_assign_case_joins_a_case_that_appeared_mid_flight(
     db: SubmissionDb, migrated_db_connection, test_author, monkeypatch: pytest.MonkeyPatch
 ):
-    """The threaded test above cannot guarantee the two actually interleave, so force it."""
+    """``test_concurrent_assign_case_settles_on_one_case`` cannot guarantee the two actually
+    interleave, so force it.
+    """
     sid = _sid(SUBMITTER_A, "0000000a")
     _add(db, sid, SubmissionType.initial)
     other = SubmissionDb(db_url=migrated_db_connection, author=test_author, debug=False)
@@ -926,10 +925,9 @@ def test_every_unique_index_is_classified(db: SubmissionDb):
 
 
 def test_a_rejected_change_set_writes_nothing(db: SubmissionDb, metadata: GrzSubmissionMetadata):
-    """A change set is one answer to one metadata file, so it is applied whole or not at all.
-
-    The link used to be committed before the fields, so a rejected field left the submission
-    linked, and the next preview started from somewhere the operator had never seen.
+    """A change set is one answer to one metadata file, so it is applied whole or not at all:
+    the case link and every field write share one transaction, and a rejection undoes all of
+    it.
     """
     initial_metadata = _with_submission_type(metadata, "initial")
     submitter = initial_metadata.submission.submitter_id
@@ -1100,8 +1098,8 @@ def test_assert_no_duplicate_initial_names_the_submission_holding_the_slot(db: S
 def test_assert_no_duplicate_initial_does_not_swallow_a_resolution_failure(db: SubmissionDb, metadata):
     """Answering "not a duplicate" when the question could not be answered is how one gets through.
 
-    Nothing downstream treats an unresolvable case as an error any more, so a swallow here
-    would be the last chance to notice.
+    Nothing downstream treats an unresolvable case as an error, so a swallow here would be
+    the last chance to notice.
     """
     initial_metadata = _with_submission_type(metadata, "initial")
     submitter = initial_metadata.submission.submitter_id

--- a/packages/grz-db/tests/test_case.py
+++ b/packages/grz-db/tests/test_case.py
@@ -1051,21 +1051,56 @@ def test_assign_case_names_the_psn_that_rejected_the_case_it_opened(db: Submissi
     assert db.get_submission(sid).case_id is None, "and must not leave the submission linked"
 
 
-def test_assert_no_duplicate_initial_leaves_a_redacted_case_key_alone(db: SubmissionDb, metadata):
-    """A redaction placeholder cannot key a case, so the question is never put to the database."""
+def test_assert_no_duplicate_initial_never_keys_on_a_redaction_placeholder(db: SubmissionDb, metadata):
+    """A redaction placeholder keys no case, so it cannot collapse two submissions onto one.
+
+    The placeholder-keyed case is written directly, which no application path does, so a resolver
+    that stopped rejecting placeholders would match it here and report a duplicate.
+    """
     initial_metadata = _with_submission_type(metadata, "initial")
-    submission_id = initial_metadata.submission_id
-    _add(db, submission_id, SubmissionType.initial)
+    submitter = initial_metadata.submission.submitter_id
 
-    with _counting_reads(db.engine) as counts:
+    stray = db.create_case(submitter_id=submitter, local_case_id=REDACTED_LOCAL_CASE_ID)
+    holder = _sid(submitter, "0000ee01")
+    _add(db, holder, SubmissionType.initial)
+    db.set_submission_case(holder, stray.id)
+    _record_basic_qc(db, holder, True)
+
+    rival = _sid(submitter, "0000ee02")
+    _add(db, rival, SubmissionType.initial)
+
+    db.assert_no_duplicate_initial(
+        rival,
+        submitter_id=submitter,
+        local_case_id=REDACTED_LOCAL_CASE_ID,
+        submission_type=SubmissionType.initial,
+    )
+
+
+def test_assert_no_duplicate_initial_consults_the_resolver_it_was_given(db: SubmissionDb, metadata):
+    """An injected resolver answers here, on identifiers the default resolver cannot key.
+
+    ``local_case_id`` is absent, so the default resolver has nothing to match; only the injected
+    one can see the case. Screening on the default key before consulting the resolver would
+    report this rival as clear.
+    """
+    initial_metadata = _with_submission_type(metadata, "initial")
+    submitter = initial_metadata.submission.submitter_id
+
+    case = db.create_case(submitter_id=submitter, local_case_id="caseZ", psn="RKI-PSN-9")
+    holder = _sid(submitter, "0000ff01")
+    _add(db, holder, SubmissionType.initial)
+    db.set_submission_case(holder, case.id)
+    _record_basic_qc(db, holder, True)
+
+    rival = _sid(submitter, "0000ff02")
+    _add(db, rival, SubmissionType.initial)
+
+    with pytest.raises(DuplicateInitialSubmissionError) as excinfo:
         db.assert_no_duplicate_initial(
-            submission_id,
-            submitter_id=initial_metadata.submission.submitter_id,
-            local_case_id=REDACTED_LOCAL_CASE_ID,
-            submission_type=SubmissionType.initial,
+            rival, psn="RKI-PSN-9", submission_type=SubmissionType.initial, resolver=PsnResolver()
         )
-
-    assert counts["transactions"] == 0, "the guard must fire before the database is touched"
+    assert holder in str(excinfo.value)
 
 
 def test_assert_no_duplicate_initial_names_the_submission_holding_the_slot(db: SubmissionDb, metadata):

--- a/packages/grz-db/tests/test_migration_cases.py
+++ b/packages/grz-db/tests/test_migration_cases.py
@@ -2,7 +2,9 @@
 
 Seeds submissions at the revision just before the cases migration, upgrades, and asserts that the
 backfill groups by ``(submitter_id, pseudonym)``, stores the keys on the case, links submissions,
-keeps distinct submitters apart, and leaves unkeyable rows unlinked.
+keeps distinct submitters apart, and leaves unkeyable rows unlinked. Also asserts that the
+migration fails fast when two QC-passed 'initial' submissions share a key, and that it extends
+the PostgreSQL ``failurereasonenum`` type with ``duplicate_initial``.
 """
 
 import pytest

--- a/packages/grz-db/tests/test_migration_cases.py
+++ b/packages/grz-db/tests/test_migration_cases.py
@@ -1,0 +1,201 @@
+"""Backfill coverage for the cases migration (f8c1a4b7e2d9).
+
+Seeds submissions at the revision just before the cases migration, upgrades, and asserts that the
+backfill groups by ``(submitter_id, pseudonym)``, stores the keys on the case, links submissions,
+keeps distinct submitters apart, and leaves unkeyable rows unlinked.
+"""
+
+import pytest
+import sqlalchemy
+from grz_db.models.submission import SubmissionDb
+
+PRE_CASES_REVISION = "c8d4a7f2b1e6"
+CASES_REVISION = "f8c1a4b7e2d9"
+
+
+def _tan(i: int) -> str:
+    return f"{i:064x}"
+
+
+def test_cases_backfill_groups_by_submitter_and_local_case(db_test_connection: str):
+    db = SubmissionDb(db_url=db_test_connection, author=None)
+    db.upgrade_schema(revision=PRE_CASES_REVISION)
+
+    engine = sqlalchemy.create_engine(db_test_connection)
+    submissions = sqlalchemy.Table("submissions", sqlalchemy.MetaData(), autoload_with=engine)
+
+    shared_a1 = "111111111_2025-01-01_00000001"
+    shared_a2 = "111111111_2025-01-02_00000002"
+    other_submitter = "222222222_2025-01-01_00000003"
+    null_pseudonym = "111111111_2025-01-03_00000004"
+    null_submitter = "333333333_2025-01-01_00000005"
+    redacted_1 = "111111111_2025-01-04_00000006"
+    redacted_2 = "111111111_2025-01-05_00000007"
+    empty_pseudonym = "111111111_2025-01-06_00000008"
+    test_type = "111111111_2025-01-07_00000009"
+
+    redacted = "REDACTED_LOCAL_CASE_ID"
+    rows = [
+        # two submissions, same (submitter, local case id) -> one case, both linked
+        dict(id=shared_a1, tan_g=_tan(1), pseudonym="caseX", submitter_id="111111111", submission_type="initial"),
+        dict(id=shared_a2, tan_g=_tan(2), pseudonym="caseX", submitter_id="111111111", submission_type="addition"),
+        # different submitter, same local case id -> a distinct case
+        dict(id=other_submitter, tan_g=_tan(3), pseudonym="caseX", submitter_id="222222222", submission_type="initial"),
+        # no pseudonym -> unlinked
+        dict(id=null_pseudonym, tan_g=_tan(4), pseudonym=None, submitter_id="111111111", submission_type="initial"),
+        # pseudonym but no submitter -> cannot form the key, unlinked
+        dict(id=null_submitter, tan_g=_tan(5), pseudonym="caseY", submitter_id=None, submission_type="initial"),
+        # redaction placeholders are not real case keys: two redacted 'initial' rows for the same
+        # submitter must not be grouped into one case, and must not falsely trigger the migration's
+        # duplicate-detection query either
+        dict(id=redacted_1, tan_g=_tan(6), pseudonym=redacted, submitter_id="111111111", submission_type="initial"),
+        dict(id=redacted_2, tan_g=_tan(7), pseudonym=redacted, submitter_id="111111111", submission_type="initial"),
+        dict(id=empty_pseudonym, tan_g=_tan(8), pseudonym="", submitter_id="111111111", submission_type="initial"),
+        # test submissions are never case-tracked, even with a full (submitter, local case id) key
+        dict(id=test_type, tan_g=_tan(9), pseudonym="caseX", submitter_id="111111111", submission_type="test"),
+    ]
+    with engine.begin() as conn:
+        conn.execute(submissions.insert(), rows)
+
+    db.upgrade_schema(revision=CASES_REVISION)
+
+    case_id_a1 = db.get_submission(shared_a1).case_id
+    case_id_a2 = db.get_submission(shared_a2).case_id
+    case_id_b = db.get_submission(other_submitter).case_id
+    assert case_id_a1 is not None and case_id_b is not None
+    assert case_id_a1 == case_id_a2  # shared (submitter, local case id) -> same case
+    assert case_id_a1 != case_id_b  # distinct submitter -> distinct case
+
+    # the case stores the resolution keys, psn is not assigned yet
+    case_a = db.get_case(case_id_a1)
+    assert case_a.submitter_id == "111111111" and case_a.local_case_id == "caseX"
+    assert case_a.psn is None and db.get_case(case_id_b).psn is None
+
+    assert {s.id for s in db.list_submissions_for_case(case_id_a1)} == {shared_a1, shared_a2}
+    assert {s.id for s in db.list_submissions_for_case(case_id_b)} == {other_submitter}
+
+    # unkeyable rows stay unlinked, and no spurious case is created for them
+    assert db.get_submission(null_pseudonym).case_id is None
+    assert db.get_submission(null_submitter).case_id is None
+    assert db.get_submission(redacted_1).case_id is None
+    assert db.get_submission(redacted_2).case_id is None
+    assert db.get_submission(empty_pseudonym).case_id is None
+    assert db.get_submission(test_type).case_id is None  # despite sharing case A's key
+
+    assert len(db.list_cases()) == 2
+
+
+def test_cases_backfill_rejects_duplicate_qc_passed_initials(db_test_connection: str):
+    """Two QC-passed 'initial' submissions sharing (submitter_id, pseudonym) are genuinely inconsistent.
+
+    A case may have at most one initial submission that passed basic QC, so the migration must
+    fail fast instead of silently choosing one of the two as the case's initial submission. This
+    exercises the duplicate-detection query (COUNT(*) ... GROUP BY ... HAVING COUNT(*) > 1).
+    """
+    db = SubmissionDb(db_url=db_test_connection, author=None)
+    db.upgrade_schema(revision=PRE_CASES_REVISION)
+
+    engine = sqlalchemy.create_engine(db_test_connection)
+    submissions = sqlalchemy.Table("submissions", sqlalchemy.MetaData(), autoload_with=engine)
+
+    initial_a = "111111111_2025-01-01_00000001"
+    initial_b = "111111111_2025-01-02_00000002"
+    rows = [
+        # two QC-passed 'initial' submissions for the same (submitter, local case id) -> inconsistent
+        dict(
+            id=initial_a,
+            tan_g=_tan(1),
+            pseudonym="caseX",
+            submitter_id="111111111",
+            submission_type="initial",
+            basic_qc_passed=True,
+        ),
+        dict(
+            id=initial_b,
+            tan_g=_tan(2),
+            pseudonym="caseX",
+            submitter_id="111111111",
+            submission_type="initial",
+            basic_qc_passed=True,
+        ),
+    ]
+    with engine.begin() as conn:
+        conn.execute(submissions.insert(), rows)
+
+    with pytest.raises(RuntimeError, match="more than one QC-passed 'initial' submission shares"):
+        db.upgrade_schema(revision=CASES_REVISION)
+
+    # the failed upgrade must not have created the cases table
+    inspector = sqlalchemy.inspect(engine)
+    assert "cases" not in inspector.get_table_names()
+
+
+def test_cases_backfill_links_competing_initials_that_did_not_all_pass_qc(db_test_connection: str):
+    """Legacy rows sharing one (submitter_id, pseudonym) key, where basic QC did not pass for all
+    of them, still link to a single case; the migration must recognize the QC-passed row among
+    them as the case's initial submission.
+    """
+    db = SubmissionDb(db_url=db_test_connection, author=None)
+    db.upgrade_schema(revision=PRE_CASES_REVISION)
+
+    engine = sqlalchemy.create_engine(db_test_connection)
+    submissions = sqlalchemy.Table("submissions", sqlalchemy.MetaData(), autoload_with=engine)
+
+    failed = "111111111_2025-01-01_00000001"
+    corrected = "111111111_2025-01-02_00000002"
+    pending = "111111111_2025-01-03_00000003"
+    rows = [
+        dict(
+            id=failed,
+            tan_g=_tan(1),
+            pseudonym="caseX",
+            submitter_id="111111111",
+            submission_type="initial",
+            basic_qc_passed=False,
+        ),
+        dict(
+            id=corrected,
+            tan_g=_tan(2),
+            pseudonym="caseX",
+            submitter_id="111111111",
+            submission_type="initial",
+            basic_qc_passed=True,
+        ),
+        dict(
+            id=pending,
+            tan_g=_tan(3),
+            pseudonym="caseX",
+            submitter_id="111111111",
+            submission_type="initial",
+            basic_qc_passed=None,
+        ),
+    ]
+    with engine.begin() as conn:
+        conn.execute(submissions.insert(), rows)
+
+    db.upgrade_schema(revision=CASES_REVISION)
+
+    case_ids = {db.get_submission(sid).case_id for sid in (failed, corrected, pending)}
+    assert len(case_ids) == 1 and None not in case_ids
+    (case_id,) = case_ids
+    assert db.get_initial_submission(case_id).id == corrected
+
+
+def test_cases_migration_extends_failure_reason_enum(db_test_connection: str):
+    """The migration must add 'duplicate_initial' to the PostgreSQL failurereasonenum type, the
+    value recorded when a duplicate initial submission fails basic QC.
+    """
+    db = SubmissionDb(db_url=db_test_connection, author=None)
+    db.upgrade_schema(revision=CASES_REVISION)
+
+    engine = sqlalchemy.create_engine(db_test_connection)
+    if engine.dialect.name != "postgresql":
+        pytest.skip("SQLite stores the enum as plain VARCHAR; only PostgreSQL needs the type extended")
+    with engine.connect() as conn:
+        labels = conn.execute(
+            sqlalchemy.text(
+                "SELECT enumlabel FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid "
+                "WHERE pg_type.typname = 'failurereasonenum'"
+            )
+        ).scalars()
+        assert "duplicate_initial" in set(labels)

--- a/packages/grz-db/tests/test_submission.py
+++ b/packages/grz-db/tests/test_submission.py
@@ -1,10 +1,15 @@
 import datetime
+import json
 from collections.abc import Callable
 
 import pytest
 from grz_db.errors import DuplicateTanGError
-from grz_db.models.submission import Submission, SubmissionDb
-from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
+from grz_db.models.submission import OutdatedDatabaseSchemaError, Submission, SubmissionDb
+from grz_pydantic_models.submission.metadata import (
+    REDACTED_LOCAL_CASE_ID,
+    REDACTED_TAN,
+    GrzSubmissionMetadata,
+)
 
 TWO_TB = 2 * 1024**4  # 2,199,023,255,552 bytes
 SUBMISSION_ID = "123456789_2024-01-01_abcdef01"
@@ -145,3 +150,121 @@ def test_raises_on_duplicate_tan_g(
     sub2 = db.add_submission(SUBMISSION_ID_2)
     with pytest.raises(DuplicateTanGError):
         set_tan_g(db, sub2, TAN_G_1)
+
+
+def _redacted(metadata: GrzSubmissionMetadata, local_case_id: str) -> GrzSubmissionMetadata:
+    """A copy of *metadata* redacted the way archival redacts it.
+
+    Archival writes the ``REDACTED_LOCAL_CASE_ID`` sentinel; older objects in the
+    archive carry an empty ``localCaseId``, so both spellings are in the archive and
+    both have to be recognised.
+    """
+    raw = json.loads(metadata.model_dump_json(by_alias=True))
+    raw["submission"]["tanG"] = REDACTED_TAN
+    raw["submission"]["localCaseId"] = local_case_id
+    return GrzSubmissionMetadata.model_validate(raw)
+
+
+@pytest.mark.parametrize("placeholder", ["", REDACTED_LOCAL_CASE_ID], ids=["empty", "sentinel"])
+def test_restore_redacted_fields_uses_the_stored_row(
+    db: SubmissionDb, metadata: GrzSubmissionMetadata, placeholder: str
+) -> None:
+    """Both redaction spellings are restored from the columns populate wrote."""
+    submission = db.add_submission(SUBMISSION_ID)
+    db.modify_submission(SUBMISSION_ID, "tan_g", TAN_G_1)
+    db.modify_submission(SUBMISSION_ID, "pseudonym", "the-real-case")
+    submission = db.get_submission(SUBMISSION_ID)
+
+    archived = _redacted(metadata, placeholder)
+    unrestored = submission.restore_redacted_fields(archived)
+
+    assert unrestored == frozenset()
+    assert archived.submission.tan_g == TAN_G_1
+    assert archived.submission.local_case_id == "the-real-case"
+
+
+@pytest.mark.parametrize("placeholder", ["", REDACTED_LOCAL_CASE_ID], ids=["empty", "sentinel"])
+def test_restore_redacted_fields_reports_what_it_cannot_restore(
+    db: SubmissionDb, metadata: GrzSubmissionMetadata, placeholder: str
+) -> None:
+    """A row with nothing stored leaves the placeholders in place and names the columns."""
+    submission = db.add_submission(SUBMISSION_ID)
+
+    archived = _redacted(metadata, placeholder)
+    unrestored = submission.restore_redacted_fields(archived)
+
+    assert unrestored == frozenset({"tan_g", "pseudonym"})
+    assert archived.submission.tan_g == REDACTED_TAN
+    assert archived.submission.local_case_id == placeholder
+
+
+def test_restore_redacted_fields_leaves_unredacted_values_alone(
+    db: SubmissionDb, metadata: GrzSubmissionMetadata
+) -> None:
+    """An unredacted copy is authoritative, so it is diffed rather than overwritten."""
+    db.add_submission(SUBMISSION_ID)
+    db.modify_submission(SUBMISSION_ID, "tan_g", TAN_G_1)
+    db.modify_submission(SUBMISSION_ID, "pseudonym", "stored-case")
+    submission = db.get_submission(SUBMISSION_ID)
+
+    unrestored = submission.restore_redacted_fields(metadata)
+
+    assert unrestored == frozenset()
+    assert metadata.submission.tan_g != TAN_G_1
+    assert metadata.submission.local_case_id != "stored-case"
+
+
+def test_restore_redacted_fields_restores_each_column_independently(
+    db: SubmissionDb, metadata: GrzSubmissionMetadata
+) -> None:
+    """A stored pseudonym still helps even when the tanG cannot be recovered."""
+    db.add_submission(SUBMISSION_ID)
+    db.modify_submission(SUBMISSION_ID, "pseudonym", "the-real-case")
+    submission = db.get_submission(SUBMISSION_ID)
+
+    archived = _redacted(metadata, "")
+    unrestored = submission.restore_redacted_fields(archived)
+
+    assert unrestored == frozenset({"tan_g"})
+    assert archived.submission.local_case_id == "the-real-case"
+
+
+def test_the_schema_is_checked_once_per_database(db: SubmissionDb, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Asking costs a scan of the migration directory and a connection of its own.
+
+    One pass over a submission opens a session per write, so asking every time paid that over
+    and over for an answer that cannot change under us.
+    """
+    calls = 0
+    original = SubmissionDb._at_latest_schema
+
+    def counted(self: SubmissionDb) -> bool:
+        nonlocal calls
+        calls += 1
+        return original(self)
+
+    monkeypatch.setattr(SubmissionDb, "_at_latest_schema", counted)
+    db._schema_confirmed = False  # a freshly constructed instance has not asked yet
+
+    db.add_submission(SUBMISSION_ID)
+    db.modify_submission(SUBMISSION_ID, "basic_qc_passed", True)
+    db.get_submission(SUBMISSION_ID)
+
+    assert calls == 1
+
+
+def test_a_database_that_is_behind_is_asked_again(db: SubmissionDb, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only a returned answer is remembered, never a raised one.
+
+    ``db init`` and ``db upgrade`` build this object precisely when the schema is behind, so a
+    remembered failure would outlive the upgrade that fixed it.
+    """
+    behind = True
+    monkeypatch.setattr(SubmissionDb, "_at_latest_schema", lambda self: not behind)
+    db._schema_confirmed = False
+
+    with pytest.raises(OutdatedDatabaseSchemaError):
+        db.get_submission(SUBMISSION_ID)
+
+    behind = False
+    assert db.get_submission(SUBMISSION_ID) is None, "the upgrade must be picked up"

--- a/packages/grz-db/tests/test_submission.py
+++ b/packages/grz-db/tests/test_submission.py
@@ -230,10 +230,10 @@ def test_restore_redacted_fields_restores_each_column_independently(
 
 
 def test_the_schema_is_checked_once_per_database(db: SubmissionDb, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Asking costs a scan of the migration directory and a connection of its own.
-
-    One pass over a submission opens a session per write, so asking every time paid that over
-    and over for an answer that cannot change under us.
+    """The schema check scans the migration directory and opens a connection of its own, and
+    each write opens its own session, so caching the answer on the instance is what keeps
+    that cost from being paid on every write. The answer cannot change while the process is
+    running, so the cache cannot go stale.
     """
     calls = 0
     original = SubmissionDb._at_latest_schema

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -12,7 +12,7 @@ from importlib.resources import files
 from itertools import groupby
 from operator import attrgetter
 from pathlib import Path, PurePosixPath
-from typing import Annotated, Any, Self
+from typing import Annotated, Any, Self, cast
 
 from pydantic import (
     AfterValidator,
@@ -39,6 +39,18 @@ from .versioning import Version
 SCHEMA_URL_PATTERN = r"https://raw\.githubusercontent\.com/BfArM-MVH/MVGenomseq/refs/tags/v([0-9]+)\.([0-9]+)(?:\.([0-9]+))?/GRZ/grz-schema\.json"
 REDACTED_TAN = "0" * 64
 REDACTED_LOCAL_CASE_ID = "REDACTED_LOCAL_CASE_ID"
+# Archival wrote an empty string before REDACTED_LOCAL_CASE_ID was introduced, so both
+# spellings are in the archive and neither identifies a patient.
+LOCAL_CASE_ID_PLACEHOLDERS = ("", REDACTED_LOCAL_CASE_ID)
+
+
+def is_redacted_local_case_id(local_case_id: str | None) -> bool:
+    """Whether *local_case_id* is a redaction placeholder rather than a submitter's value.
+
+    A placeholder identifies no patient, so it must never be stored as one, keyed on, or
+    treated as a case identifier.
+    """
+    return local_case_id is None or local_case_id in LOCAL_CASE_ID_PLACEHOLDERS
 
 
 def redact_metadata_dict(metadata: dict[str, Any]) -> dict[str, Any]:
@@ -53,9 +65,6 @@ def redact_metadata_dict(metadata: dict[str, Any]) -> dict[str, Any]:
     keeping the archived record faithful to what the submitter sent, while
     :meth:`GrzSubmissionMetadata.to_redacted_dict` applies the same rule to a model dump.
     One list of sensitive fields, two carriers.
-
-    Archived documents may also carry an empty ``localCaseId`` instead of the
-    :data:`REDACTED_LOCAL_CASE_ID` placeholder, so a reader has to treat both as redacted.
 
     :param metadata: Parsed metadata JSON. Not modified.
     :returns: A deep copy of ``metadata`` with the sensitive fields redacted.
@@ -1314,6 +1323,44 @@ class GrzSubmissionMetadata(StrictBaseModel):
         :returns: Redacted metadata dictionary
         """
         return redact_metadata_dict(self.get_raw_dict())
+
+    def restore_redacted_fields(self, *, tan_g: str | None, local_case_id: str | None) -> frozenset[str]:
+        """Put authoritative values back into the fields redaction replaced, in place.
+
+        The partial inverse of :meth:`to_redacted_dict`, for a caller that kept the
+        submitter's values elsewhere: a metadata.json read back from an archive carries
+        placeholders, not what was submitted.
+
+        Redaction replaces a third field, the index donor's pseudonym, which this
+        deliberately leaves alone. Every accepted schema version already prescribes the
+        literal ``"index"`` there, so redacting it only bites on a document from v1.1.x or
+        earlier, whose description read "For Index patient use TanG" and which therefore
+        carries the tanG in that field. Restoring it would change nothing observable, since
+        every consumer that keeps a copy stores ``"index"`` for the index donor, and there
+        would be nothing to restore it from once a tanG is traded for a PSN.
+
+        A field holding something other than a placeholder is left alone and stays
+        authoritative, so an unredacted copy is never overwritten.
+
+        :param tan_g: Value to restore ``tanG`` to, or ``None`` if unknown.
+        :param local_case_id: Value to restore ``localCaseId`` to, or ``None`` if unknown.
+        :returns: The names of the fields still redacted because no value was supplied.
+        """
+        unrestored = set()
+
+        if self.submission.tan_g == REDACTED_TAN:
+            if tan_g:
+                self.submission.tan_g = tan_g
+            else:
+                unrestored.add("tan_g")
+
+        if is_redacted_local_case_id(self.submission.local_case_id):
+            if not is_redacted_local_case_id(local_case_id):
+                self.submission.local_case_id = cast(str, local_case_id)
+            else:
+                unrestored.add("local_case_id")
+
+        return frozenset(unrestored)
 
     @field_validator("donors", mode="after")
     @classmethod

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -1332,12 +1332,11 @@ class GrzSubmissionMetadata(StrictBaseModel):
         placeholders, not what was submitted.
 
         Redaction replaces a third field, the index donor's pseudonym, which this
-        deliberately leaves alone. Every accepted schema version already prescribes the
-        literal ``"index"`` there, so redacting it only bites on a document from v1.1.x or
-        earlier, whose description read "For Index patient use TanG" and which therefore
-        carries the tanG in that field. Restoring it would change nothing observable, since
-        every consumer that keeps a copy stores ``"index"`` for the index donor, and there
-        would be nothing to restore it from once a tanG is traded for a PSN.
+        deliberately leaves alone. v1.1.1 to v1.1.7 (still supported) told submitters to put
+        the tanG in ``donorPseudonym``; v1.1.8 onward says ``"index"``. Restoring it would
+        change nothing observable for a document from v1.1.8 onward, since every consumer
+        that keeps a copy stores ``"index"`` for the index donor there, and there would be
+        nothing to restore it from once a tanG is traded for a PSN.
 
         A field holding something other than a placeholder is left alone and stays
         authoritative, so an unredacted copy is never overwritten.

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -39,8 +39,8 @@ from .versioning import Version
 SCHEMA_URL_PATTERN = r"https://raw\.githubusercontent\.com/BfArM-MVH/MVGenomseq/refs/tags/v([0-9]+)\.([0-9]+)(?:\.([0-9]+))?/GRZ/grz-schema\.json"
 REDACTED_TAN = "0" * 64
 REDACTED_LOCAL_CASE_ID = "REDACTED_LOCAL_CASE_ID"
-# Archival wrote an empty string before REDACTED_LOCAL_CASE_ID was introduced, so both
-# spellings are in the archive and neither identifies a patient.
+# The archive contains both an empty string and REDACTED_LOCAL_CASE_ID as redaction
+# placeholders; neither spelling identifies a patient.
 LOCAL_CASE_ID_PLACEHOLDERS = ("", REDACTED_LOCAL_CASE_ID)
 
 

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -29,6 +29,7 @@ from grz_pydantic_models.submission.metadata import (
     get_accepted_versions,
 )
 from grz_pydantic_models.submission.metadata.v1 import (
+    LOCAL_CASE_ID_PLACEHOLDERS,
     PROFILES_REQUIRING_PERIOD_END,
     REDACTED_LOCAL_CASE_ID,
     REDACTED_TAN,
@@ -40,6 +41,7 @@ from grz_pydantic_models.submission.metadata.v1 import (
     LibraryType,
     ResearchConsent,
     ResearchConsentCodes,
+    is_redacted_local_case_id,
     redact_metadata_dict,
 )
 from grz_pydantic_models_testing import example_metadata, example_research_consent, example_terminology
@@ -1748,6 +1750,63 @@ def test_no_scope_justification_standard_passes_after_cutoff(version: str, justi
             consent.pop("scope", None)
 
     GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+
+
+def _archived(metadata: GrzSubmissionMetadata, local_case_id: str) -> GrzSubmissionMetadata:
+    """A copy redacted the way archival redacts it, with *local_case_id* as the placeholder."""
+    raw = json.loads(metadata.model_dump_json(by_alias=True))
+    raw["submission"]["tanG"] = REDACTED_TAN
+    raw["submission"]["localCaseId"] = local_case_id
+    for donor in raw["donors"]:
+        if donor["relation"] == "index":
+            donor["donorPseudonym"] = "index"
+    return GrzSubmissionMetadata.model_validate(raw)
+
+
+@pytest.mark.parametrize("placeholder", LOCAL_CASE_ID_PLACEHOLDERS)
+def test_restore_redacted_fields_replaces_both_placeholder_spellings(placeholder: str) -> None:
+    original = _metadata("wgs_tumor_germline", "1.3.0")
+    archived = _archived(original, placeholder)
+    assert archived.submission.tan_g == REDACTED_TAN
+
+    unrestored = archived.restore_redacted_fields(
+        tan_g=original.submission.tan_g,
+        local_case_id=original.submission.local_case_id,
+    )
+
+    assert unrestored == frozenset()
+    assert archived.submission.tan_g == original.submission.tan_g
+    assert archived.submission.local_case_id == original.submission.local_case_id
+
+
+@pytest.mark.parametrize("supplied", [None, *LOCAL_CASE_ID_PLACEHOLDERS])
+def test_restore_redacted_fields_reports_what_it_could_not_restore(supplied: str | None) -> None:
+    """A placeholder is no better than nothing, so supplying one restores neither field."""
+    archived = _archived(_metadata("wgs_tumor_germline", "1.3.0"), "")
+
+    unrestored = archived.restore_redacted_fields(tan_g=None, local_case_id=supplied)
+
+    assert unrestored == frozenset({"tan_g", "local_case_id"})
+    assert archived.submission.tan_g == REDACTED_TAN
+    assert is_redacted_local_case_id(archived.submission.local_case_id)
+
+
+def test_restore_redacted_fields_leaves_an_unredacted_copy_alone() -> None:
+    """An unredacted value is authoritative and must survive untouched."""
+    metadata = _metadata("wgs_tumor_germline", "1.3.0")
+    original_tan_g = metadata.submission.tan_g
+    original_local_case_id = metadata.submission.local_case_id
+
+    unrestored = metadata.restore_redacted_fields(tan_g="f" * 64, local_case_id="something-else")
+
+    assert unrestored == frozenset()
+    assert metadata.submission.tan_g == original_tan_g
+    assert metadata.submission.local_case_id == original_local_case_id
+
+
+def test_is_redacted_local_case_id_accepts_a_real_identifier() -> None:
+    assert not is_redacted_local_case_id("case-4711")
+    assert all(is_redacted_local_case_id(value) for value in (None, *LOCAL_CASE_ID_PLACEHOLDERS))
 
 
 ALL_EXAMPLES = sorted(

--- a/packages/grzctl/src/grzctl/commands/cli_wrappers.py
+++ b/packages/grzctl/src/grzctl/commands/cli_wrappers.py
@@ -59,7 +59,7 @@ def _check_duplicate_initial(db: "SubmissionDb", metadata: GrzSubmissionMetadata
 
     A resolution failure is left to propagate. Reporting "not a duplicate" when the
     question could not be answered is how a duplicate would pass basic QC unnoticed, and
-    nothing downstream treats an unresolvable case as an error any more.
+    nothing downstream treats an unresolvable case as an error.
     """
     submission = metadata.submission
     db.assert_no_duplicate_initial(

--- a/packages/grzctl/src/grzctl/commands/cli_wrappers.py
+++ b/packages/grzctl/src/grzctl/commands/cli_wrappers.py
@@ -2,17 +2,24 @@
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 import grz_cli.commands.encrypt as encrypt_module
 import grz_cli.commands.validate as validate_module
 import grz_common.cli as grzcli
 from grz_common.workers.worker import Worker
+from grz_db.errors import DuplicateInitialSubmissionError
 from grz_db.models.submission import SubmissionStateEnum
+from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
 
 from ..commands import grzctl_configuration, inbox_option
+from ..commands.db.cli import get_submission_db_instance
 from ..dbcontext import DbContext
 from ..models.config import GrzctlConfig
+
+if TYPE_CHECKING:
+    from grz_db.models.submission import SubmissionDb
 
 log = logging.getLogger(__name__)
 
@@ -40,6 +47,55 @@ def derive_encrypt_config(config: GrzctlConfig) -> dict:
     if config.keys.grz_private_key_path is not None:
         keys_dump["grz_private_key_path"] = config.keys.grz_private_key_path
     return {"keys": keys_dump}
+
+
+def _check_duplicate_initial(db: "SubmissionDb", metadata: GrzSubmissionMetadata) -> None:
+    """Raise :class:`DuplicateInitialSubmissionError` if this initial submission is a duplicate.
+
+    The rule and the index enforcing it belong to the database layer, which answers this in
+    one transaction; all that is left here is unpacking the metadata. Validation is what the
+    answer buys: the database would reject the submission anyway, but only once basic QC is
+    being recorded, by which point the effort has been spent.
+
+    A resolution failure is left to propagate. Reporting "not a duplicate" when the
+    question could not be answered is how a duplicate would pass basic QC unnoticed, and
+    nothing downstream treats an unresolvable case as an error any more.
+    """
+    submission = metadata.submission
+    db.assert_no_duplicate_initial(
+        metadata.submission_id,
+        submitter_id=submission.submitter_id,
+        local_case_id=submission.local_case_id,
+        submission_type=submission.submission_type,
+    )
+
+
+def _warn_on_duplicate_initial(configuration: GrzctlConfig, submission_dir: Path, threads: int) -> None:
+    """Best-effort, read-only duplicate-initial check when DB updates are disabled.
+
+    Warns instead of raising, since nothing is written to the database in this mode.
+
+    A check that was attempted and could not be answered is worth saying out loud:
+    silence here reads as "not a duplicate", and that is an answer nobody got.
+    """
+    try:
+        db = get_submission_db_instance(configuration.db.database_url, author=None)
+        metadata = (
+            Worker(
+                metadata_dir=submission_dir / "metadata",
+                files_dir=submission_dir / "files",
+                log_dir=submission_dir / "logs",
+                encrypted_files_dir=submission_dir / "encrypted_files",
+                threads=threads,
+            )
+            .parse_submission()
+            .metadata.content
+        )
+        _check_duplicate_initial(db, metadata)
+    except DuplicateInitialSubmissionError as e:
+        log.warning(f"{e} Basic QC would be recorded as failed; continuing because DB updates are disabled.")
+    except Exception as e:
+        log.warning(f"Could not check whether this is a duplicate initial submission: {e}")
 
 
 @click.command()
@@ -86,6 +142,19 @@ def validate(  # noqa: PLR0913
         end_state=SubmissionStateEnum.VALIDATED,
         enabled=update_db,
     ) as dbcontext_inst:
+        if update_db:
+            try:
+                _check_duplicate_initial(dbcontext_inst.db, submission.metadata.content)
+            except DuplicateInitialSubmissionError as e:
+                # Another initial submission of this case already passed basic QC, so this
+                # submission fails basic QC without spending any validation effort. Re-raising
+                # lets DbContext record the ERROR state with the duplicate_initial reason.
+                log.warning(f"{e} Failing basic QC for submission '{submission_id}' without validating.")
+                _ = dbcontext_inst.db.modify_submission(submission_id, "basic_qc_passed", "false")
+                raise
+        else:
+            _warn_on_duplicate_initial(configuration, submission_dir, threads)
+
         validate_module.validate.callback(  # type: ignore[misc]
             configuration=derive_validate_config(configuration),
             submission_dir=submission_dir,
@@ -96,7 +165,17 @@ def validate(  # noqa: PLR0913
         )
 
         if update_db:
-            _ = dbcontext_inst.db.modify_submission(submission_id, "basic_qc_passed", "true")
+            try:
+                _ = dbcontext_inst.db.modify_submission(submission_id, "basic_qc_passed", "true")
+            except DuplicateInitialSubmissionError as e:
+                # Catches a competing initial submission of this case that passed basic QC
+                # while this submission was being validated; handled the same way as the
+                # pre-check above.
+                log.warning(
+                    f"Submission '{submission_id}' data validated, but {e} Failing basic QC for this submission."
+                )
+                _ = dbcontext_inst.db.modify_submission(submission_id, "basic_qc_passed", "false")
+                raise
 
 
 @click.command()

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -1419,16 +1419,6 @@ class _BackfillResult(StrEnum):
     CONSENT_MISMATCH = "consent_mismatch"
 
 
-# Metadata re-read from S3 is redacted, so tan_g and the pseudonym are restored from the
-# stored row before diffing (see Submission.restore_redacted_fields) rather than ignored
-# outright: that way an unredacted copy is still checked against the database, and a
-# placeholder never becomes a case key. Whatever cannot be restored is ignored per
-# submission. This constant covers only the upload date: it is computed above and passed
-# to diff() as an explicit parameter, so the generic field diff must not also read it
-# from metadata.
-_BACKFILL_IGNORE_FIELDS = frozenset({"submission_uploaded_date"})
-
-
 def _backfill_submission(  # noqa: C901, PLR0911, PLR0913
     current_submission: Submission,
     s3_client: Any,
@@ -1633,7 +1623,7 @@ def backfill(  # noqa: C901, PLR0912, PLR0913, PLR0915
     if force and allow_overwrite:
         raise click.UsageError("--force and --allow-overwrite are mutually exclusive; --force already permits all.")
 
-    ignore_fields = set(ignore_field) | _BACKFILL_IGNORE_FIELDS
+    ignore_fields = set(ignore_field)
 
     # ── Build S3 clients for both archive targets ────────────────────────────
     archive_targets = [

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -6,10 +6,11 @@ import logging
 import sys
 import traceback
 from collections import Counter, namedtuple
+from collections.abc import Iterable
 from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 import botocore.exceptions
 import click
@@ -26,21 +27,28 @@ from grz_common.logging import LOGGING_DATEFMT, LOGGING_FORMAT
 from grz_common.transfer import init_s3_client
 from grz_common.workers.download import query_submissions
 from grz_db.errors import (
+    CaseHasLinkedSubmissionsError,
+    CaseNotFoundError,
     DatabaseConfigurationError,
+    DuplicateCaseError,
+    DuplicatePsnError,
     SubmissionError,
     SubmissionNotFoundError,
+    SubmissionTypeInvalidForCaseError,
 )
 from grz_db.models.author import Author
 from grz_db.models.submission import (
+    Case,
     ChangeRequestEnum,
     ChangeRequestLog,
     DetailedQCResult,
+    DiffState,
     FailureReasonEnum,
     FieldDiff,
     Submission,
     SubmissionBase,
+    SubmissionChangeSet,
     SubmissionDb,
-    SubmissionDiffCollection,
     SubmissionStateEnum,
     SubmissionStateFilterModeEnum,
     SubmissionStateLog,
@@ -69,6 +77,53 @@ console = rich.console.Console()
 console_err = rich.console.Console(stderr=True)
 log = logging.getLogger(__name__)
 _TEXT_MISSING = rich.text.Text("missing", style="italic yellow")
+
+
+def _attribute_table(rows: Iterable[tuple[str, Any]]) -> rich.table.Table:
+    """Build the two-column Attribute/Value table the ``show`` commands render.
+
+    A ``None`` renders as *missing* rather than as the string "None", so a column that was
+    never populated cannot be mistaken for one holding that text.
+
+    :param rows: ``(label, value)`` pairs, in display order.
+    """
+    table = rich.table.Table(box=None)
+    table.add_column("Attribute", justify="right")
+    table.add_column("Value")
+    for label, value in rows:
+        table.add_row(
+            rich.text.Text(label, style="cyan"),
+            rich.text.Text(str(value)) if value is not None else _TEXT_MISSING,
+        )
+    return table
+
+
+def _dump_json(payload: Any) -> None:
+    """Write *payload* to stdout as JSON, indented, and nothing else.
+
+    Not through the rich console: it decides on ANSI colour when it is constructed, which for
+    this module happens at import, and it honours ``FORCE_COLOR`` even when stdout is a pipe.
+    A consumer then parses escape codes. ``TTY_COMPATIBLE=0`` suppresses that, but only the
+    test suite sets it. Indented because a case is read by eye as often as by a program.
+    """
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+def _abort(e: Exception) -> NoReturn:
+    """Print *e* as a red error on stderr and abort the command."""
+    console_err.print(f"[red]Error: {e}[/red]")
+    raise click.Abort() from e
+
+
+def _abort_missing_submission(e: SubmissionNotFoundError, submission_id: str) -> NoReturn:
+    """Like :func:`_abort`, plus a hint on how to add the missing submission."""
+    console_err.print(f"[red]Error: {e}[/red]")
+    console_err.print(f"You might need to add it first: grzctl db submission add {submission_id}")
+    raise click.Abort() from e
+
+
+_submission_id_argument = click.argument("submission_id", type=str)
 
 
 def get_submission_db_instance(db_url: str, author: Author | None = None) -> SubmissionDb:
@@ -128,6 +183,171 @@ def db(
 def submission(ctx: click.Context):
     """Submission operations"""
     pass
+
+
+@db.group()
+@click.pass_context
+def case(ctx: click.Context):
+    """Case operations"""
+    pass
+
+
+_CASE_MUTABLE_KEYS = sorted(Case.mutable_fields())
+
+_case_id_argument = click.argument("case_id", type=int)
+
+
+@case.command("list")
+@output_json
+@click.pass_context
+def case_list(ctx: click.Context, output_json: bool):
+    """List all cases with their linked-submission counts."""
+    db = ctx.obj["db_url"]
+    db_service = get_submission_db_instance(db, author=ctx.obj["author"])
+    cases = db_service.list_cases()
+
+    if output_json:
+        payload = [{**case_obj.model_dump(mode="json"), "submission_count": count} for case_obj, count in cases]
+        _dump_json(payload)
+        return
+
+    table = rich.table.Table(title="Cases")
+    table.add_column("ID", justify="right")
+    table.add_column("PSN")
+    table.add_column("Submitter ID")
+    table.add_column("Local Case ID")
+    table.add_column("Submissions", justify="right")
+    for case_obj, count in cases:
+        table.add_row(
+            str(case_obj.id),
+            case_obj.psn if case_obj.psn is not None else "-",
+            case_obj.submitter_id if case_obj.submitter_id is not None else "-",
+            case_obj.local_case_id if case_obj.local_case_id is not None else "-",
+            str(count),
+        )
+    console.print(table)
+
+
+@case.command("show")
+@_case_id_argument
+@output_json
+@click.pass_context
+def case_show(ctx: click.Context, case_id: int, output_json: bool):
+    """Show a case and its linked submissions."""
+    db = ctx.obj["db_url"]
+    db_service = get_submission_db_instance(db, author=ctx.obj["author"])
+    case_obj = db_service.get_case(case_id)
+    if case_obj is None:
+        _abort(CaseNotFoundError(case_id))
+    submissions = db_service.list_submissions_for_case(case_id)
+
+    if output_json:
+        payload = {
+            **case_obj.model_dump(mode="json"),
+            "submissions": [
+                {
+                    "id": s.id,
+                    "submission_type": s.submission_type,
+                    "basic_qc_passed": s.basic_qc_passed,
+                    "latest_state": (latest.state if (latest := s.get_latest_state()) else None),
+                }
+                for s in submissions
+            ],
+        }
+        _dump_json(payload)
+        return
+
+    attribute_table = _attribute_table(
+        (
+            ("ID", case_obj.id),
+            ("PSN", case_obj.psn),
+            ("Submitter ID", case_obj.submitter_id),
+            ("Local Case ID", case_obj.local_case_id),
+        )
+    )
+
+    submissions_table = rich.table.Table(title="Submissions")
+    submissions_table.add_column("Submission ID")
+    submissions_table.add_column("Type")
+    # Basic QC state distinguishes the case's QC-passed initial submission from any
+    # duplicate initial submissions of the same case, so it is included here.
+    submissions_table.add_column("Basic QC")
+    submissions_table.add_column("Latest State")
+    for s in submissions:
+        latest = s.get_latest_state()
+        submissions_table.add_row(
+            s.id,
+            str(s.submission_type) if s.submission_type is not None else "-",
+            "pending" if s.basic_qc_passed is None else ("passed" if s.basic_qc_passed else "failed"),
+            str(latest.state) if latest is not None else "-",
+        )
+    console.print(rich.panel.Panel.fit(rich.console.Group(attribute_table, submissions_table), title=f"Case {case_id}"))
+
+
+@case.command("modify", epilog="Currently available KEYs are: " + ", ".join(_CASE_MUTABLE_KEYS))
+@_case_id_argument
+@click.argument("key", metavar="KEY", type=click.Choice(_CASE_MUTABLE_KEYS))
+@click.argument("value", metavar="VALUE", type=str)
+@click.pass_context
+def case_modify(ctx: click.Context, case_id: int, key: str, value: str):
+    """Modify a mutable field of a case."""
+    db = ctx.obj["db_url"]
+    db_service = get_submission_db_instance(db, author=ctx.obj["author"])
+    try:
+        db_service.modify_case(case_id, key, value)
+        console_err.print(f"[green]Updated {key} of case {case_id}[/green]")
+    except (CaseNotFoundError, DuplicatePsnError, ValueError) as e:
+        _abort(e)
+
+
+@case.command("create")
+@click.argument("submitter_id", type=str)
+@click.argument("local_case_id", type=str)
+@click.option("--psn", default=None, help="RKI pseudonym (must be unique).")
+@click.pass_context
+def case_create(ctx: click.Context, submitter_id: str, local_case_id: str, psn: str | None):
+    """Manually create a case (cases are normally created during populate)."""
+    db = ctx.obj["db_url"]
+    db_service = get_submission_db_instance(db, author=ctx.obj["author"])
+    try:
+        case_obj = db_service.create_case(submitter_id=submitter_id, local_case_id=local_case_id, psn=psn)
+        console_err.print(
+            f"[green]Created case {case_obj.id} for submitter '{submitter_id}', local case '{local_case_id}'[/green]"
+        )
+    except (DuplicateCaseError, DuplicatePsnError) as e:
+        _abort(e)
+
+
+@case.command("relink")
+@_submission_id_argument
+@_case_id_argument
+@click.pass_context
+def case_relink(ctx: click.Context, submission_id: str, case_id: int):
+    """Relink a submission to a different case for repair.
+
+    A case may still have at most one initial submission that passed basic QC.
+    """
+    db = ctx.obj["db_url"]
+    db_service = get_submission_db_instance(db, author=ctx.obj["author"])
+    try:
+        db_service.set_submission_case(submission_id, case_id)
+        console_err.print(f"[green]Linked submission '{submission_id}' to case {case_id}[/green]")
+    except (SubmissionNotFoundError, CaseNotFoundError, SubmissionTypeInvalidForCaseError) as e:
+        _abort(e)
+
+
+@case.command("delete")
+@_case_id_argument
+@click.pass_context
+def case_delete(ctx: click.Context, case_id: int):
+    """Delete an empty case (refuses when submissions are still linked)."""
+    db = ctx.obj["db_url"]
+    db_service = get_submission_db_instance(db, author=ctx.obj["author"])
+    try:
+        db_service.delete_case(case_id)
+        console_err.print(f"[green]Deleted case {case_id}[/green]")
+    except (CaseNotFoundError, CaseHasLinkedSubmissionsError) as e:
+        _abort(e)
 
 
 @db.command()
@@ -366,7 +586,7 @@ def tui(ctx: click.Context, quarter: int | None, year: int | None):
 
 
 @db.command("should-qc")
-@click.argument("submission_id")
+@_submission_id_argument
 @click.option(
     "--target-percentage",
     "target_percentage",
@@ -442,7 +662,7 @@ def _build_submission_dict_from(
 
 
 @submission.command()
-@click.argument("submission_id", type=str)
+@_submission_id_argument
 @click.pass_context
 def add(ctx: click.Context, submission_id: str):
     """
@@ -454,15 +674,14 @@ def add(ctx: click.Context, submission_id: str):
         db_submission = db_service.add_submission(submission_id)
         console_err.print(f"[green]Submission '{db_submission.id}' added successfully.[/green]")
     except SubmissionError as e:
-        console_err.print(f"[red]Error: {e}[/red]")
-        raise click.Abort() from e
+        _abort(e)
     except Exception as e:
         console_err.print(f"[red]An unexpected error occurred: {e}[/red]")
         raise click.ClickException(f"Failed to add submission: {e}") from e
 
 
 @submission.command()
-@click.argument("submission_id", type=str)
+@_submission_id_argument
 @click.argument("state_str", metavar="STATE", type=click.Choice(SubmissionStateEnum.list(), case_sensitive=False))
 @click.option("--data", "data_json", type=str, default=None, help='Additional JSON data (e.g., \'{"k":"v"}\').')
 @click.option(
@@ -531,9 +750,7 @@ def update(  # noqa: C901, PLR0913
         if new_state_log.data:
             console_err.print(f"  Data: {new_state_log.data}")
     except SubmissionNotFoundError as e:
-        console_err.print(f"[red]Error: {e}[/red]")
-        console_err.print(f"You might need to add it first: grzctl db submission add {submission_id}")
-        raise click.Abort() from e
+        _abort_missing_submission(e, submission_id)
     except click.exceptions.Exit as e:
         if e.exit_code != 0:
             raise e
@@ -543,14 +760,18 @@ def update(  # noqa: C901, PLR0913
         raise click.ClickException(f"Failed to update submission state: {e}") from e
 
 
-# Exactly what SubmissionDb.modify_submission accepts. The epilog and the KEY choices below both
-# build from this, so --help always advertises what the command accepts. Same set as the
-# --allow-overwrite choices.
+# Exactly what SubmissionDb.modify_submission accepts. The epilog and the KEY choices both build
+# from this, so --help always advertises what the command accepts. SubmissionBase, not Submission:
+# the table model adds case_id, which `db case relink` sets. Same set as --allow-overwrite.
 _MODIFIABLE_SUBMISSION_KEYS = sorted(SubmissionBase.model_fields.keys() - SubmissionBase.immutable_fields)
 
 
-@submission.command(epilog="Currently available KEYs are: " + ", ".join(_MODIFIABLE_SUBMISSION_KEYS))
-@click.argument("submission_id", type=str)
+@submission.command(
+    epilog="Currently available KEYs are: "
+    + ", ".join(_MODIFIABLE_SUBMISSION_KEYS)
+    + ". A submission's case is not a column: use 'db case relink' to change it."
+)
+@_submission_id_argument
 @click.argument("key", metavar="KEY", type=click.Choice(_MODIFIABLE_SUBMISSION_KEYS))
 @click.argument("value", metavar="VALUE", type=str)
 @click.pass_context
@@ -568,9 +789,9 @@ def modify(ctx: click.Context, submission_id: str, key: str, value: str):
         _ = db_service.modify_submission(submission_id, key, value)
         console_err.print(f"[green]Updated {key} of submission '{submission_id}'[/green]")
     except SubmissionNotFoundError as e:
-        console_err.print(f"[red]Error: {e}[/red]")
-        console_err.print(f"You might need to add it first: grzctl db submission add {submission_id}")
-        raise click.Abort() from e
+        _abort_missing_submission(e, submission_id)
+    except SubmissionTypeInvalidForCaseError as e:
+        _abort(e)
     except Exception as e:
         console_err.print(f"[red]An unexpected error occurred: {e}[/red]")
         traceback.print_exc()
@@ -580,34 +801,57 @@ def modify(ctx: click.Context, submission_id: str, key: str, value: str):
 _ignore_field_option = click.option(
     "--ignore-field",
     "ignore_field",
-    type=click.Choice(list(SubmissionBase.model_fields.keys() - SubmissionBase.immutable_fields), case_sensitive=False),
-    help="Do not populate the given field from the metadata to the database. Can be specified multiple times.",
+    type=click.Choice(
+        [*(SubmissionBase.model_fields.keys() - SubmissionBase.immutable_fields), "case_id"],
+        case_sensitive=False,
+    ),
+    help="Do not populate the given field from the metadata to the database. Can be specified multiple times. "
+    "Passing --ignore-field case_id skips case resolution and linking.",
     multiple=True,
 )
 
 
-def _prepare_submission_console_table(submission_diff: "SubmissionDiffCollection") -> rich.console.RenderableType:
+def _prepare_submission_console_table(changes: "SubmissionChangeSet") -> rich.console.RenderableType:
     """Build a Rich renderable that shows pending submission-level metadata changes.
 
-    :param submission_diff: :class:`SubmissionDiff` instance produced by :func:`diff_metadata`.
+    :param changes: :class:`SubmissionChangeSet` instance produced by :meth:`SubmissionDb.diff`.
     :returns: A :class:`rich.table.Table` when there are pending changes, or a plain text message otherwise.
     """
-    pending = [d for d in submission_diff.pending if d.key != "submission_metadata"]
-    if pending:
+    rows = [
+        (d.key, str(d.diff.before) if d.diff.before is not None else _TEXT_MISSING, str(d.diff.after))
+        for d in changes.fields.pending
+        if d.key != "submission_metadata"
+    ]
+    if (link := changes.case_link) is not None:
+        rows.append(
+            (
+                "case_id",
+                str(link.before) if link.before is not None else _TEXT_MISSING,
+                str(link.after) if link.after is not None else "new case",
+            )
+        )
+    elif changes.case_link_error is not None:
+        # Shown rather than raised: the operator decides whether the rest is worth recording
+        # while the case itself waits on them to resolve it.
+        rows.append(("case_id", _TEXT_MISSING, f"unresolved: {changes.case_link_error}"))
+    if rows:
         diff_table_tbl = rich.table.Table(title="Submission Metadata")
         diff_table_tbl.add_column("Key")
         diff_table_tbl.add_column("Before")
         diff_table_tbl.add_column("After")
-        for field_diff in sorted(pending, key=lambda d: d.key):
-            diff_table_tbl.add_row(
-                field_diff.key,
-                str(field_diff.diff.before) if field_diff.diff.before is not None else _TEXT_MISSING,
-                str(field_diff.diff.after),
-            )
+        for key, before, after in sorted(rows, key=lambda row: row[0]):
+            diff_table_tbl.add_row(key, before, after)
         diff_table: rich.console.RenderableType = diff_table_tbl
     else:
         diff_table = rich.padding.Padding(rich.text.Text("No changes to submission-level metadata."), pad=(0, 0, 0, 0))
     return diff_table
+
+
+def _report_case_link(db_service: SubmissionDb, submission_id: str) -> None:
+    """Print which case a submission is linked to; call after committing a change set that includes a case link."""
+    linked = db_service.get_submission(submission_id)
+    if linked is not None and linked.case_id is not None:
+        console_err.print(f"[green]Submission linked to case {linked.case_id}.[/green]")
 
 
 def _prepare_donor_console_table(
@@ -636,7 +880,7 @@ def _prepare_donor_console_table(
 
 
 @submission.command()
-@click.argument("submission_id", type=str)
+@_submission_id_argument
 @click.argument("metadata_path", metavar="path/to/metadata.json", type=str)
 @click.option(
     "--submission_date",
@@ -651,7 +895,7 @@ def _prepare_donor_console_table(
 )
 @_ignore_field_option
 @click.pass_context
-def populate(  # noqa: C901, PLR0913
+def populate(  # noqa: C901, PLR0912, PLR0913
     ctx: click.Context,
     submission_id: str,
     metadata_path: str,
@@ -679,9 +923,7 @@ def populate(  # noqa: C901, PLR0913
         if not submission:
             raise SubmissionNotFoundError(submission_id)
     except SubmissionNotFoundError as e:
-        console_err.print(f"[red]Error: {e}[/red]")
-        console_err.print(f"You might need to add it first: grzctl db submission add {submission_id}")
-        raise click.Abort() from e
+        _abort_missing_submission(e, submission_id)
     except Exception as e:
         console_err.print(f"[red]An unexpected error occurred: {e}[/red]")
         traceback.print_exc()
@@ -710,29 +952,36 @@ def populate(  # noqa: C901, PLR0913
         )
         submission_uploaded_date = metadata.submission.submission_date
 
-    submission_diff, donors_diff = db_service.diff(
-        submission_id,
-        metadata,
-        submission_uploaded_date=submission_uploaded_date,
-        ignore_fields=set(ignore_field),
-    )
+    try:
+        changes = db_service.diff(
+            submission_id,
+            metadata,
+            submission_uploaded_date=submission_uploaded_date,
+            ignore_fields=set(ignore_field),
+        )
+    except SubmissionError as e:
+        _abort(e)
 
     # build donor diff and attach Rich tables for console preview in one pass
     diff_tables: list[rich.console.RenderableType] = []
-    for donor_diff in donors_diff.added + donors_diff.updated:
+    for donor_diff in changes.donors.added + changes.donors.updated:
         diff_tables.append(
             _prepare_donor_console_table(donor_diff.changes, donor_diff.pseudonym or "", donor_diff.state)
         )
-    for donor_diff in donors_diff.deleted:
+    for donor_diff in changes.donors.deleted:
         diff_tables.append(rich.text.Text(f"Donor {donor_diff.pseudonym} deleted", style="red"))
 
-    if not submission_diff.has_pending and not donors_diff.has_pending:
-        console_err.print("[green]Database is already up to date with the provided metadata![/green]")
+    if not changes.has_pending:
+        console_err.print(
+            f"[yellow]Case link unresolved: {changes.case_link_error}[/yellow]"
+            if changes.case_link_error is not None
+            else "[green]Database is already up to date with the provided metadata![/green]"
+        )
         return
 
     console.print(
         rich.panel.Panel.fit(
-            rich.console.Group(_prepare_submission_console_table(submission_diff), *diff_tables, fit=True),
+            rich.console.Group(_prepare_submission_console_table(changes), *diff_tables, fit=True),
             title="Pending Changes",
         )
     )
@@ -742,7 +991,12 @@ def populate(  # noqa: C901, PLR0913
         default=False,
         show_default=True,
     ):
-        db_service.commit_changes(submission_id, submission_diff, donors_diff)
+        try:
+            db_service.commit_changes(submission_id, changes)
+        except SubmissionError as e:
+            _abort(e)
+        if changes.case_link is not None:
+            _report_case_link(db_service, submission_id)
         console_err.print("[green]Database populated successfully.[/green]")
 
 
@@ -787,7 +1041,7 @@ class QCReportRow(StrictBaseModel):
 
 
 @submission.command()
-@click.argument("submission_id", type=str)
+@_submission_id_argument
 @click.argument("report_csv_path", metavar="path/to/report.csv", type=grzcli.FILE_R_E)
 @click.option(
     "--qc-workflow-version",
@@ -904,7 +1158,7 @@ def populate_qc(
 
 
 @submission.command()
-@click.argument("submission_id", type=str)
+@_submission_id_argument
 @click.argument("change_str", metavar="CHANGE", type=click.Choice(ChangeRequestEnum.list(), case_sensitive=False))
 @click.option("--data", "data_json", type=str, default=None, help='Inline JSON data (e.g., \'{"k":"v"}\').')
 @click.option(
@@ -987,9 +1241,7 @@ def change_request(  # noqa: PLR0913
             console_err.print(f"  Data: {new_change_request_log.data}")
 
     except SubmissionNotFoundError as e:
-        console_err.print(f"[red]Error: {e}[/red]")
-        console_err.print(f"You might need to add it first: grzctl db submission add {submission_id}")
-        raise click.Abort() from e
+        _abort_missing_submission(e, submission_id)
     except Exception as e:
         console_err.print(f"[red]An unexpected error occurred: {e}[/red]")
         traceback.print_exc()
@@ -1025,9 +1277,7 @@ def _build_attribute_table(submission: Submission, research_consented_now: bool 
         (see :func:`_research_consented_now`), or ``None`` when unavailable.
     :returns: A populated rich table of submission attributes.
     """
-    attribute_table = rich.table.Table(box=None)
-    attribute_table.add_column("Attribute", justify="right")
-    attribute_table.add_column("Value")
+    rows: list[tuple[str, Any]] = []
     for label, attr_name in (
         ("tanG", "tan_g"),
         ("Pseudonym", "pseudonym"),
@@ -1035,6 +1285,7 @@ def _build_attribute_table(submission: Submission, research_consented_now: bool 
         ("Submission Size", "submission_size"),
         ("Submission Type", "submission_type"),
         ("Submitter ID", "submitter_id"),
+        ("Case ID", "case_id"),
         ("Data Node ID", "data_node_id"),
         ("Disease Type", "disease_type"),
         ("Genomic Study Type", "genomic_study_type"),
@@ -1044,21 +1295,15 @@ def _build_attribute_table(submission: Submission, research_consented_now: bool 
         ("Selected For QC", "selected_for_qc"),
         ("Detailed QC Passed", "detailed_qc_passed"),
     ):
-        attr = getattr(submission, attr_name)
-        attribute_table.add_row(
-            rich.text.Text(f"{label}", style="cyan"), rich.text.Text(str(attr)) if attr is not None else _TEXT_MISSING
-        )
+        rows.append((label, getattr(submission, attr_name)))
         if attr_name == "consented":
             # Adjacent row: research consent re-evaluated as of now (recomputed from stored metadata).
-            attribute_table.add_row(
-                rich.text.Text("Research consent (now)", style="cyan"),
-                rich.text.Text(str(research_consented_now)) if research_consented_now is not None else _TEXT_MISSING,
-            )
-    return attribute_table
+            rows.append(("Research consent (now)", research_consented_now))
+    return _attribute_table(rows)
 
 
 @submission.command("show")
-@click.argument("submission_id", type=str)
+@_submission_id_argument
 @output_json
 @click.pass_context
 def show(ctx: click.Context, submission_id: str, output_json: bool):
@@ -1158,22 +1403,27 @@ def _fetch_metadata_json(s3_client: Any, bucket: str, submission_id: str) -> str
         raise
 
 
-# Archival redacts before writing, so a metadata.json re-read from S3 always carries placeholders
-# for these two and is never authoritative about them. Diffing them would only offer to overwrite
-# a real value with a placeholder.
-_BACKFILL_IGNORE_FIELDS = frozenset({"tan_g", "pseudonym"})
-
-
 class _BackfillResult(StrEnum):
     UPDATED = "updated"
     UP_TO_DATE = "up_to_date"
     NOT_FOUND = "not_found"
     WOULD_OVERWRITE = "would_overwrite"
+    # Everything but the case link was written; re-running once the cause is cleared links it.
+    LINK_UNRESOLVED = "link_unresolved"
     ERROR = "error"
     CONSENT_MISMATCH = "consent_mismatch"
 
 
-def _backfill_submission(  # noqa: PLR0911, PLR0913
+# Metadata re-read from S3 is redacted, so tan_g and the pseudonym are restored from the
+# stored row before diffing (see Submission.restore_redacted_fields) rather than ignored
+# outright: that way an unredacted copy is still checked against the database, and a
+# placeholder never becomes a case key. Whatever cannot be restored is ignored per
+# submission. This constant covers only the upload date, which diff() derives from the
+# metadata's submission_date when the database has none.
+_BACKFILL_IGNORE_FIELDS = frozenset({"submission_uploaded_date"})
+
+
+def _backfill_submission(  # noqa: C901, PLR0911, PLR0913
     current_submission: Submission,
     s3_client: Any,
     bucket: str,
@@ -1188,7 +1438,9 @@ def _backfill_submission(  # noqa: PLR0911, PLR0913
     Uses the same :func:`SubmissionDb.diff` / :func:`SubmissionDb.commit_changes` path
     as ``grzctl db submission populate`` so that every derived field (not only
     *submission_size* and *submission_metadata*) is kept consistent, donor records are
-    synchronised, and already-up-to-date submissions are detected without a write.
+    synchronised, the case link is resolved and committed (``"case_id"`` in
+    *ignore_fields* disables that), and already-up-to-date submissions are detected
+    without a write.
 
     When *force* is False, a destructive diff (existing non-NULL field would change)
     is skipped instead of committed, preserving manually-corrected values. The caller
@@ -1214,6 +1466,10 @@ def _backfill_submission(  # noqa: PLR0911, PLR0913
         console_err.print(f"[red]  {submission_id}: failed to parse metadata.json – {exc}[/red]")
         return _BackfillResult.ERROR
 
+    # The archived copy is redacted; the stored row holds the submitter's values.
+    still_redacted = current_submission.restore_redacted_fields(metadata)
+    ignore_fields = set(ignore_fields) | still_redacted
+
     try:
         # Backfill has no authoritative date to offer: the archive does not carry one, and the
         # submitter's declared submission_date is not when the upload finished, which is what this
@@ -1222,7 +1478,7 @@ def _backfill_submission(  # noqa: PLR0911, PLR0913
         # construction and then exclude the field, so backfill never writes it. Passing the row's
         # own value instead would compare a snapshot taken before the run against the row diff()
         # re-reads, and write the stale one.
-        submission_diff, donors_diff = db_service.diff(
+        changes = db_service.diff(
             submission_id,
             metadata,
             submission_uploaded_date=None,
@@ -1232,35 +1488,51 @@ def _backfill_submission(  # noqa: PLR0911, PLR0913
         console_err.print(f"[red]  {submission_id}: diff failed – {exc}[/red]")
         return _BackfillResult.ERROR
 
-    if not submission_diff.has_pending and not donors_diff.has_pending:
+    # An unresolvable case link costs the submission its link and nothing else: the reason is
+    # rarely about this submission, an ambiguous key needs an operator to merge the cases first,
+    # and the rest of the metadata is what the Prüfbericht is built from. A re-run links it once
+    # the cause is cleared.
+    link_unresolved = changes.case_link_error is not None
+    if link_unresolved:
+        console_err.print(f"[yellow]  {submission_id}: case link unresolved – {changes.case_link_error}[/yellow]")
+
+    if not changes.has_pending:
         console_err.print(f"[dim]  {submission_id}: already up to date, skipping.[/dim]")
-        return _BackfillResult.UP_TO_DATE
+        return _BackfillResult.LINK_UNRESOLVED if link_unresolved else _BackfillResult.UP_TO_DATE
 
     # Filling a field that was NULL destroys nothing, so it is always written. Replacing one that
     # already has a value needs saying so: --force permits every such overwrite, --allow-overwrite
     # only the fields it names, and anything else is held back and reported.
-    allowed = {diff.key for diff in submission_diff.pending} if force else allow_overwrite
-    submission_diff, withheld = submission_diff.withhold_destructive(allowed)
+    allowed = {diff.key for diff in changes.fields.pending} if force else allow_overwrite
+    changes.fields, withheld = changes.fields.withhold_destructive(allowed)
     if withheld:
         console_err.print(
             f"[dim]  {submission_id}: not overwriting {', '.join(diff.key for diff in withheld)} "
             f"(use --force for all, or --allow-overwrite for named fields).[/dim]"
         )
-    if not submission_diff.has_pending and not donors_diff.has_pending:
+
+    # The case link is not a column, so --allow-overwrite cannot name it. Replacing one would undo a
+    # deliberate case relink, so an unpermitted change holds the whole submission back.
+    if not force and changes.case_link is not None and changes.case_link.state is DiffState.UPDATED:
+        console_err.print(
+            f"[dim]  {submission_id}: would overwrite the case link (case {changes.case_link.before}), "
+            "skipping (use --force to overwrite).[/dim]"
+        )
+        return _BackfillResult.WOULD_OVERWRITE
+
+    if not changes.has_pending:
         return _BackfillResult.WOULD_OVERWRITE
 
     if dry_run:
         console_err.print(
-            f"[yellow]  [dry-run] {submission_id}: would update fields: {[d.key for d in submission_diff.pending]}[/yellow]"
+            f"[yellow]  [dry-run] {submission_id}: would update: {', '.join(changes.pending_changes)}[/yellow]"
         )
-        return _BackfillResult.UPDATED
+        return _BackfillResult.LINK_UNRESOLVED if link_unresolved else _BackfillResult.UPDATED
 
     try:
-        db_service.commit_changes(submission_id, submission_diff, donors_diff)
-        console_err.print(
-            f"[green]  {submission_id}: updated ({', '.join(d.key for d in submission_diff.pending) or 'no scalar changes'}).[/green]"
-        )
-        return _BackfillResult.UPDATED
+        db_service.commit_changes(submission_id, changes)
+        console_err.print(f"[green]  {submission_id}: updated ({', '.join(changes.pending_changes)}).[/green]")
+        return _BackfillResult.LINK_UNRESOLVED if link_unresolved else _BackfillResult.UPDATED
     except Exception as exc:
         console_err.print(f"[red]  {submission_id}: failed to commit – {exc}[/red]")
         return _BackfillResult.ERROR
@@ -1334,6 +1606,10 @@ def backfill(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
     Both the consented and non-consented archive buckets are always scanned.
     If a submission's metadata.json is found in both, an error is raised.
+
+    The case link is resolved and written like any other missing value, but --allow-overwrite
+    cannot name it, so replacing an existing link holds the whole submission back until
+    --force is passed. Pass --ignore-field case_id to skip case linking altogether.
 
     Candidate selection (mutually exclusive):
 
@@ -1453,6 +1729,7 @@ def backfill(  # noqa: C901, PLR0912, PLR0913, PLR0915
         f"  Up to date: {counts[_BackfillResult.UP_TO_DATE]}\n"
         f"  Not in bucket (split consent): {counts[_BackfillResult.NOT_FOUND]}\n"
         f"  Would overwrite (needs --force): {counts[_BackfillResult.WOULD_OVERWRITE]}\n"
+        f"  Written without a case link: {counts[_BackfillResult.LINK_UNRESOLVED]}\n"
         f"  Errors: {counts[_BackfillResult.ERROR]}[/cyan]"
     )
 

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -296,7 +296,7 @@ def case_modify(ctx: click.Context, case_id: int, key: str, value: str):
     try:
         db_service.modify_case(case_id, key, value)
         console_err.print(f"[green]Updated {key} of case {case_id}[/green]")
-    except (CaseNotFoundError, DuplicatePsnError, ValueError) as e:
+    except (CaseNotFoundError, DuplicateCaseError, DuplicatePsnError, ValueError) as e:
         _abort(e)
 
 
@@ -314,7 +314,7 @@ def case_create(ctx: click.Context, submitter_id: str, local_case_id: str, psn: 
         console_err.print(
             f"[green]Created case {case_obj.id} for submitter '{submitter_id}', local case '{local_case_id}'[/green]"
         )
-    except (DuplicateCaseError, DuplicatePsnError) as e:
+    except (DuplicateCaseError, DuplicatePsnError, ValueError) as e:
         _abort(e)
 
 

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -325,7 +325,8 @@ def case_create(ctx: click.Context, submitter_id: str, local_case_id: str, psn: 
 def case_relink(ctx: click.Context, submission_id: str, case_id: int):
     """Relink a submission to a different case for repair.
 
-    A case may still have at most one initial submission that passed basic QC.
+    A case may still have at most one initial submission that passed basic QC. The case
+    being vacated is left as-is and may become empty.
     """
     db = ctx.obj["db_url"]
     db_service = get_submission_db_instance(db, author=ctx.obj["author"])
@@ -903,7 +904,11 @@ def populate(  # noqa: C901, PLR0912, PLR0913
     confirm: bool,
     ignore_field: tuple[str, ...],
 ):
-    """Populate a submission in the database based on the given metadata.json file."""
+    """Populate a submission in the database based on the given metadata.json file.
+
+    Also resolves and links the submission's case; an unresolved link is shown rather
+    than blocking the rest of the diff.
+    """
     log.debug("Ignored fields for populate: %s", ignore_field)
 
     if submission_date is not None:
@@ -1408,7 +1413,7 @@ class _BackfillResult(StrEnum):
     UP_TO_DATE = "up_to_date"
     NOT_FOUND = "not_found"
     WOULD_OVERWRITE = "would_overwrite"
-    # Everything but the case link was written; re-running once the cause is cleared links it.
+    # The case link could not be resolved for this submission. Re-running once the cause is cleared links it.
     LINK_UNRESOLVED = "link_unresolved"
     ERROR = "error"
     CONSENT_MISMATCH = "consent_mismatch"
@@ -1418,8 +1423,9 @@ class _BackfillResult(StrEnum):
 # stored row before diffing (see Submission.restore_redacted_fields) rather than ignored
 # outright: that way an unredacted copy is still checked against the database, and a
 # placeholder never becomes a case key. Whatever cannot be restored is ignored per
-# submission. This constant covers only the upload date, which diff() derives from the
-# metadata's submission_date when the database has none.
+# submission. This constant covers only the upload date: it is computed above and passed
+# to diff() as an explicit parameter, so the generic field diff must not also read it
+# from metadata.
 _BACKFILL_IGNORE_FIELDS = frozenset({"submission_uploaded_date"})
 
 
@@ -1452,7 +1458,7 @@ def _backfill_submission(  # noqa: C901, PLR0911, PLR0913
     try:
         raw_json = _fetch_metadata_json(s3_client, bucket, submission_id)
     except Exception as exc:
-        console_err.print(f"[red]  {submission_id}: S3 error – {exc}[/red]")
+        console_err.print(f"[red]  {submission_id}: S3 error: {exc}[/red]")
         return _BackfillResult.ERROR
 
     if raw_json is None:
@@ -1463,7 +1469,7 @@ def _backfill_submission(  # noqa: C901, PLR0911, PLR0913
     try:
         metadata = GrzSubmissionMetadata.model_validate_json(raw_json)
     except Exception as exc:
-        console_err.print(f"[red]  {submission_id}: failed to parse metadata.json – {exc}[/red]")
+        console_err.print(f"[red]  {submission_id}: failed to parse metadata.json: {exc}[/red]")
         return _BackfillResult.ERROR
 
     # The archived copy is redacted; the stored row holds the submitter's values.
@@ -1485,7 +1491,7 @@ def _backfill_submission(  # noqa: C901, PLR0911, PLR0913
             ignore_fields=ignore_fields or None,
         )
     except Exception as exc:
-        console_err.print(f"[red]  {submission_id}: diff failed – {exc}[/red]")
+        console_err.print(f"[red]  {submission_id}: diff failed: {exc}[/red]")
         return _BackfillResult.ERROR
 
     # An unresolvable case link costs the submission its link and nothing else: the reason is
@@ -1494,7 +1500,7 @@ def _backfill_submission(  # noqa: C901, PLR0911, PLR0913
     # the cause is cleared.
     link_unresolved = changes.case_link_error is not None
     if link_unresolved:
-        console_err.print(f"[yellow]  {submission_id}: case link unresolved – {changes.case_link_error}[/yellow]")
+        console_err.print(f"[yellow]  {submission_id}: case link unresolved: {changes.case_link_error}[/yellow]")
 
     if not changes.has_pending:
         console_err.print(f"[dim]  {submission_id}: already up to date, skipping.[/dim]")
@@ -1534,7 +1540,7 @@ def _backfill_submission(  # noqa: C901, PLR0911, PLR0913
         console_err.print(f"[green]  {submission_id}: updated ({', '.join(changes.pending_changes)}).[/green]")
         return _BackfillResult.LINK_UNRESOLVED if link_unresolved else _BackfillResult.UPDATED
     except Exception as exc:
-        console_err.print(f"[red]  {submission_id}: failed to commit – {exc}[/red]")
+        console_err.print(f"[red]  {submission_id}: failed to commit: {exc}[/red]")
         return _BackfillResult.ERROR
 
 
@@ -1652,7 +1658,7 @@ def backfill(  # noqa: C901, PLR0912, PLR0913, PLR0915
     else:
         candidates = list(db_service.list_processed_between(start_date.date(), end_date.date()))
         console_err.print(
-            f"[cyan]Date window: {start_date.date()} – {end_date.date()} ({len(candidates)} submission(s)).[/cyan]"
+            f"[cyan]Date window: {start_date.date()} to {end_date.date()} ({len(candidates)} submission(s)).[/cyan]"
         )
 
     counts: Counter[_BackfillResult] = Counter()
@@ -1685,7 +1691,7 @@ def backfill(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
         if len(found_in) > 1:
             console_err.print(
-                f"[red]  {submission.id}: ERROR — metadata.json found in both consented and non_consented archives[/red]"
+                f"[red]  {submission.id}: ERROR: metadata.json found in both consented and non_consented archives[/red]"
             )
             counts[_BackfillResult.ERROR] += 1
             continue
@@ -1729,7 +1735,7 @@ def backfill(  # noqa: C901, PLR0912, PLR0913, PLR0915
         f"  Up to date: {counts[_BackfillResult.UP_TO_DATE]}\n"
         f"  Not in bucket (split consent): {counts[_BackfillResult.NOT_FOUND]}\n"
         f"  Would overwrite (needs --force): {counts[_BackfillResult.WOULD_OVERWRITE]}\n"
-        f"  Written without a case link: {counts[_BackfillResult.LINK_UNRESOLVED]}\n"
+        f"  Case link unresolved: {counts[_BackfillResult.LINK_UNRESOLVED]}\n"
         f"  Errors: {counts[_BackfillResult.ERROR]}[/cyan]"
     )
 

--- a/packages/grzctl/src/grzctl/dbcontext.py
+++ b/packages/grzctl/src/grzctl/dbcontext.py
@@ -10,7 +10,7 @@ from grz_common.exceptions import (
     NetworkError,
     UploadError,
 )
-from grz_db.errors import DuplicateTanGError, SubmissionNotFoundError
+from grz_db.errors import DuplicateInitialSubmissionError, DuplicateTanGError, SubmissionNotFoundError
 from grz_db.models.author import Author
 from grz_db.models.submission import FailureReasonEnum, SubmissionDb, SubmissionStateEnum
 from pydantic import ValidationError
@@ -212,6 +212,7 @@ class DbContext:
             NetworkError: FailureReasonEnum.NETWORK_ERROR,
             UploadError: FailureReasonEnum.UPLOAD_ERROR,
             DuplicateTanGError: FailureReasonEnum.DUPLICATE_TANG,
+            DuplicateInitialSubmissionError: FailureReasonEnum.DUPLICATE_INITIAL,
             IncompleteSubmissionError: FailureReasonEnum.INCOMPLETE_SUBMISSION,
         }
         for exc_class, failure_reason in exception_map.items():

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import boto3
 import pytest
+import sqlalchemy
 from grz_db.models.submission import Submission, SubmissionBase, SubmissionDb
 from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
 from grz_pydantic_models_testing.example_metadata import grzctl as grzctl_metadata
@@ -23,7 +24,7 @@ from moto import mock_aws
 
 BUCKET = "test-backfill-bucket"
 REGION = "us-east-1"
-IGNORE_FIELDS = set(_BACKFILL_IGNORE_FIELDS)
+IGNORE_FIELDS = _BACKFILL_IGNORE_FIELDS
 DIFFERENT_TAN_G = "b" * 64
 DIFFERENT_PSEUDONYM = "different-pseudonym"
 DIFFERENT_DATE = datetime.date(1999, 1, 1)
@@ -66,8 +67,7 @@ def _put_metadata(s3_client: Any, submission_id: str, metadata: GrzSubmissionMet
 def _populate_full_row(db: SubmissionDb, submission_id: str, metadata: GrzSubmissionMetadata) -> Submission:
     """Persist a fully-populated row by running the same diff/commit path the production code uses."""
     db.add_submission(submission_id)
-    submission_diff, donors_diff = db.diff(submission_id, metadata, submission_uploaded_date=None)
-    db.commit_changes(submission_id, submission_diff, donors_diff)
+    db.commit_changes(submission_id, db.diff(submission_id, metadata, submission_uploaded_date=None))
     return db.get_submission(submission_id)
 
 
@@ -260,7 +260,10 @@ def test_backfill_submission_force_applies_destructive_changes(
 def test_backfill_submission_force_does_not_overwrite_ignore_fields(
     db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata, submission_id: str
 ) -> None:
-    """Even with --force, the hard-coded ignore_fields are not overwritten by re-derived metadata."""
+    """An unredacted copy is authoritative, so --force reconciles the database against it.
+
+    Only the upload date stays hard-ignored, since metadata.json does not carry one.
+    """
     current = db.add_submission(submission_id)
     current.submission_uploaded_date = DIFFERENT_DATE
     current.tan_g = DIFFERENT_TAN_G
@@ -285,8 +288,8 @@ def test_backfill_submission_force_does_not_overwrite_ignore_fields(
     assert result == _BackfillResult.UPDATED
     persisted = db.get_submission(submission_id)
     assert persisted.submission_uploaded_date == DIFFERENT_DATE
-    assert persisted.tan_g == DIFFERENT_TAN_G
-    assert persisted.pseudonym == DIFFERENT_PSEUDONYM
+    assert persisted.tan_g == metadata.submission.tan_g
+    assert persisted.pseudonym == metadata.submission.local_case_id
     assert persisted.submission_size == metadata.get_submission_size()
     assert persisted.submission_metadata is not None
     assert persisted.submission_metadata == metadata.to_redacted_dict()
@@ -458,6 +461,206 @@ def test_backfill_submission_allow_overwrite_reports_would_overwrite_when_nothin
 
     assert result == _BackfillResult.WOULD_OVERWRITE
     assert db.get_submission(submission_id).submission_size == 1
+
+
+def test_backfill_never_overwrites_stored_values_with_placeholders(
+    db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata, submission_id: str
+) -> None:
+    """A redacted archive copy is restored from the row first, so the stored values survive."""
+    db.add_submission(submission_id)
+    db.modify_submission(submission_id, "tan_g", DIFFERENT_TAN_G)
+    db.modify_submission(submission_id, "pseudonym", DIFFERENT_PSEUDONYM)
+    current = db.get_submission(submission_id)
+    _put_metadata(s3_client_mock, submission_id, _archived(metadata))
+
+    assert _run_backfill(db, s3_client_mock, current) == _BackfillResult.UPDATED
+
+    persisted = db.get_submission(submission_id)
+    assert persisted.tan_g == DIFFERENT_TAN_G
+    assert persisted.pseudonym == DIFFERENT_PSEUDONYM
+    # and the restored pseudonym is what keyed the case, not the placeholder
+    assert [case.local_case_id for case, _count in db.list_cases()] == [DIFFERENT_PSEUDONYM]
+
+
+def _as_initial(metadata: GrzSubmissionMetadata) -> GrzSubmissionMetadata:
+    raw = json.loads(metadata.model_dump_json(by_alias=True))
+    raw["submission"]["submissionType"] = "initial"
+    return GrzSubmissionMetadata.model_validate(raw)
+
+
+def test_backfill_submission_links_case_by_default(
+    db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata
+) -> None:
+    """Backfill links submissions to cases by default (skip via --ignore-field case_id)."""
+    initial_metadata = _as_initial(metadata)
+    sid = initial_metadata.submission_id
+    db.add_submission(sid)
+    db.commit_changes(sid, db.diff(sid, initial_metadata, submission_uploaded_date=None, ignore_fields={"case_id"}))
+    current = db.get_submission(sid)
+    assert current.case_id is None
+    _put_metadata(s3_client_mock, sid, initial_metadata)
+
+    result = _backfill_submission(
+        current_submission=current,
+        s3_client=s3_client_mock,
+        bucket=BUCKET,
+        db_service=db,
+        dry_run=False,
+        force=False,
+        ignore_fields=IGNORE_FIELDS | {"case_id"},
+    )
+    assert result == _BackfillResult.UP_TO_DATE
+    assert db.get_submission(sid).case_id is None
+
+    result = _backfill_submission(
+        current_submission=db.get_submission(sid),
+        s3_client=s3_client_mock,
+        bucket=BUCKET,
+        db_service=db,
+        dry_run=False,
+        force=False,
+        ignore_fields=IGNORE_FIELDS,
+    )
+    assert result == _BackfillResult.UPDATED
+    linked = db.get_submission(sid)
+    assert linked.case_id is not None
+    # this copy is unredacted, so it is authoritative and fills the NULL pseudonym too
+    assert linked.pseudonym == initial_metadata.submission.local_case_id
+
+
+def _archived(metadata: GrzSubmissionMetadata) -> GrzSubmissionMetadata:
+    """The copy archival uploads, in its older spelling: tanG zeroed and localCaseId emptied.
+
+    Mirrors ``S3BotoUploadWorker.archive``, so the case key in an archive bucket is a
+    placeholder shared by every submission of that submitter.
+    """
+    raw = metadata.to_redacted_dict()
+    raw["submission"]["submissionType"] = "initial"
+    # the older archival spelling, which is still what most objects in the archive carry
+    raw["submission"]["localCaseId"] = ""
+    return GrzSubmissionMetadata.model_validate(raw)
+
+
+def _run_backfill(db: SubmissionDb, s3_client: Any, current: Submission) -> _BackfillResult:
+    return _backfill_submission(
+        current_submission=current,
+        s3_client=s3_client,
+        bucket=BUCKET,
+        db_service=db,
+        dry_run=False,
+        force=False,
+        ignore_fields=IGNORE_FIELDS,
+    )
+
+
+def test_backfill_keys_cases_on_the_stored_pseudonym(
+    db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata
+) -> None:
+    """Two patients whose archived metadata both read localCaseId "" must not share a case."""
+    archived = _archived(metadata)
+    submitter = metadata.submission.submitter_id
+    rows = []
+    for sid, tan_g, pseudonym in (
+        (f"{submitter}_2024-01-01_aaaaaaa1", "a" * 64, "patient-A"),
+        (f"{submitter}_2024-01-02_aaaaaaa2", "b" * 64, "patient-B"),
+    ):
+        db.add_submission(sid)
+        db.modify_submission(sid, "tan_g", tan_g)
+        db.modify_submission(sid, "pseudonym", pseudonym)
+        db.modify_submission(sid, "submission_type", "initial")
+        _put_metadata(s3_client_mock, sid, archived)
+        rows.append(db.get_submission(sid))
+
+    for row in rows:
+        assert _run_backfill(db, s3_client_mock, row) == _BackfillResult.UPDATED
+
+    assert {(case.submitter_id, case.local_case_id) for case, _count in db.list_cases()} == {
+        (submitter, "patient-A"),
+        (submitter, "patient-B"),
+    }
+    linked = {row.id: db.get_submission(row.id).case_id for row in rows}
+    assert None not in linked.values()
+    assert len(set(linked.values())) == 2
+
+
+def test_backfill_without_a_stored_pseudonym_skips_the_case_link(
+    db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata, submission_id: str
+) -> None:
+    """Nothing to restore from, so the placeholders are ignored rather than written or keyed on."""
+    current = db.add_submission(submission_id)
+    _put_metadata(s3_client_mock, submission_id, _archived(metadata))
+
+    assert _run_backfill(db, s3_client_mock, current) == _BackfillResult.UPDATED
+
+    persisted = db.get_submission(submission_id)
+    assert persisted.submission_size == metadata.get_submission_size()
+    assert persisted.case_id is None
+    assert persisted.pseudonym is None
+    assert persisted.tan_g is None
+    assert db.list_cases() == []
+
+
+def _second_case_for_the_same_key(db: SubmissionDb, submitter_id: str, local_case_id: str) -> None:
+    """Give one key a second case, which ``ux_cases_submitter_local_case`` forbids.
+
+    Only reachable by writing around the application, which is exactly the state backfill's
+    unresolvable-link handling exists to survive.
+    """
+    with db.transaction() as session:
+        session.execute(sqlalchemy.text("DROP INDEX ux_cases_submitter_local_case"))
+        session.execute(
+            sqlalchemy.text("INSERT INTO cases (submitter_id, local_case_id) VALUES (:submitter, :local_case)"),
+            {"submitter": submitter_id, "local_case": local_case_id},
+        )
+        session.commit()
+
+
+def test_backfill_writes_everything_but_the_link_when_the_case_key_is_ambiguous(
+    db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata
+) -> None:
+    """An ambiguous key needs an operator to merge the cases; the submission still gets recorded.
+
+    Discarding the change set would leave submission_size, submission_metadata and the donors
+    unwritten, which are what the Prüfbericht is built from.
+    """
+    submitter = metadata.submission.submitter_id
+    db.create_case(submitter, "patient-A")
+    _second_case_for_the_same_key(db, submitter, "patient-A")
+
+    sid = f"{submitter}_2024-01-01_aaaaaaa1"
+    db.add_submission(sid)
+    db.modify_submission(sid, "pseudonym", "patient-A")
+    current = db.get_submission(sid)
+    _put_metadata(s3_client_mock, sid, _archived(metadata))
+
+    assert _run_backfill(db, s3_client_mock, current) == _BackfillResult.LINK_UNRESOLVED
+
+    persisted = db.get_submission(sid)
+    assert persisted.case_id is None
+    assert persisted.submission_size == metadata.get_submission_size()
+    assert persisted.submission_metadata is not None
+    assert db.get_donors(sid)
+
+
+def test_backfill_links_once_the_ambiguity_is_gone(
+    db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata
+) -> None:
+    """Re-running after an operator merges the duplicates completes the link."""
+    submitter = metadata.submission.submitter_id
+    kept = db.create_case(submitter, "patient-A")
+    _second_case_for_the_same_key(db, submitter, "patient-A")
+    spare = next(case for case, _n in db.list_cases() if case.id != kept.id)
+
+    sid = f"{submitter}_2024-01-01_aaaaaaa1"
+    db.add_submission(sid)
+    db.modify_submission(sid, "pseudonym", "patient-A")
+    _put_metadata(s3_client_mock, sid, _archived(metadata))
+    assert _run_backfill(db, s3_client_mock, db.get_submission(sid)) == _BackfillResult.LINK_UNRESOLVED
+
+    db.delete_case(spare.id)
+
+    assert _run_backfill(db, s3_client_mock, db.get_submission(sid)) == _BackfillResult.UPDATED
+    assert db.get_submission(sid).case_id is not None
 
 
 def test_backfill_ignores_only_fields_that_exist() -> None:

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -16,15 +16,14 @@ from typing import Any
 import boto3
 import pytest
 import sqlalchemy
-from grz_db.models.submission import Submission, SubmissionBase, SubmissionDb
+from grz_db.models.submission import Submission, SubmissionDb
 from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
 from grz_pydantic_models_testing.example_metadata import grzctl as grzctl_metadata
-from grzctl.commands.db.cli import _BACKFILL_IGNORE_FIELDS, _backfill_submission, _BackfillResult
+from grzctl.commands.db.cli import _backfill_submission, _BackfillResult
 from moto import mock_aws
 
 BUCKET = "test-backfill-bucket"
 REGION = "us-east-1"
-IGNORE_FIELDS = _BACKFILL_IGNORE_FIELDS
 DIFFERENT_TAN_G = "b" * 64
 DIFFERENT_PSEUDONYM = "different-pseudonym"
 DIFFERENT_DATE = datetime.date(1999, 1, 1)
@@ -87,7 +86,7 @@ def test_backfill_submission_happy_path(
         db_service=db,
         dry_run=False,
         force=False,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
     assert result == _BackfillResult.UPDATED
@@ -109,7 +108,7 @@ def test_backfill_submission_returns_not_found_when_metadata_missing_in_s3(
         db_service=db,
         dry_run=False,
         force=False,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
     assert result == _BackfillResult.NOT_FOUND
@@ -136,7 +135,7 @@ def test_backfill_submission_records_error_on_invalid_json(
         db_service=db,
         dry_run=False,
         force=False,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
     assert result == _BackfillResult.ERROR
@@ -159,7 +158,7 @@ def test_backfill_submission_returns_up_to_date_when_no_pending_diff(
         db_service=db,
         dry_run=False,
         force=True,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
     assert result == _BackfillResult.UP_TO_DATE
@@ -187,7 +186,7 @@ def test_backfill_submission_holds_back_a_destructive_change_without_force(
         db_service=db,
         dry_run=False,
         force=False,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
     assert result == _BackfillResult.UPDATED
@@ -211,7 +210,7 @@ def test_backfill_submission_returns_would_overwrite_when_only_overwrites_are_pe
         db_service=db,
         dry_run=False,
         force=True,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
     current = db.get_submission(submission_id)
     current.submission_size = 1
@@ -224,7 +223,7 @@ def test_backfill_submission_returns_would_overwrite_when_only_overwrites_are_pe
         db_service=db,
         dry_run=False,
         force=False,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
     assert result == _BackfillResult.WOULD_OVERWRITE
@@ -248,7 +247,7 @@ def test_backfill_submission_force_applies_destructive_changes(
         db_service=db,
         dry_run=False,
         force=True,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
     assert result == _BackfillResult.UPDATED
@@ -282,7 +281,7 @@ def test_backfill_force_reconciles_against_an_unredacted_copy(
         db_service=db,
         dry_run=False,
         force=True,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
     assert result == _BackfillResult.UPDATED
@@ -318,7 +317,7 @@ def test_backfill_leaves_a_missing_upload_date_alone(
         db_service=db,
         dry_run=False,
         force=True,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
     assert result == _BackfillResult.UPDATED
@@ -384,7 +383,7 @@ def test_backfill_submission_reads_a_consent_datetime_without_a_timezone(
         db_service=db,
         dry_run=False,
         force=False,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
     assert result == _BackfillResult.UPDATED
@@ -415,7 +414,7 @@ def test_backfill_submission_allow_overwrite_writes_only_the_named_field(
         db_service=db,
         dry_run=False,
         force=False,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
         allow_overwrite=frozenset({"submission_metadata"}),
     )
 
@@ -441,7 +440,7 @@ def test_backfill_submission_allow_overwrite_reports_would_overwrite_when_nothin
         db_service=db,
         dry_run=False,
         force=True,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
     current = db.get_submission(submission_id)
@@ -455,7 +454,7 @@ def test_backfill_submission_allow_overwrite_reports_would_overwrite_when_nothin
         db_service=db,
         dry_run=False,
         force=False,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
         allow_overwrite=frozenset({"submission_metadata"}),
     )
 
@@ -507,7 +506,7 @@ def test_backfill_submission_links_case_by_default(
         db_service=db,
         dry_run=False,
         force=False,
-        ignore_fields=IGNORE_FIELDS | {"case_id"},
+        ignore_fields={"case_id"},
     )
     assert result == _BackfillResult.UP_TO_DATE
     assert db.get_submission(sid).case_id is None
@@ -519,7 +518,7 @@ def test_backfill_submission_links_case_by_default(
         db_service=db,
         dry_run=False,
         force=False,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
     assert result == _BackfillResult.UPDATED
     linked = db.get_submission(sid)
@@ -549,7 +548,7 @@ def _run_backfill(db: SubmissionDb, s3_client: Any, current: Submission) -> _Bac
         db_service=db,
         dry_run=False,
         force=False,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
 
@@ -662,13 +661,3 @@ def test_backfill_links_once_the_ambiguity_is_gone(
 
     assert _run_backfill(db, s3_client_mock, db.get_submission(sid)) == _BackfillResult.UPDATED
     assert db.get_submission(sid).case_id is not None
-
-
-def test_backfill_ignores_only_fields_that_exist() -> None:
-    """Every name in ``_BACKFILL_IGNORE_FIELDS`` must be an actual Submission column.
-
-    A name that matches no column silently ignores nothing (set difference against a
-    non-member is a no-op), so a typo here would only surface once it let backfill overwrite
-    a field it was meant to skip; this asserts it directly instead.
-    """
-    assert _BACKFILL_IGNORE_FIELDS <= SubmissionBase.model_fields.keys()

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -55,7 +55,7 @@ def s3_client_mock() -> Iterator[Any]:
 def _put_metadata(s3_client: Any, submission_id: str, metadata: GrzSubmissionMetadata) -> None:
     """Write *metadata* unredacted, unlike archival, which redacts first.
 
-    No test here covers the redacted shape backfill actually reads from the archive.
+    For the redacted shape backfill actually reads from the archive, use ``_archived`` instead.
     """
     s3_client.put_object(
         Bucket=BUCKET,
@@ -257,7 +257,7 @@ def test_backfill_submission_force_applies_destructive_changes(
     assert persisted.submission_metadata == metadata.to_redacted_dict()
 
 
-def test_backfill_submission_force_does_not_overwrite_ignore_fields(
+def test_backfill_force_reconciles_against_an_unredacted_copy(
     db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata, submission_id: str
 ) -> None:
     """An unredacted copy is authoritative, so --force reconciles the database against it.

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -1,4 +1,4 @@
-# Backfill unit tests — see .vbw-planning/phases/02-implement-grzctl-db-backfill-command/02-02-PLAN.md
+# Backfill unit tests, see .vbw-planning/phases/02-implement-grzctl-db-backfill-command/02-02-PLAN.md
 """Unit tests for `_backfill_submission`.
 
 The tests target `_backfill_submission` directly with a real SubmissionDb on every supported
@@ -604,7 +604,8 @@ def _second_case_for_the_same_key(db: SubmissionDb, submitter_id: str, local_cas
     """Give one key a second case, which ``ux_cases_submitter_local_case`` forbids.
 
     Only reachable by writing around the application, which is exactly the state backfill's
-    unresolvable-link handling exists to survive.
+    unresolvable-link handling exists to survive: the index is dropped first so the row can
+    be inserted at all.
     """
     with db.transaction() as session:
         session.execute(sqlalchemy.text("DROP INDEX ux_cases_submitter_local_case"))
@@ -645,7 +646,7 @@ def test_backfill_writes_everything_but_the_link_when_the_case_key_is_ambiguous(
 def test_backfill_links_once_the_ambiguity_is_gone(
     db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata
 ) -> None:
-    """Re-running after an operator merges the duplicates completes the link."""
+    """Re-running after an operator deletes the spurious duplicate case completes the link."""
     submitter = metadata.submission.submitter_id
     kept = db.create_case(submitter, "patient-A")
     _second_case_for_the_same_key(db, submitter, "patient-A")

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -261,7 +261,7 @@ def test_backfill_force_reconciles_against_an_unredacted_copy(
 ) -> None:
     """An unredacted copy is authoritative, so --force reconciles the database against it.
 
-    Only the upload date stays hard-ignored, since metadata.json does not carry one.
+    The upload date is the exception: metadata.json does not carry one, so diff() excludes it.
     """
     current = db.add_submission(submission_id)
     current.submission_uploaded_date = DIFFERENT_DATE
@@ -351,7 +351,7 @@ def test_backfill_does_not_write_an_upload_date_from_a_stale_snapshot(
         db_service=db,
         dry_run=False,
         force=True,
-        ignore_fields=IGNORE_FIELDS,
+        ignore_fields=set(),
     )
 
     assert result == _BackfillResult.UPDATED

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -1161,7 +1161,7 @@ def test_template_with_only_date_filled_in_still_fails(migrated_database_config_
 
 
 def test_change_request_template_for_other_change_types_includes_audit_fields():
-    """Audit fields are universal — every change type prints the same scaffold (with type-specific guidance)."""
+    """Audit fields are universal: every change type prints the same scaffold (with type-specific guidance)."""
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
     result = runner.invoke(cli, ["change-request-template", "Modify"])
@@ -1177,14 +1177,14 @@ def test_change_request_validate_accepts_valid_input_without_config(tmp_path: Pa
     data_file.write_text(yaml.safe_dump(_DELETE_CHANGE_REQUEST_DATA, allow_unicode=True))
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
-    # Note: no `db --config-file ...` — the command must work standalone.
+    # Note: no `db --config-file ...`; the command must work standalone.
     result = runner.invoke(cli, ["change-request-validate", "Delete", "--data-file", str(data_file)])
     assert result.exit_code == 0, result.stderr
     assert "valid" in result.stderr.lower()
 
 
 def test_change_request_validate_rejects_unedited_template(tmp_path: Path):
-    """Saving the template and validating it unchanged must fail — the safety net still applies offline."""
+    """Saving the template and validating it unchanged must fail: the safety net still applies offline."""
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
     template = runner.invoke(cli, ["change-request-template", "Delete"]).stdout
@@ -1316,7 +1316,7 @@ def test_change_request_dry_run_validates_before_db_check(migrated_database_conf
 
 
 def test_change_request_modify_requires_audit_fields_too(migrated_database_config_path: Path, tmp_path: Path):
-    """Audit fields are universal — Modify also requires them via --data/--data-file."""
+    """Audit fields are universal: Modify also requires them via --data/--data-file."""
     args_common = ["--config", migrated_database_config_path, "db"]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -742,6 +742,7 @@ def test_submission_show_json(migrated_database_config_path: Path, test_metadata
         "submission_type": metadata.submission.submission_type,
         "submission_metadata": metadata.to_redacted_dict(),
         "submitter_id": metadata.submission.submitter_id,
+        "case_id": None,  # the example is a test submission, which is never case-tracked
         "data_node_id": metadata.submission.genomic_data_center_id,
         "coverage_type": metadata.submission.coverage_type,
         "disease_type": metadata.submission.disease_type,
@@ -1688,22 +1689,23 @@ def test_submission_show_json_includes_failure_reason(migrated_database_config_p
 def test_modify_offers_exactly_the_keys_it_accepts():
     """A key the command lists must be one it can honour.
 
-    The choices and the epilog were built from two different field sets, so `modify` offered
-    `id` and then died on a traceback when it was chosen.
+    These were built from two different field sets, so `modify` offered `case_id` and `id` and
+    then died on a traceback when either was chosen.
     """
     from grzctl.commands.db.cli import _MODIFIABLE_SUBMISSION_KEYS
 
     assert set(_MODIFIABLE_SUBMISSION_KEYS) == SubmissionBase.model_fields.keys() - SubmissionBase.immutable_fields
 
 
-def test_modify_refuses_an_unofferable_key_with_a_usage_error(migrated_database_config_path):
+@pytest.mark.parametrize("key", ["case_id", "id"])
+def test_modify_refuses_an_unofferable_key_with_a_usage_error(migrated_database_config_path, key: str):
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
     args_common = ["--config", str(migrated_database_config_path), "db"]
     submission_id = "111111111_2025-01-01_0000000a"
     assert runner.invoke(cli, [*args_common, "submission", "add", submission_id]).exit_code == 0
 
-    result = runner.invoke(cli, [*args_common, "submission", "modify", submission_id, "id", "1"])
+    result = runner.invoke(cli, [*args_common, "submission", "modify", submission_id, key, "1"])
 
     assert result.exit_code == 2, result.output
     assert "An unexpected error occurred" not in result.output

--- a/packages/grzctl/tests/cli/test_db_case.py
+++ b/packages/grzctl/tests/cli/test_db_case.py
@@ -339,8 +339,9 @@ def test_case_json_survives_a_coloured_environment(migrated_database_config_path
 
     rich decides on ANSI colour when a Console is built, which for the CLI modules happens at
     import, and it honours ``FORCE_COLOR`` even when stdout is a pipe. This runs out of process
-    because the test suite pins ``TTY_COMPATIBLE=0`` at import for every in-process test, which
-    is exactly what hid this the first time: the colourised output only ever reached users.
+    because the test suite pins ``TTY_COMPATIBLE=0`` at import for every in-process test: an
+    in-process run would inherit that pin and never see escapes a real user's shell can
+    produce.
     """
     cli = grzctl.cli.build_cli()
     assert _create_case(cli, migrated_database_config_path, "111111111", "case-colour").exit_code == 0

--- a/packages/grzctl/tests/cli/test_db_case.py
+++ b/packages/grzctl/tests/cli/test_db_case.py
@@ -93,6 +93,24 @@ def test_case_create_duplicate_psn_rejected(migrated_database_config_path: Path)
     assert len(_list_cases(cli, migrated_database_config_path)) == 1
 
 
+def test_case_create_invalid_submitter_id_rejected(migrated_database_config_path: Path):
+    """A malformed submitter ID fails ``Case``'s pydantic validation, not an uncaught crash.
+
+    ``submitter_id`` is pattern-constrained (``^[0-9]{9}$``) and ``Case`` validates on assignment,
+    so this is a ``ValidationError`` (a ``ValueError`` subclass), distinct from the db-level
+    ``DuplicateCaseError``/``DuplicatePsnError`` this command already catches.
+    """
+    cli = grzctl.cli.build_cli()
+
+    result = _create_case(cli, migrated_database_config_path, "not-a-submitter-id", "case-X")
+
+    assert result.exit_code != 0
+    # a caught, reported error, not an exception that escaped to the runner uncaught
+    assert "Error:" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert len(_list_cases(cli, migrated_database_config_path)) == 0
+
+
 def test_case_list_and_show_json(migrated_database_config_path: Path):
     """``case list --json`` and ``case show --json`` expose the expected fields."""
     cli = grzctl.cli.build_cli()
@@ -157,6 +175,40 @@ def test_case_modify_psn(migrated_database_config_path: Path):
         cli, migrated_database_config_path, "case", "modify", str(case_id), "not_a_real_key", "value"
     )
     assert result_modify_bad_key.exit_code != 0
+
+
+def test_case_modify_duplicate_pair_rejected(migrated_database_config_path: Path):
+    """Modifying ``local_case_id`` into another case's ``(submitter_id, local_case_id)`` pair is
+    rejected cleanly, not an uncaught crash.
+
+    The pair is enforced by the partial unique index ``ux_cases_submitter_local_case``, so this
+    raises ``DuplicateCaseError``, distinct from the ``CaseNotFoundError``/``DuplicatePsnError``/
+    ``ValueError`` this command already catches.
+    """
+    cli = grzctl.cli.build_cli()
+
+    result_first = _create_case(cli, migrated_database_config_path, "123456789", "case-A")
+    assert result_first.exit_code == 0, result_first.stderr
+    result_second = _create_case(cli, migrated_database_config_path, "123456789", "case-B")
+    assert result_second.exit_code == 0, result_second.stderr
+    second_case_id = next(
+        c["id"] for c in _list_cases(cli, migrated_database_config_path) if c["local_case_id"] == "case-B"
+    )
+
+    result_modify = _invoke(
+        cli, migrated_database_config_path, "case", "modify", str(second_case_id), "local_case_id", "case-A"
+    )
+
+    assert result_modify.exit_code != 0
+    # a caught, reported error, not an exception that escaped to the runner uncaught
+    assert "Error:" in result_modify.stderr
+    assert "Traceback" not in result_modify.stderr
+
+    # the change must not have gone through
+    unchanged = next(
+        c["local_case_id"] for c in _list_cases(cli, migrated_database_config_path) if c["id"] == second_case_id
+    )
+    assert unchanged == "case-B"
 
 
 def test_case_show_unknown_exits_nonzero(migrated_database_config_path: Path):

--- a/packages/grzctl/tests/cli/test_db_case.py
+++ b/packages/grzctl/tests/cli/test_db_case.py
@@ -1,0 +1,316 @@
+"""
+Tests for the ``grzctl db case`` subcommand group.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import click.testing
+import grzctl.cli
+import pytest
+from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
+
+
+def _invoke(cli, config_path: Path, *args: str, input: str | None = None) -> click.testing.Result:
+    """Invoke ``grzctl db ... `` with the given config file and arguments."""
+    runner = click.testing.CliRunner()
+    return runner.invoke(cli, ["--config", str(config_path), "db", *args], input=input)
+
+
+def _create_case(
+    cli, config_path: Path, submitter_id: str, local_case_id: str, psn: str | None = None
+) -> click.testing.Result:
+    args = ["case", "create", submitter_id, local_case_id]
+    if psn is not None:
+        args += ["--psn", psn]
+    return _invoke(cli, config_path, *args)
+
+
+def _list_cases(cli, config_path: Path) -> list[dict]:
+    result = _invoke(cli, config_path, "case", "list", "--json")
+    assert result.exit_code == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _as_initial_submission(test_metadata_path: Path, tmp_path: Path) -> Path:
+    """Write a copy of *test_metadata_path* typed ``initial``, so populating it creates a case."""
+    raw = json.loads(test_metadata_path.read_text())
+    raw["submission"]["submissionType"] = "initial"
+    metadata_path = tmp_path / "initial.metadata.json"
+    metadata_path.write_text(json.dumps(raw))
+    return metadata_path
+
+
+def _add_and_populate(cli, config_path: Path, test_metadata_path: Path) -> str:
+    """Add + populate the example submission (test-type, so no case is created). Returns the submission id."""
+    submission_id = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text()).submission_id
+
+    result_add = _invoke(cli, config_path, "submission", "add", submission_id)
+    assert result_add.exit_code == 0, result_add.stderr
+
+    result_populate = _invoke(
+        cli, config_path, "submission", "populate", submission_id, str(test_metadata_path), "--no-confirm"
+    )
+    assert result_populate.exit_code == 0, result_populate.stderr
+
+    return submission_id
+
+
+def test_case_create_duplicate_pair_rejected(migrated_database_config_path: Path):
+    """A submitter's local case ID identifies one patient, so it identifies one case."""
+    cli = grzctl.cli.build_cli()
+
+    result_create = _create_case(cli, migrated_database_config_path, "123456789", "case-A")
+    assert result_create.exit_code == 0, result_create.stderr
+
+    # the created case id should be reported (message goes to stderr)
+    cases = _list_cases(cli, migrated_database_config_path)
+    assert len(cases) == 1
+    assert str(cases[0]["id"]) in result_create.stderr
+
+    result_duplicate = _create_case(cli, migrated_database_config_path, "123456789", "case-A")
+
+    assert result_duplicate.exit_code != 0
+    assert "already exists" in result_duplicate.stderr
+    assert len(_list_cases(cli, migrated_database_config_path)) == 1
+
+
+def test_case_create_duplicate_psn_rejected(migrated_database_config_path: Path):
+    """Uniqueness is enforced on --psn: reusing a psn makes the second create fail."""
+    cli = grzctl.cli.build_cli()
+
+    result_first = _create_case(cli, migrated_database_config_path, "123456789", "case-A", psn="RKI-1")
+    assert result_first.exit_code == 0, result_first.stderr
+
+    # a different (submitter_id, local_case_id) but the same psn must fail
+    result_second = _create_case(cli, migrated_database_config_path, "987654321", "case-B", psn="RKI-1")
+    assert result_second.exit_code != 0
+
+    # only the first case was created
+    assert len(_list_cases(cli, migrated_database_config_path)) == 1
+
+
+def test_case_list_and_show_json(migrated_database_config_path: Path):
+    """``case list --json`` and ``case show --json`` expose the expected fields."""
+    cli = grzctl.cli.build_cli()
+
+    result_create = _create_case(cli, migrated_database_config_path, "123456789", "case-B")
+    assert result_create.exit_code == 0, result_create.stderr
+
+    cases = _list_cases(cli, migrated_database_config_path)
+    assert len(cases) == 1
+    case = cases[0]
+    for key in ("id", "psn", "submitter_id", "local_case_id", "submission_count"):
+        assert key in case
+    assert case["submitter_id"] == "123456789"
+    assert case["local_case_id"] == "case-B"
+    assert case["psn"] is None
+    assert case["submission_count"] == 0
+
+    case_id = case["id"]
+    result_show = _invoke(cli, migrated_database_config_path, "case", "show", str(case_id), "--json")
+    assert result_show.exit_code == 0, result_show.stderr
+    shown = json.loads(result_show.stdout)
+    for key in ("id", "psn", "submitter_id", "local_case_id", "submissions"):
+        assert key in shown
+    assert shown["id"] == case_id
+    assert shown["submitter_id"] == "123456789"
+    assert shown["local_case_id"] == "case-B"
+    assert shown["psn"] is None
+    assert shown["submissions"] == []
+
+
+def test_case_modify_psn(migrated_database_config_path: Path):
+    """``case modify <id> psn`` updates the PSN; duplicates and unknown keys are rejected."""
+    cli = grzctl.cli.build_cli()
+
+    result_create = _create_case(cli, migrated_database_config_path, "123456789", "case-C")
+    assert result_create.exit_code == 0, result_create.stderr
+    case_id = _list_cases(cli, migrated_database_config_path)[0]["id"]
+
+    result_modify = _invoke(cli, migrated_database_config_path, "case", "modify", str(case_id), "psn", "RKI-1")
+    assert result_modify.exit_code == 0, result_modify.stderr
+
+    result_show = _invoke(cli, migrated_database_config_path, "case", "show", str(case_id), "--json")
+    assert result_show.exit_code == 0, result_show.stderr
+    assert json.loads(result_show.stdout)["psn"] == "RKI-1"
+
+    # submitter_id is mutable (only ``id`` is immutable)
+    result_modify_submitter = _invoke(
+        cli, migrated_database_config_path, "case", "modify", str(case_id), "submitter_id", "999999999"
+    )
+    assert result_modify_submitter.exit_code == 0, result_modify_submitter.stderr
+    result_show_submitter = _invoke(cli, migrated_database_config_path, "case", "show", str(case_id), "--json")
+    assert json.loads(result_show_submitter.stdout)["submitter_id"] == "999999999"
+
+    # modifying psn to a value already used by another case is rejected
+    result_other = _create_case(cli, migrated_database_config_path, "123456789", "case-D", psn="RKI-2")
+    assert result_other.exit_code == 0, result_other.stderr
+    result_modify_dup = _invoke(cli, migrated_database_config_path, "case", "modify", str(case_id), "psn", "RKI-2")
+    assert result_modify_dup.exit_code != 0
+
+    # an unknown modify KEY is rejected by the click Choice
+    result_modify_bad_key = _invoke(
+        cli, migrated_database_config_path, "case", "modify", str(case_id), "not_a_real_key", "value"
+    )
+    assert result_modify_bad_key.exit_code != 0
+
+
+def test_case_show_unknown_exits_nonzero(migrated_database_config_path: Path):
+    """Showing a nonexistent case id exits non-zero."""
+    cli = grzctl.cli.build_cli()
+    result = _invoke(cli, migrated_database_config_path, "case", "show", "999999")
+    assert result.exit_code != 0
+
+
+def test_case_delete_empty(migrated_database_config_path: Path):
+    """An empty case can be deleted, after which it can no longer be shown."""
+    cli = grzctl.cli.build_cli()
+
+    result_create = _create_case(cli, migrated_database_config_path, "123456789", "case-D")
+    assert result_create.exit_code == 0, result_create.stderr
+    case_id = _list_cases(cli, migrated_database_config_path)[0]["id"]
+
+    result_delete = _invoke(cli, migrated_database_config_path, "case", "delete", str(case_id))
+    assert result_delete.exit_code == 0, result_delete.stderr
+
+    result_show = _invoke(cli, migrated_database_config_path, "case", "show", str(case_id))
+    assert result_show.exit_code != 0
+
+
+def test_populate_creates_no_case_for_test_submission(migrated_database_config_path: Path, test_metadata_path: Path):
+    """Test submissions are never case-tracked: populating one leaves the case table empty."""
+    cli = grzctl.cli.build_cli()
+
+    _add_and_populate(cli, migrated_database_config_path, test_metadata_path)
+
+    assert _list_cases(cli, migrated_database_config_path) == []
+
+
+def test_case_delete_refuses_when_linked(migrated_database_config_path: Path):
+    """Deleting a case that still has linked submissions is refused."""
+    cli = grzctl.cli.build_cli()
+
+    submission_id = "123456789_2025-01-01_0000000a"
+    result_add = _invoke(cli, migrated_database_config_path, "submission", "add", submission_id)
+    assert result_add.exit_code == 0, result_add.stderr
+    # a case only takes a submission whose type is known and is not a test submission
+    result_type = _invoke(
+        cli, migrated_database_config_path, "submission", "modify", submission_id, "submission_type", "initial"
+    )
+    assert result_type.exit_code == 0, result_type.stderr
+
+    # a submission can be linked to a case created by hand, not only one populate resolved
+    result_create = _create_case(cli, migrated_database_config_path, "123456789", "delete-target")
+    assert result_create.exit_code == 0, result_create.stderr
+    linked_case = _list_cases(cli, migrated_database_config_path)[0]
+    result_relink = _invoke(cli, migrated_database_config_path, "case", "relink", submission_id, str(linked_case["id"]))
+    assert result_relink.exit_code == 0, result_relink.stderr
+
+    result_delete = _invoke(cli, migrated_database_config_path, "case", "delete", str(linked_case["id"]))
+    assert result_delete.exit_code != 0
+
+
+def test_case_relink(migrated_database_config_path: Path):
+    """A submission can be relinked to a different case."""
+    cli = grzctl.cli.build_cli()
+
+    submission_id = "123456789_2025-01-01_0000000a"
+    result_add = _invoke(cli, migrated_database_config_path, "submission", "add", submission_id)
+    assert result_add.exit_code == 0, result_add.stderr
+    # a case only takes a submission whose type is known and is not a test submission
+    result_type = _invoke(
+        cli, migrated_database_config_path, "submission", "modify", submission_id, "submission_type", "initial"
+    )
+    assert result_type.exit_code == 0, result_type.stderr
+
+    result_first = _create_case(cli, migrated_database_config_path, "123456789", "first-case")
+    assert result_first.exit_code == 0, result_first.stderr
+    original_case_id = _list_cases(cli, migrated_database_config_path)[0]["id"]
+    result_link = _invoke(cli, migrated_database_config_path, "case", "relink", submission_id, str(original_case_id))
+    assert result_link.exit_code == 0, result_link.stderr
+
+    # create a second, empty case to relink the submission into
+    result_create = _create_case(cli, migrated_database_config_path, "123456789", "relink-target")
+    assert result_create.exit_code == 0, result_create.stderr
+    new_case_id = next(c["id"] for c in _list_cases(cli, migrated_database_config_path) if c["id"] != original_case_id)
+
+    result_relink = _invoke(cli, migrated_database_config_path, "case", "relink", submission_id, str(new_case_id))
+    assert result_relink.exit_code == 0, result_relink.stderr
+
+    # the submission now shows up under the new case
+    result_show = _invoke(cli, migrated_database_config_path, "case", "show", str(new_case_id), "--json")
+    assert result_show.exit_code == 0, result_show.stderr
+    shown = json.loads(result_show.stdout)
+    assert submission_id in {s["id"] for s in shown["submissions"]}
+    # basic QC state is what tells the case's QC-passed initial submission apart from any
+    # duplicate initial submissions of the same case, so `case show` must carry it
+    assert all("basic_qc_passed" in s for s in shown["submissions"])
+
+
+def test_populate_declined_confirmation_creates_no_case(
+    migrated_database_config_path: Path, test_metadata_path: Path, tmp_path: Path
+):
+    """Answering 'no' at the populate confirmation must leave the database unchanged, cases included.
+
+    The metadata is retyped ``initial`` first: the shipped example is a test submission, which is
+    never case-tracked, so against it the assertion would hold whatever the answer was.
+    """
+    cli = grzctl.cli.build_cli()
+    metadata_path = _as_initial_submission(test_metadata_path, tmp_path)
+    submission_id = GrzSubmissionMetadata.model_validate_json(metadata_path.read_text()).submission_id
+
+    result_add = _invoke(cli, migrated_database_config_path, "submission", "add", submission_id)
+    assert result_add.exit_code == 0, result_add.stderr
+
+    result = _invoke(
+        cli, migrated_database_config_path, "submission", "populate", submission_id, str(metadata_path), input="n\n"
+    )
+    assert result.exit_code == 0, result.stderr
+    assert "Database populated successfully" not in result.stderr
+    assert _list_cases(cli, migrated_database_config_path) == []
+
+    # accepting the same populate does create one, so the decline is what the assertion above rests on
+    result_accepted = _invoke(
+        cli, migrated_database_config_path, "submission", "populate", submission_id, str(metadata_path), "--no-confirm"
+    )
+    assert result_accepted.exit_code == 0, result_accepted.stderr
+    assert len(_list_cases(cli, migrated_database_config_path)) == 1
+
+
+@pytest.mark.parametrize("command", [("case", "list"), ("case", "show", "{case_id}")])
+def test_case_json_survives_a_coloured_environment(migrated_database_config_path, command):
+    """``--json`` output must be JSON for a consumer piping it, whatever the shell exports.
+
+    rich decides on ANSI colour when a Console is built, which for the CLI modules happens at
+    import, and it honours ``FORCE_COLOR`` even when stdout is a pipe. This runs out of process
+    because the test suite pins ``TTY_COMPATIBLE=0`` at import for every in-process test, which
+    is exactly what hid this the first time: the colourised output only ever reached users.
+    """
+    cli = grzctl.cli.build_cli()
+    assert _create_case(cli, migrated_database_config_path, "111111111", "case-colour").exit_code == 0
+    case_id = _list_cases(cli, migrated_database_config_path)[0]["id"]
+
+    environment = {**os.environ, "FORCE_COLOR": "1"}
+    environment.pop("TTY_COMPATIBLE", None)
+    completed = subprocess.run(
+        [
+            str(Path(sys.executable).parent / "grzctl"),
+            "--config",
+            str(migrated_database_config_path),
+            "db",
+            *(part.format(case_id=case_id) for part in command),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "\x1b" not in completed.stdout, "ANSI escapes reached a consumer parsing this"
+    json.loads(completed.stdout)  # raises if anything but JSON was written

--- a/packages/grzctl/tests/cli/test_db_populate.py
+++ b/packages/grzctl/tests/cli/test_db_populate.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from grz_db.errors import SubmissionNotFoundError
 from grz_db.models.submission import SubmissionDb
-from grz_db.models.submission.diff import DiffState, DonorDiff, DonorsDiffCollection, SubmissionDiffCollection
+from grz_db.models.submission.diff import DiffState, DonorDiff, SubmissionChangeSet
 from grz_pydantic_models.submission.metadata import REDACTED_LOCAL_CASE_ID, REDACTED_TAN, GrzSubmissionMetadata
 from grzctl.models.config import GrzctlConfig
 
@@ -122,18 +122,17 @@ def test_populate_raises_without_force_on_submission_update(db_ctx: SimpleNamesp
 def test_populate_raises_without_force_on_donor_deletion(db_ctx: SimpleNamespace):
     """RuntimeError when donors would be deleted and force=False.
 
-    ``db.diff`` is mocked so the submission diff is clean but one donor is
-    deleted, isolating the donors guard.
+    ``db.diff`` is mocked so the field diffs are clean but one donor is
+    deleted, isolating the donor part of the destructive guard.
     """
     ctx = db_ctx
-    clean_submission_diff = SubmissionDiffCollection()
-    donors_diff_with_deletion = DonorsDiffCollection()
-    donors_diff_with_deletion.deleted.append(
+    changes = SubmissionChangeSet()
+    changes.donors.deleted.append(
         DonorDiff(before=MagicMock(), after=None, state=DiffState.DELETED, pseudonym="deleted_donor")
     )
 
-    with patch.object(ctx.db, "diff", return_value=(clean_submission_diff, donors_diff_with_deletion)):
-        with pytest.raises(RuntimeError, match="donors"):
+    with patch.object(ctx.db, "diff", return_value=changes):
+        with pytest.raises(RuntimeError, match="donor 'deleted_donor'"):
             ctx.db.populate(ctx.submission_id, ctx.metadata, SUBMISSION_DATE, force=False)
 
 

--- a/packages/grzctl/tests/cli/test_validate.py
+++ b/packages/grzctl/tests/cli/test_validate.py
@@ -123,7 +123,7 @@ def _set_up_case_with_qc_passed_initial(tmp_path, migrated_database_config_path,
 
 def _assert_duplicate_failed_basic_qc(competing: SimpleNamespace) -> None:
     """The duplicate initial submission must carry ``basic_qc_passed=False`` and an ERROR log
-    naming the case's QC-passed initial submission.
+    naming the case's QC-passed initial submission, which itself must be left unaffected.
     """
     result = competing.db("submission", "show", competing.duplicate_id, "--json")
     assert result.exit_code == 0, result.output
@@ -170,8 +170,8 @@ def test_validate_rejects_duplicate_initial_before_validating(
 def test_validate_records_duplicate_initial_detected_during_validation(
     tmp_path, monkeypatch, migrated_database_config_path, test_metadata_path
 ):
-    """The write-time check catches a competing initial submission that passed basic QC
-    while this submission was being validated.
+    """The write-time check catches a competing initial submission that already passed basic
+    QC, once a blind pre-check has missed it.
 
     The pre-check is forced inconclusive, so the duplicate rejection is triggered instead by
     the write-time update, which records basic QC as failed the same way the pre-check would

--- a/packages/grzctl/tests/cli/test_validate.py
+++ b/packages/grzctl/tests/cli/test_validate.py
@@ -1,9 +1,15 @@
 """Tests for the grzctl ``validate`` wrapper command."""
 
+import json
+import logging
+from types import SimpleNamespace
+
 import click.testing
 import grz_cli.commands.validate as grz_cli_validate
 import grzctl.cli
 import pytest
+from grz_db.models.submission import SubmissionDb
+from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
 
 
 @pytest.fixture
@@ -64,3 +70,198 @@ def test_validate_forwards_mmap_to_inner_callback(tmp_path, monkeypatch, flag, e
 
     assert result.exit_code == 0, result.output
     assert received["mmap"] is expected
+
+
+def _set_up_case_with_qc_passed_initial(tmp_path, migrated_database_config_path, test_metadata_path) -> SimpleNamespace:
+    """Register two competing initial submissions for one case; one has already passed basic QC.
+
+    Returns the CLI harness plus the directory of the other (duplicate) initial submission,
+    ready for ``validate``.
+    """
+    qc_passed_raw = json.loads(test_metadata_path.read_text())
+    qc_passed_raw["submission"]["submissionType"] = "initial"
+    duplicate_raw = json.loads(json.dumps(qc_passed_raw))
+    duplicate_raw["submission"]["submissionDate"] = "2025-01-02"  # distinct id, same local case id
+    duplicate_raw["submission"]["tanG"] = "f" * 64  # a re-upload comes with a fresh transaction number
+    qc_passed_id = GrzSubmissionMetadata.model_validate(qc_passed_raw).submission_id
+    duplicate_id = GrzSubmissionMetadata.model_validate(duplicate_raw).submission_id
+
+    qc_passed_meta = tmp_path / "qc_passed.metadata.json"
+    qc_passed_meta.write_text(json.dumps(qc_passed_raw))
+    duplicate_meta = tmp_path / "duplicate.metadata.json"
+    duplicate_meta.write_text(json.dumps(duplicate_raw))
+    submission_dir = tmp_path / "duplicate-submission"
+    for sub in ("metadata", "files", "logs", "encrypted_files"):
+        (submission_dir / sub).mkdir(parents=True)
+    (submission_dir / "metadata" / "metadata.json").write_text(json.dumps(duplicate_raw))
+
+    runner = click.testing.CliRunner()
+    cli = grzctl.cli.build_cli()
+    config = str(migrated_database_config_path)
+
+    def db(*args: str) -> click.testing.Result:
+        return runner.invoke(cli, ["--config", config, "db", *args])
+
+    for sid, meta in ((qc_passed_id, qc_passed_meta), (duplicate_id, duplicate_meta)):
+        result = db("submission", "add", sid)
+        assert result.exit_code == 0, result.output
+        result = db("submission", "populate", sid, str(meta), "--no-confirm")
+        assert result.exit_code == 0, result.output
+    result = db("submission", "modify", qc_passed_id, "basic_qc_passed", "true")
+    assert result.exit_code == 0, result.output
+
+    return SimpleNamespace(
+        runner=runner,
+        cli=cli,
+        config=config,
+        db=db,
+        qc_passed_id=qc_passed_id,
+        duplicate_id=duplicate_id,
+        submission_dir=submission_dir,
+    )
+
+
+def _assert_duplicate_failed_basic_qc(competing: SimpleNamespace) -> None:
+    """The duplicate initial submission must carry ``basic_qc_passed=False`` and an ERROR log
+    naming the case's QC-passed initial submission.
+    """
+    result = competing.db("submission", "show", competing.duplicate_id, "--json")
+    assert result.exit_code == 0, result.output
+    duplicate = json.loads(result.stdout)
+    assert duplicate["basic_qc_passed"] is False
+    error = [s for s in duplicate["states"] if s["state"] == "Error"][-1]
+    assert error["failure_reason"] == "duplicate_initial"
+    assert competing.qc_passed_id in error["data"]["error"]
+    result = competing.db("submission", "show", competing.qc_passed_id, "--json")
+    assert json.loads(result.stdout)["basic_qc_passed"] is True
+
+
+def test_validate_rejects_duplicate_initial_before_validating(
+    tmp_path, monkeypatch, migrated_database_config_path, test_metadata_path
+):
+    """A duplicate initial submission fails basic QC before validation runs.
+
+    The case already has an initial submission that passed basic QC, so the DB pre-check
+    rejects the duplicate initial submission: ``basic_qc_passed`` is set to ``False``, an
+    ERROR state log carries the ``duplicate_initial`` failure reason, and the command exits
+    with a nonzero code, without spending validation effort.
+    """
+    competing = _set_up_case_with_qc_passed_initial(tmp_path, migrated_database_config_path, test_metadata_path)
+
+    def _must_not_validate(**kwargs):
+        raise AssertionError("validation must not run for a duplicate initial submission")
+
+    monkeypatch.setattr(grz_cli_validate.validate, "callback", _must_not_validate)
+    result = competing.runner.invoke(
+        competing.cli,
+        [
+            "--config",
+            competing.config,
+            "validate",
+            "--submission-dir",
+            str(competing.submission_dir),
+            "--update-db",
+        ],
+    )
+    assert result.exit_code != 0, "a failed basic QC must fail the validate step"
+    _assert_duplicate_failed_basic_qc(competing)
+
+
+def test_validate_records_duplicate_initial_detected_during_validation(
+    tmp_path, monkeypatch, migrated_database_config_path, test_metadata_path
+):
+    """The write-time check catches a competing initial submission that passed basic QC
+    while this submission was being validated.
+
+    The pre-check is forced inconclusive, so the duplicate rejection is triggered instead by
+    the write-time update, which records basic QC as failed the same way the pre-check would
+    have.
+    """
+    competing = _set_up_case_with_qc_passed_initial(tmp_path, migrated_database_config_path, test_metadata_path)
+
+    monkeypatch.setattr(SubmissionDb, "resolve_case", lambda self, *args, **kwargs: None)
+    monkeypatch.setattr(grz_cli_validate.validate, "callback", lambda **kwargs: None)
+    result = competing.runner.invoke(
+        competing.cli,
+        [
+            "--config",
+            competing.config,
+            "validate",
+            "--submission-dir",
+            str(competing.submission_dir),
+            "--update-db",
+        ],
+    )
+    assert result.exit_code != 0, "a failed basic QC must fail the validate step"
+    _assert_duplicate_failed_basic_qc(competing)
+
+
+def test_validate_without_update_db_warns_about_duplicate_initial(
+    tmp_path, monkeypatch, caplog, migrated_database_config_path, test_metadata_path
+):
+    """With ``--no-update-db``, a duplicate initial submission produces a warning.
+
+    Basic QC is not marked failed and the database is not written.
+    """
+    competing = _set_up_case_with_qc_passed_initial(tmp_path, migrated_database_config_path, test_metadata_path)
+
+    monkeypatch.setattr(grz_cli_validate.validate, "callback", lambda **kwargs: None)
+    with caplog.at_level(logging.WARNING, logger="grzctl.commands.cli_wrappers"):
+        result = competing.runner.invoke(
+            competing.cli,
+            [
+                "--config",
+                competing.config,
+                "validate",
+                "--submission-dir",
+                str(competing.submission_dir),
+                "--no-update-db",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "already has an initial submission" in caplog.text
+
+    result = competing.db("submission", "show", competing.duplicate_id, "--json")
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["basic_qc_passed"] is None
+
+
+def _submission_dir_with_initial_metadata(tmp_path, test_metadata_path) -> str:
+    """A submission directory holding one ``initial`` metadata.json, ready for ``validate``."""
+    raw = json.loads(test_metadata_path.read_text())
+    raw["submission"]["submissionType"] = "initial"
+    submission_dir = tmp_path / "submission"
+    for sub in ("metadata", "files", "logs", "encrypted_files"):
+        (submission_dir / sub).mkdir(parents=True)
+    (submission_dir / "metadata" / "metadata.json").write_text(json.dumps(raw))
+    return str(submission_dir)
+
+
+def _validate_without_update_db(config_path, submission_dir) -> click.testing.Result:
+    runner = click.testing.CliRunner()
+    return runner.invoke(
+        grzctl.cli.build_cli(),
+        ["--config", str(config_path), "validate", "--submission-dir", submission_dir, "--no-update-db"],
+    )
+
+
+def test_validate_without_update_db_reports_a_check_it_could_not_run(
+    tmp_path, monkeypatch, caplog, empty_database_config_path, test_metadata_path
+):
+    """A configured database that cannot answer must be reported, not passed over in silence.
+
+    Nothing is written in this mode, so the command still succeeds. What must not happen is
+    the operator reading the absence of a warning as "not a duplicate": here the database is
+    configured but behind on its schema, so the question was never put to it.
+    """
+    submission_dir = _submission_dir_with_initial_metadata(tmp_path, test_metadata_path)
+    monkeypatch.setattr(grz_cli_validate.validate, "callback", lambda **kwargs: None)
+
+    with caplog.at_level(logging.WARNING, logger="grzctl.commands.cli_wrappers"):
+        result = _validate_without_update_db(empty_database_config_path, submission_dir)
+
+    assert result.exit_code == 0, result.output
+    warnings = [r.message for r in caplog.records if r.name == "grzctl.commands.cli_wrappers"]
+    assert len(warnings) == 1, warnings
+    assert "Could not check whether this is a duplicate initial submission" in warnings[0]
+    assert "not at latest schema" in warnings[0], "the reason the check could not run must be named"

--- a/packages/grzctl/tests/test_dbcontext.py
+++ b/packages/grzctl/tests/test_dbcontext.py
@@ -9,7 +9,7 @@ from grz_common.exceptions import (
     NetworkError,
     UploadError,
 )
-from grz_db.errors import DuplicateTanGError
+from grz_db.errors import DuplicateInitialSubmissionError, DuplicateTanGError
 from grz_db.models.submission import FailureReasonEnum, SubmissionStateEnum
 from grzctl.dbcontext import DbContext
 from pydantic import ValidationError
@@ -104,6 +104,7 @@ class TestMapExceptionToFailureReason:
                 NetworkError(),
                 UploadError(),
                 DuplicateTanGError(),
+                DuplicateInitialSubmissionError(1),
                 IncompleteSubmissionError(),
                 validation_exc,
             ]


### PR DESCRIPTION
Introduces case tracking so multiple submissions can be grouped into one case (an `initial` submission plus its `addition`/`correction`/`followup` for the same patient/case).

The authoritative case identity is the RKI pseudonym (`psn`), unique once assigned. `(submitter_id, local_case_id)` are resolution keys used to locate a case before a `psn` exists: a partial unique index keeps the pair unique wherever both halves are present, but neither is required, since a future flow may resolve by `psn` alone. Case lookup is a pluggable strategy (`SubmitterLocalCaseResolver` today, `PsnResolver` for the future PSN-based flow). `submitter_id` stays on `submissions`.

feat(grzctl): add db case commands and link submissions to cases on populate

Adds `grzctl db case` (`list`/`show`/`modify`/`create`/`relink`/`delete`) and links each submission to its case during `db submission populate`. Any submission type may open a brand-new case except `test`, which is never case-tracked and is rejected outright: a patient's first submission to reach this GRZ need not be the `initial` one, so a `followup` whose `initial` never arrived here still opens the case itself. A case may have at most one `initial` submission that has passed basic QC; competing initials may coexist while QC is pending, but only one of them may ever pass, which a partial unique index enforces.

A new Alembic migration adds the `cases` table and a nullable `submissions.case_id`, backfills existing submissions by grouping on `(submitter_id, pseudonym)`, and keeps `submitter_id` on `submissions`. Redaction placeholders are excluded from the grouping, since a placeholder identifies no patient and would otherwise collapse every redacted submission of a submitter onto one case. The upgrade refuses to run when two QC-passed `initial` submissions already share a key, naming the groups so they can be resolved first. Deploying requires `grzctl db upgrade`.

Backfill no longer hardcodes any field to ignore. `tan_g` and the pseudonym are restored from the
stored row before diffing, so they compare equal rather than needing exclusion, and whatever cannot be
restored is ignored for that submission alone. The upload date is `diff`'s call, not backfill's. That
removes the last hardcoded ignore list, and with it the failure mode where a name spelled wrong
silently ignores nothing, which is how `local_case_id` protected the pseudonym column for three months
without anyone noticing.

feat(grzctl): fail a rival initial submission's basic QC during validate

A submission validated against a case whose initial has already passed basic QC records `duplicate_initial` and fails, rather than discovering it at write time.

fix(grz-db): consult the resolver passed to assert_no_duplicate_initial

The duplicate pre-check screened on `local_case_id`, the default resolver's key, before consulting the resolver it was given, so a `psn`-keyed resolver was never called. The placeholder rejection now lives in the resolver that reads that key.

fix(grzctl): abort cleanly on a duplicate case key and a malformed submitter ID

`db case modify` and `db case create` each missed exactly what the other caught, so a colliding `(submitter_id, local_case_id)` pair and a submitter ID failing its pattern both produced a traceback instead of the red `Error:` line every other case command prints.

fix(grz-db): require grz-pydantic-models >=3.1 for is_redacted_local_case_id

Fixes #632
