### PR TITLE
chore(repo): relax uv version spec

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   # common
   - python >=3.12
-  - uv =0.11.22
+  - uv ~=0.11.22
   # for grz-check
   - rust =1.89.0
   # for grz-db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ grz-check = { workspace = true }
 # enforces it on every local invocation. (The constraint-dependencies 
 # below as well as conda `environment-dev.yml`pin must be kept in sync 
 # by hand.)
-required-version = "==0.11.22"
+required-version = "~=0.11.22"
 
 # Centralize test/dev tool version ranges here so each package's
 # `[dependency-groups]` only lists bare package names. uv applies these
@@ -53,7 +53,7 @@ constraint-dependencies = [
     "responses ==0.25.*",
     "numpy >=2.1.2,<3",
     "ruff >=0.11.12,<1",
-    "uv ==0.11.22"
+    "uv ~=0.11.22"
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,7 @@ constraints = [
     { name = "pytest-sugar", specifier = ">=1.0.0,<2" },
     { name = "responses", specifier = "==0.25.*" },
     { name = "ruff", specifier = ">=0.11.12,<1" },
-    { name = "uv", specifier = "==0.11.22" },
+    { name = "uv", specifier = "~=0.11.22" },
 ]
 
 [[package]]


### PR DESCRIPTION
to avoid local uv installations clashing with the very strict ==