### PR TITLE
fix(grz-pydantic-models): warn instead of error on tumor+germline labData check before 2025-12-04

### DIFF
--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -1282,10 +1282,16 @@ class GrzSubmissionMetadata(StrictBaseModel):
             missing_subtypes = required_sequencing_subtypes - donor_sequence_subtypes
 
             if missing_subtypes:
-                raise ValueError(
+                message = (
                     f"Index donor is missing sequence subtypes for submission type '{self.submission.genomic_study_subtype}': "
-                    f"{', '.join(missing_subtypes)}."
+                    f"{', '.join(missing_subtypes)}, starting 04.12.2025."
                 )
+                # This check was published in grz-pydantic-models v2.5.0 (2025-12-04); submissions
+                # predating that release were not subject to it, so only warn for them.
+                if self.submission.submission_date >= date(2025, 12, 4):
+                    raise ValueError(message)
+                else:
+                    log.warning(message)
 
             return self
 

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -95,6 +95,11 @@ def test_wgs_tumor_germline_missing_dna(version):
         importlib.resources.files(example_metadata).joinpath("wgs_tumor_germline", f"v{version}.json").read_text()
     )
 
+    # The example predates the 04.12.2025 cutoff, before which a missing subtype only warns.
+    metadata = json.loads(metadata_str)
+    metadata["submission"]["submissionDate"] = "2025-12-04"
+    metadata_str = json.dumps(metadata)
+
     ### tumor+germline
 
     # delete germline DNA
@@ -168,6 +173,47 @@ def test_wgs_tumor_germline_missing_dna(version):
 
     # missing tumor DNA should pass
     GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+
+
+@pytest.mark.parametrize("version", TESTED_VERSIONS)
+def test_missing_sequence_subtype_warns_before_cutoff(version: str, caplog):
+    """
+    The labData/genomicStudySubtype check was published in grz-pydantic-models v2.5.0 (04.12.2025).
+    Submissions predating that release must only warn, so that backfills and other operations
+    replaying historical data do not fail retroactively.
+    """
+    metadata = json.loads(
+        importlib.resources.files(example_metadata).joinpath("wgs_tumor_germline", f"v{version}.json").read_text()
+    )
+    metadata["submission"]["submissionDate"] = "2025-12-03"
+    assert metadata["donors"][0]["labData"][0]["sequenceSubtype"] == "germline"
+    del metadata["donors"][0]["labData"][0]
+
+    # must not raise for this rule
+    try:
+        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+    except ValidationError as e:
+        assert "Index donor is missing sequence subtypes" not in str(e)
+
+    assert "Index donor is missing sequence subtypes" in caplog.text
+    assert "starting 04.12.2025" in caplog.text
+
+
+@pytest.mark.parametrize("version", TESTED_VERSIONS)
+def test_missing_sequence_subtype_raises_on_cutoff(version: str):
+    """On the cutoff date itself the check is enforced."""
+    metadata = json.loads(
+        importlib.resources.files(example_metadata).joinpath("wgs_tumor_germline", f"v{version}.json").read_text()
+    )
+    metadata["submission"]["submissionDate"] = "2025-12-04"
+    assert metadata["donors"][0]["labData"][0]["sequenceSubtype"] == "germline"
+    del metadata["donors"][0]["labData"][0]
+
+    with pytest.raises(
+        ValidationError,
+        match=r"""Index donor is missing sequence subtypes for submission type 'tumor\+germline': germline""",
+    ):
+        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
historical tumor+germline submissions predating its enforcement (grz-pydantic-models v2.5.0, 2025-12-04) only warn instead of erroring. This unblocks backfill/archive re-validating for older archived submissions. Fixes #604.
