### PR TITLE
fix(grz-pydantic-models)!: grant research consent only while in force

### DIFF
--- a/packages/grz-common/pyproject.toml
+++ b/packages/grz-common/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pydantic >=2.12,<3",
     "pydantic-settings >=2.11.0,<3",
     "platformdirs >=4.3.6,<5",
-    "grz-pydantic-models >=2.7,<3",
+    "grz-pydantic-models >=3,<4",
     "grz-check >=0.3.1",
 ]
 classifiers = [

--- a/packages/grz-common/src/grz_common/models/version.py
+++ b/packages/grz-common/src/grz_common/models/version.py
@@ -1,9 +1,10 @@
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any, Self
 
 import botocore
+from grz_pydantic_models.common import as_aware_datetime
 from packaging.version import Version
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 from pydantic_core import core_schema
@@ -59,17 +60,10 @@ class VersionInfo(BaseModel):
     @field_validator("enforced_from", mode="before")
     @classmethod
     def parse_datetime(cls, v):
-        if isinstance(v, datetime):
-            # Already a datetime — ensure it is timezone-aware by treating naive datetimes as UTC.
-            # This guarantees safe comparison with datetime.now(UTC) regardless of whether the
-            # value was constructed programmatically (e.g. in tests) or parsed from a string.
-            return v if v.tzinfo is not None else v.replace(tzinfo=UTC)
-
-        # Parse ISO 8601 strings. Strings without a timezone offset (e.g. "2026-03-01T00:00:00")
-        # are treated as UTC rather than local time, ensuring consistent behaviour across
-        # environments and avoiding ambiguity when comparing against datetime.now(UTC).
-        dt = datetime.fromisoformat(str(v))
-        return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+        # Naive values, whether constructed programmatically (e.g. in tests) or parsed from a string
+        # without an offset (e.g. "2026-03-01T00:00:00"), are treated as UTC so that comparisons
+        # against datetime.now(UTC) stay unambiguous across environments.
+        return as_aware_datetime(v if isinstance(v, datetime) else datetime.fromisoformat(str(v)))
 
     @model_validator(mode="after")
     def check_version_order(self):

--- a/packages/grz-db/pyproject.toml
+++ b/packages/grz-db/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "alembic[tz] >=1.16.1",
     "cryptography >=45.0.3,<49",
     "sqlmodel >=0.0.38",
-    "grz-pydantic-models >=2.7,<3",
+    "grz-pydantic-models >=3,<4",
     "psycopg[binary] ~=3.2"
 ]
 

--- a/packages/grz-db/src/grz_db/common.py
+++ b/packages/grz-db/src/grz_db/common.py
@@ -2,6 +2,8 @@ import datetime
 import enum
 import logging
 
+from grz_pydantic_models.common import as_aware_datetime
+
 log = logging.getLogger(__name__)
 
 
@@ -52,10 +54,4 @@ def serialize_datetime_to_iso_z(dt: datetime.datetime) -> str:
     """
     Serializes a datetime object to a canonical ISO 8601 string format with 'Z' for UTC.
     """
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=datetime.UTC)
-
-    if dt.tzinfo != datetime.UTC and dt.utcoffset() != datetime.timedelta(0):
-        dt = dt.astimezone(datetime.UTC)
-
-    return dt.isoformat().replace("+00:00", "Z")
+    return as_aware_datetime(dt).astimezone(datetime.UTC).isoformat().replace("+00:00", "Z")

--- a/packages/grz-pydantic-models-testing/pyproject.toml
+++ b/packages/grz-pydantic-models-testing/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Topic :: Software Development :: Testing",
 ]
 dependencies = [
-    "grz-pydantic-models >=2.7,<3",
+    "grz-pydantic-models >=3,<4",
 ]
 
 [project.urls]

--- a/packages/grz-pydantic-models-testing/scripts/vendor_mii_consent_package.py
+++ b/packages/grz-pydantic-models-testing/scripts/vendor_mii_consent_package.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 REGISTRY = "https://packages2.fhir.org/packages/de.medizininformatikinitiative.kerndatensatz.consent"
 
-#: Artefact inside the FHIR package -> file name prefix used in example_terminology.
+# Artefact inside the FHIR package -> file name prefix used in example_terminology.
 ARTEFACTS = {
     "CodeSystem-MiiConsentPolicyCodeSystem.json": "mii-cs-consent-policy",
     "CodeSystem-MiiConsentVersionModuleCodeSystem.json": "mii-cs-consent-version-modules",
@@ -34,8 +34,8 @@ ARTEFACTS = {
 
 TERMINOLOGY_DIR = Path(__file__).resolve().parent.parent / "src/grz_pydantic_models_testing/example_terminology"
 
-#: Package version -> version each artefact of that package states. A package version appears
-#: nowhere inside the artefacts it ships, so writing them out by resource version alone loses it.
+# Package version -> version each artefact of that package states. A package version appears
+# nowhere inside the artefacts it ships, so writing them out by resource version alone loses it.
 MANIFEST = TERMINOLOGY_DIR / "packages.json"
 
 

--- a/packages/grz-pydantic-models-testing/scripts/vendor_mii_consent_package.py
+++ b/packages/grz-pydantic-models-testing/scripts/vendor_mii_consent_package.py
@@ -4,8 +4,9 @@ Vendor the MII consent artefacts the consent tests check the model against.
 
 Downloads one published version of ``de.medizininformatikinitiative.kerndatensatz.consent`` and
 writes the CodeSystems and the Consent profile into ``example_terminology``, named after the version
-stated inside each resource. Run this by hand when the MII publishes a release; the test suite never
-reaches the network itself.
+stated inside each resource, plus an entry in ``packages.json`` tying the package version to the
+versions it ships. Run this by hand when the MII publishes a release; the test suite never reaches
+the network itself.
 
 Usage::
 
@@ -32,6 +33,10 @@ ARTEFACTS = {
 }
 
 TERMINOLOGY_DIR = Path(__file__).resolve().parent.parent / "src/grz_pydantic_models_testing/example_terminology"
+
+#: Package version -> version each artefact of that package states. A package version appears
+#: nowhere inside the artefacts it ships, so writing them out by resource version alone loses it.
+MANIFEST = TERMINOLOGY_DIR / "packages.json"
 
 
 def download(package_version: str) -> dict[str, dict]:
@@ -92,6 +97,20 @@ def vendor(artefacts: dict[str, dict], force: bool) -> int:
     return 1 if conflicts and not force else 0
 
 
+def record(package_version: str, artefacts: dict[str, dict]) -> None:
+    """Record which version each artefact of a package states, keyed by the package version.
+
+    :param package_version: published package version the artefacts came from.
+    :param artefacts: parsed artefacts keyed by their file name in the package.
+    """
+    manifest = json.loads(MANIFEST.read_text()) if MANIFEST.exists() else {}
+    manifest[package_version] = {
+        prefix: artefacts[name]["version"] for name, prefix in ARTEFACTS.items() if name in artefacts
+    }
+    MANIFEST.write_text(json.dumps(dict(sorted(manifest.items())), indent=2, ensure_ascii=False) + "\n")
+    print(f"  {MANIFEST.name}: recorded {package_version}")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("package_version", help="published package version, e.g. 2026.0.1")
@@ -102,7 +121,9 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    exit_code = vendor(download(args.package_version), args.force)
+    artefacts = download(args.package_version)
+    exit_code = vendor(artefacts, args.force)
+    record(args.package_version, artefacts)
     print(f"\nvendored into {TERMINOLOGY_DIR}")
     print("next: uv run pytest packages/grz-pydantic-models")
     return exit_code

--- a/packages/grz-pydantic-models-testing/scripts/vendor_mii_consent_package.py
+++ b/packages/grz-pydantic-models-testing/scripts/vendor_mii_consent_package.py
@@ -54,7 +54,7 @@ def download(package_version: str) -> dict[str, dict]:
     with tarfile.open(fileobj=archive, mode="r:gz") as tar:
         shipped = set(tar.getnames())
         for name in ARTEFACTS:
-            # not every package ships every artefact: the version and module CodeSystem appears in
+            # not every package ships every artefact: the version and modules CodeSystem appears in
             # 2026.0.0 only, and the 2026.0.1 release candidates dropped it again
             if f"package/{name}" not in shipped:
                 continue

--- a/packages/grz-pydantic-models-testing/scripts/vendor_mii_consent_package.py
+++ b/packages/grz-pydantic-models-testing/scripts/vendor_mii_consent_package.py
@@ -123,7 +123,10 @@ def main() -> int:
 
     artefacts = download(args.package_version)
     exit_code = vendor(artefacts, args.force)
-    record(args.package_version, artefacts)
+    if exit_code == 0:
+        record(args.package_version, artefacts)
+    else:
+        print(f"  {MANIFEST.name}: left alone, since the artefacts on disk are not this package's")
     print(f"\nvendored into {TERMINOLOGY_DIR}")
     print("next: uv run pytest packages/grz-pydantic-models")
     return exit_code

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_terminology/README.md
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_terminology/README.md
@@ -16,9 +16,9 @@ uv run pytest packages/grz-pydantic-models
 The script fetches the package, writes each artefact under the name given below, records in
 `packages.json` which version each of them states, and reports whether the artefact was added, was
 already vendored unchanged, or is not shipped by that package. It refuses to overwrite a vendored
-file whose contents differ from upstream and exits non-zero instead: the MII has published two
-different profiles under version 1.0.9, so a version number alone is not proof that nothing changed.
-Pass `--force` once you have looked at the difference and want upstream to win.
+file whose contents differ from upstream, records nothing, and exits non-zero instead: the MII has
+published two different profiles under version 1.0.9, so a version number alone is not proof that
+nothing changed. Pass `--force` once you have looked at the difference and want upstream to win.
 
 Only a human runs this. The test suite never reaches the network, so a registry outage cannot turn a
 build red and every change to these artefacts arrives as a reviewable diff.

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_terminology/README.md
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_terminology/README.md
@@ -45,17 +45,20 @@ that case there is nothing to add. Copy the JSON verbatim apart from re-indentin
 
 Then add the package to `packages.json`, mapping its version to the version each artefact states.
 Nothing in the copied files records which package they came from, so this is the only place that
-link survives.
+link survives. Key the inner map by the file-name prefix from the table above
+(`mii-cs-consent-policy`, `mii-cs-consent-version-modules`, `mii-pr-consent-einwilligung`), not by
+the artefact's name inside `package/`.
 
-Then run the consent tests. Anything the model does not yet cover is reported by file name:
+Then run the consent tests. Anything the model does not yet cover fails by the file or the package
+version it concerns:
 
-- an OID added to the version and module CodeSystem that `BROAD_CONSENT_DOCUMENT_OIDS` does not
+- an OID added to the version and modules CodeSystem that `BROAD_CONSENT_DOCUMENT_OIDS` does not
   classify
 - either policy code research consent is derived from going missing, deprecated or inactive
 - a profile that pins a different category CodeSystem, relaxes or tightens a period bound, changes
   the minimum number of categories, or stops forbidding what the model rejects
-- a package version `RESEARCH_CONSENT_PACKAGE_PROFILES` does not list, or one it maps to a profile
-  the package does not ship
+- any disagreement between `packages.json` and `RESEARCH_CONSENT_PACKAGE_PROFILES`: a package one
+  names and the other does not, or a package the two map to different profiles
 
 A failure is a prompt to update the model, not a reason to edit these files.
 
@@ -71,6 +74,6 @@ The profile version is the one that matters most, because it decides which cardi
 nowhere inside the artefacts, which name only themselves, so the mapping cannot be recovered from
 this directory once it is lost.
 
-Package 2026.0.0 is the only published package defining the version and module CodeSystem. The 2025
+Package 2026.0.0 is the only published package defining the version and modules CodeSystem. The 2025
 packages use its OIDs as `Consent.policy[].uri` without defining them, and the 2026.0.1 release
 candidates drop the file again while still pinning its canonical URL in the profile.

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_terminology/README.md
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_terminology/README.md
@@ -13,11 +13,12 @@ python packages/grz-pydantic-models-testing/scripts/vendor_mii_consent_package.p
 uv run pytest packages/grz-pydantic-models
 ```
 
-The script fetches the package, writes each artefact under the name given below, and reports whether
-it was added, was already vendored unchanged, or is not shipped by that package. It refuses to
-overwrite a vendored file whose contents differ from upstream and exits non-zero instead: the MII has
-published two different profiles under version 1.0.9, so a version number alone is not proof that
-nothing changed. Pass `--force` once you have looked at the difference and want upstream to win.
+The script fetches the package, writes each artefact under the name given below, records in
+`packages.json` which version each of them states, and reports whether the artefact was added, was
+already vendored unchanged, or is not shipped by that package. It refuses to overwrite a vendored
+file whose contents differ from upstream and exits non-zero instead: the MII has published two
+different profiles under version 1.0.9, so a version number alone is not proof that nothing changed.
+Pass `--force` once you have looked at the difference and want upstream to win.
 
 Only a human runs this. The test suite never reaches the network, so a registry outage cannot turn a
 build red and every change to these artefacts arrives as a reviewable diff.
@@ -42,6 +43,10 @@ From `package/`, copy each of the three artefacts below into this directory, nam
 Several packages ship the same resource version, so a file may already be present and identical; in
 that case there is nothing to add. Copy the JSON verbatim apart from re-indenting.
 
+Then add the package to `packages.json`, mapping its version to the version each artefact states.
+Nothing in the copied files records which package they came from, so this is the only place that
+link survives.
+
 Then run the consent tests. Anything the model does not yet cover is reported by file name:
 
 - an OID added to the version and module CodeSystem that `BROAD_CONSENT_DOCUMENT_OIDS` does not
@@ -49,18 +54,22 @@ Then run the consent tests. Anything the model does not yet cover is reported by
 - either policy code research consent is derived from going missing, deprecated or inactive
 - a profile that pins a different category CodeSystem, relaxes or tightens a period bound, changes
   the minimum number of categories, or stops forbidding what the model rejects
+- a package version `RESEARCH_CONSENT_PACKAGE_PROFILES` does not list, or one it maps to a profile
+  the package does not ship
 
 A failure is a prompt to update the model, not a reason to edit these files.
 
 ## Which package ships which version
 
-| Package  | Policy CodeSystem | Version and modules CodeSystem | Profile |
-| -------- | ----------------- | ------------------------------ | ------- |
-| 2025.0.1 | 1.0.5             | not shipped                    | 1.0.8   |
-| 2025.0.2 | 1.0.6             | not shipped                    | 1.0.8   |
-| 2025.0.3 | 1.0.7             | not shipped                    | 1.0.8   |
-| 2025.0.4 | 1.0.7             | not shipped                    | 1.0.8   |
-| 2026.0.0 | 1.1.0             | 0.2.0                          | 1.0.9   |
+`packages.json` holds it: one entry per package version, naming the version each artefact states,
+with an artefact the package does not ship simply absent. The consent tests check
+`RESEARCH_CONSENT_PACKAGE_PROFILES` against it, so a released package the model does not yet
+classify fails the suite instead of being quietly unsupported.
+
+The profile version is the one that matters most, because it decides which cardinalities apply:
+1.0.8 requires an end on both provision periods, 1.0.9 relaxed it. A package states its profile
+nowhere inside the artefacts, which name only themselves, so the mapping cannot be recovered from
+this directory once it is lost.
 
 Package 2026.0.0 is the only published package defining the version and module CodeSystem. The 2025
 packages use its OIDs as `Consent.policy[].uri` without defining them, and the 2026.0.1 release

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_terminology/packages.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_terminology/packages.json
@@ -1,0 +1,23 @@
+{
+  "2025.0.1": {
+    "mii-cs-consent-policy": "1.0.5",
+    "mii-pr-consent-einwilligung": "1.0.8"
+  },
+  "2025.0.2": {
+    "mii-cs-consent-policy": "1.0.6",
+    "mii-pr-consent-einwilligung": "1.0.8"
+  },
+  "2025.0.3": {
+    "mii-cs-consent-policy": "1.0.7",
+    "mii-pr-consent-einwilligung": "1.0.8"
+  },
+  "2025.0.4": {
+    "mii-cs-consent-policy": "1.0.7",
+    "mii-pr-consent-einwilligung": "1.0.8"
+  },
+  "2026.0.0": {
+    "mii-cs-consent-policy": "1.1.0",
+    "mii-cs-consent-version-modules": "0.2.0",
+    "mii-pr-consent-einwilligung": "1.0.9"
+  }
+}

--- a/packages/grz-pydantic-models/README.md
+++ b/packages/grz-pydantic-models/README.md
@@ -1,3 +1,6 @@
 # grz-pydantic-models
 
 Pydantic models of the BfArM GRZ metadata schema.
+## Documentation
+
+- [MII research consent: how the pieces fit together](docs/mii-consent.md)

--- a/packages/grz-pydantic-models/README.md
+++ b/packages/grz-pydantic-models/README.md
@@ -1,6 +1,7 @@
 # grz-pydantic-models
 
 Pydantic models of the BfArM GRZ metadata schema.
+
 ## Documentation
 
-- [MII research consent: how the pieces fit together](docs/mii-consent.md)
+- [MII research consent, explained](docs/mii-consent.md)

--- a/packages/grz-pydantic-models/docs/mii-consent.md
+++ b/packages/grz-pydantic-models/docs/mii-consent.md
@@ -8,6 +8,10 @@ inside `researchConsents[].scope`, and this package answers two questions about 
 1. **Is it well-formed?** Does it follow the MII's FHIR specification (validation)?
 2. **What does it say?** May the donor's data be used for research at a given date (evaluation)?
 
+`scope` may also be absent, paired with a `noScopeJustification` saying why. And a `scope` that
+fails Consent validation is not rejected: it is kept as a plain object, the validation errors are
+logged as warnings, and both questions below then answer "nothing known" rather than "no".
+
 Current version numbers live in the code constants and in `example_terminology/packages.json` of
 `grz-pydantic-models-testing`.
 
@@ -19,7 +23,7 @@ Current version numbers live in the code constants and in `example_terminology/p
 | KDS consent package | The MII's FHIR package (`de.medizininformatikinitiative.kerndatensatz.consent`) that defines how to represent such a consent digitally ([registry](https://packages2.fhir.org/packages/de.medizininformatikinitiative.kerndatensatz.consent)). |
 | Profile | The rulebook inside the package (`MII_PR_Consent_Einwilligung`): which fields a Consent resource must/may have. |
 | Policy CodeSystem | The catalogue of **permissions** ("use data scientifically", "contact again", …), one OID each, organized as modules with sub-items. |
-| Version & modules CodeSystem | The catalogue of **signable documents** (each broad consent version, withdrawal forms, additional modules), one OID each. |
+| Version and modules CodeSystem | The catalogue of **signable documents** (each broad consent version, withdrawal forms, additional modules), one OID each. |
 | GRZ metadata schema | BfArM's format for the whole submission; `researchConsents[]` is one small part of it. |
 
 ## A consent, annotated
@@ -31,13 +35,15 @@ Current version numbers live in the code constants and in `example_terminology/p
   "scope": { "coding": [ { "system": ".../consentscope", "code": "research" } ] },
   "category": [
     { "coding": [ { "system": "http://loinc.org", "code": "57016-8" } ] },
-    { "coding": [ { /* the MII broad consent category */ } ] }
+    { "coding": [ { "system": ".../mii-cs-consent-consent_category",
+                    "code": "2.16.840.1.113883.3.1937.777.24.2.184" } ] }
+    // ^ THAT this is an MII broad consent at all, not which version of it
   ],
   "patient": { "reference": "Patient/..." },     // or an identifier with system + value
   "dateTime": "2020-09-01",
   "policy": [
-    { "uri": "urn:oid:2.16.840.1.113883.3.1937.777.24.2.184" }
-    // ^ WHICH document was signed (an OID from the version & modules CodeSystem)
+    { "uri": "urn:oid:2.16.840.1.113883.3.1937.777.24.2.1791" }
+    // ^ WHICH document was signed: broad consent 1.6f, an OID from the version and modules CodeSystem
   ],
   "provision": {                   // root provision: the opt-in frame
     "type": "deny",                // nothing is allowed unless a nested rule permits it
@@ -58,8 +64,12 @@ Current version numbers live in the code constants and in `example_terminology/p
 
 Two different OID catalogues meet here, and telling them apart is the key to everything else:
 
-- `policy[].uri` says **which document** the donor signed → version & modules CodeSystem.
+- `policy[].uri` says **which document** the donor signed → version and modules CodeSystem.
 - `provision.provision[].code` says **what the donor allowed or refused** → policy CodeSystem.
+
+Some systems state the signed document as a `category` coding from the version and modules
+CodeSystem instead of in `policy[]`. `Consent.document_oids` reads both places, so either spelling
+works.
 
 ## Four version numbers that mean different things
 
@@ -68,11 +78,12 @@ Two different OID catalogues meet here, and telling them apart is the key to eve
 | the GRZ metadata schema | `$schema` URL of the submission | `is_supported_version`, `get_accepted_versions` |
 | the KDS consent package | `researchConsents[].schemaVersion` | `RESEARCH_CONSENT_SCHEMA_VERSIONS` |
 | each artefact inside the package (profile, CodeSystems) | inside the package files | `example_terminology/` file names + `example_terminology/packages.json` |
-| the signed broad consent document | OIDs in `Consent.policy[].uri` | `BroadConsentVersion`, `BROAD_CONSENT_DOCUMENT_OIDS` |
+| the signed broad consent document | OIDs in `Consent.policy[].uri`, or in a `category` coding from the version and modules CodeSystem | `BroadConsentVersion`, `BROAD_CONSENT_DOCUMENT_OIDS` |
 
 None of these implies another. The classic trap: **`schemaVersion` names the KDS package (the
 digital format), not the document the donor signed.** Which broad consent version the donor
-actually signed is derived from the policy OIDs (`Consent.broad_consent_versions`).
+actually signed is derived from those document OIDs (`Consent.broad_consent_versions`), wherever
+they appear.
 
 Two facts that follow from the axes moving independently:
 
@@ -85,16 +96,18 @@ Two facts that follow from the axes moving independently:
 
 ## Question 1: is it well-formed?
 
-The model (`grz_pydantic_models/mii/consent.py`) enforces what the profile pins:
+The model (`grz_pydantic_models/mii/consent.py`) enforces what the profile pins, plus two rules the
+profile leaves open but the GRZ requires, marked †. The root-provision rule is enforced one level
+up, on `ResearchConsent` in `submission/metadata/v1.py`.
 
 | Element | Rule |
 | --- | --- |
 | `status` | required; only `active` marks the consent as in force |
 | `scope` | exactly one coding, and it must be `research` |
 | `category` | must contain the LOINC consent category and the MII broad consent category, one coding each; extra categories are allowed (open slicing) |
-| `patient` | must identify the patient: reference or identifier (identifier needs `system` + `value`) |
+| `patient` | † must identify the patient: reference or identifier (identifier needs `system` + `value`). The profile requires `patient` but marks both ways of filling it mustSupport only |
 | `policy` | at least one document OID, with or without the `urn:oid:` prefix |
-| `provision` (root) | `type` must be `deny` (opt-in), `period` required, `code` forbidden |
+| `provision` (root) | † `type` must be `deny` (opt-in); the profile requires `type` but fixes no value. `period` required, `code` forbidden |
 | `provision.provision[]` | the decisions: `type`, `period`, at least one `code` |
 | a third provision level | forbidden |
 
@@ -112,14 +125,16 @@ Two quirks worth knowing:
   optional on `Period` itself, because one model serves every profile version; the version that
   decides is the one the submission declares.
 
-Unknown fields are generally ignored (FHIR resources carry much more than we read), **except**
-where ignoring would silently drop a permission the evaluation never looks at: a `code` on the
-root provision, a third provision level, a wrong `resourceType`, an unidentified patient. Those
-are rejected so the submitter notices.
+Unknown fields are ignored on the resource and its provisions (FHIR carries much more than we
+read), but **forbidden** on the small leaf elements the evaluation reads field by field: `Period`,
+`Coding` and `CodeableConcept`. Four things are rejected outright rather than ignored: a `code` on
+the root provision and a third provision level, because they carry permissions the evaluation never
+looks at and accepting them would silently lose them; a wrong `resourceType` and a patient
+identified by neither reference nor identifier, because neither can be what the submitter meant.
 
 ## Question 1b: what was signed?
 
-Every OID the MII ships in the version & modules CodeSystem is classified in
+Every OID the MII ships in the version and modules CodeSystem is classified in
 `BROAD_CONSENT_DOCUMENT_OIDS` as one of:
 
 - **consent**: the broad consent itself, per document version (incl. minor / legal-guardian variants)
@@ -131,14 +146,24 @@ Every OID the MII ships in the version & modules CodeSystem is classified in
 An OID we do not recognize (e.g. a future broad consent version) is **reported, never rejected**
 (`unknown_document_oids`): new document versions must not break submissions.
 
+**None of this feeds the research decision.** Question 2 reads only `status` and the provisions; the
+document kind is reported, not enforced. A real withdrawal or rejection says so twice, through its
+document OID *and* by denying the permissions or stating none, and it is the second half that
+Question 2 acts on. The shipped `withdrawal_complete` example shows the shape: its status is
+`active`, and what refuses is its nested `deny` of the PATDAT module. So treat a withdrawal or
+rejection OID on a consent that still permits research as a contradiction worth investigating, not
+as a refusal the model has already applied.
+
 ## Question 2: does the donor consent to research?
 
 Research use requires one specific permission from the policy CodeSystem, and that catalogue is
 hierarchical: permissions live inside modules:
 
 ```text
-…24.5.3.1  "PATDAT erheben, speichern, nutzen"      ← the module
-└── …24.5.3.8  "MDAT wissenschaftlich nutzen"       ← the permission research needs
+…24.5.3.1  "Patientendaten erheben, speichern, nutzen"   ← the module (PATDAT_ERHEBEN_SPEICHERN_NUTZEN)
+└── …24.5.3.8  "MDAT wissenschaftlich nutzen"            ← what research needs
+                                                            (MDAT_WISSENSCHAFTLICH_NUTZEN_EU_DSGVO_NIVEAU;
+                                                             policy 1.0.5-1.0.7 display it as "… EU DSGVO NIVEAU")
 ```
 
 Permitting the module includes everything inside it, so **either** OID being permitted grants

--- a/packages/grz-pydantic-models/docs/mii-consent.md
+++ b/packages/grz-pydantic-models/docs/mii-consent.md
@@ -137,16 +137,19 @@ research consent. That is why `ResearchConsentCodes` contains both.
 
 `consents_to_research(consents, date)` then applies these rules:
 
-1. A consent whose root provision period does not contain `date` contributes nothing, since the root
+1. A consent whose `status` is not `active` contributes nothing. `status` is a FHIR modifier
+   element, so a rejected, withdrawn (`inactive`), draft, proposed or erroneous consent grants
+   nothing regardless of its provisions.
+2. A consent whose root provision period does not contain `date` contributes nothing, since the root
    deny frame bounds every nested rule. Same for each nested provision's own period.
-2. Codes are matched on the OID alone, because the surrounding `system` is written
+3. Codes are matched on the OID alone, because the surrounding `system` is written
    inconsistently in the wild (with and without `urn:oid:`).
-3. **Deny wins.** A permit of either research code grants, but a deny on either revokes, also
+4. **Deny wins.** A permit of either research code grants, but a deny on either revokes, also
    across multiple consents of the same donor. So a partial withdrawal that denies `…5.3.8`
    revokes research use even while the module permit still stands.
-4. Date-only period bounds cover the whole day (a start begins at midnight, an end expires at the
+5. Date-only period bounds cover the whole day (a start begins at midnight, an end expires at the
    end of that day); datetimes without a timezone are read as UTC.
-5. A consent that states neither research code grants nothing: silence is not consent.
+6. A consent that states neither research code grants nothing: silence is not consent.
 
 ## How this stays correct over time
 

--- a/packages/grz-pydantic-models/docs/mii-consent.md
+++ b/packages/grz-pydantic-models/docs/mii-consent.md
@@ -8,7 +8,7 @@ inside `researchConsents[].scope`, and this package answers two questions about 
 1. **Is it well-formed?** Does it follow the MII's FHIR specification (validation)?
 2. **What does it say?** May the donor's data be used for research at a given date (evaluation)?
 
-Current version numbers live in the code constants and in the `example_terminology` README of
+Current version numbers live in the code constants and in `example_terminology/packages.json` of
 `grz-pydantic-models-testing`.
 
 ## Glossary
@@ -67,7 +67,7 @@ Two different OID catalogues meet here, and telling them apart is the key to eve
 | --- | --- | --- |
 | the GRZ metadata schema | `$schema` URL of the submission | `is_supported_version`, `get_accepted_versions` |
 | the KDS consent package | `researchConsents[].schemaVersion` | `RESEARCH_CONSENT_SCHEMA_VERSIONS` |
-| each artefact inside the package (profile, CodeSystems) | inside the package files | `example_terminology/` file names + its README's mapping table |
+| each artefact inside the package (profile, CodeSystems) | inside the package files | `example_terminology/` file names + `example_terminology/packages.json` |
 | the signed broad consent document | OIDs in `Consent.policy[].uri` | `BroadConsentVersion`, `BROAD_CONSENT_DOCUMENT_OIDS` |
 
 None of these implies another. The classic trap: **`schemaVersion` names the KDS package (the
@@ -76,8 +76,10 @@ actually signed is derived from the policy OIDs (`Consent.broad_consent_versions
 
 Two facts that follow from the axes moving independently:
 
-- Most package releases only grow the terminology and leave the profile untouched, so one and the
-  same Consent stays valid under every accepted `schemaVersion` (a test asserts this).
+- Most package releases only grow the terminology and leave the profile untouched, so a Consent
+  that parses under one `schemaVersion` usually parses under all of them
+  (`test_every_published_package_version_parses_the_same_consent` pins this for a fully bounded
+  consent). Where the profile did change, portability ends: see the period rule below.
 - The GRZ metadata schema sometimes lists a package version before the MII has released it; such
   versions stay rejected until the release exists and its artefacts are vendored.
 
@@ -101,12 +103,14 @@ Two quirks worth knowing:
 - The MII renamed the category CodeSystem at one point but kept shipping examples in the old
   spelling, so **both spellings are in the wild and both are accepted**
   (`MII_CONSENT_CATEGORY_SYSTEMS`).
-- Profile 1.0.9, shipped by package 2026.0.0, allows a `period` without an `end`, and such a
-  period never expires. Profile 1.0.8, shipped by every 2025 package, still requires an `end`, so
-  an open-ended period is **rejected under those `schemaVersion`s** and accepted only under
-  2026.0.0 (`PROFILES_REQUIRING_PERIOD_END`). The field is optional on `Period` itself, because
-  one model serves every profile version; the version that decides is the one the submission
-  declares.
+- Profile 1.0.9, shipped by package 2026.0.0, relaxed both provision `period.end` elements from
+  1..1 to 0..1. FHIR reads a period with no `end` as still running, so such a permission never
+  expires. Profile 1.0.8, shipped by every 2025 package, still requires an `end`, so an open-ended
+  period is **rejected under those `schemaVersion`s** (`PROFILES_REQUIRING_PERIOD_END`). It is
+  accepted under 2026.0.0, and also when the submission declares no `schemaVersion` at all, which
+  metadata 1.3 permits: with no package named there is no profile to enforce. The field stays
+  optional on `Period` itself, because one model serves every profile version; the version that
+  decides is the one the submission declares.
 
 Unknown fields are generally ignored (FHIR resources carry much more than we read), **except**
 where ignoring would silently drop a permission the evaluation never looks at: a `code` on the
@@ -160,5 +164,5 @@ research consent. That is why `ResearchConsentCodes` contains both.
 
 Every assumption above (the OID classification, the research codes' existence and hierarchy, the
 profile's cardinalities and prohibitions) is re-checked against the MII's own artefacts, vendored
-in `example_terminology/` of `grz-pydantic-models-testing`. Its README describes the
-package-to-artefact mapping and the update workflow.
+in `example_terminology/` of `grz-pydantic-models-testing`. Its `packages.json` records which
+package ships which artefact version, and its README describes the update workflow.

--- a/packages/grz-pydantic-models/docs/mii-consent.md
+++ b/packages/grz-pydantic-models/docs/mii-consent.md
@@ -101,7 +101,12 @@ Two quirks worth knowing:
 - The MII renamed the category CodeSystem at one point but kept shipping examples in the old
   spelling, so **both spellings are in the wild and both are accepted**
   (`MII_CONSENT_CATEGORY_SYSTEMS`).
-- Newer profiles allow a `period` without an `end`: such a period never expires.
+- Profile 1.0.9, shipped by package 2026.0.0, allows a `period` without an `end`, and such a
+  period never expires. Profile 1.0.8, shipped by every 2025 package, still requires an `end`, so
+  an open-ended period is **rejected under those `schemaVersion`s** and accepted only under
+  2026.0.0 (`PROFILES_REQUIRING_PERIOD_END`). The field is optional on `Period` itself, because
+  one model serves every profile version; the version that decides is the one the submission
+  declares.
 
 Unknown fields are generally ignored (FHIR resources carry much more than we read), **except**
 where ignoring would silently drop a permission the evaluation never looks at: a `code` on the

--- a/packages/grz-pydantic-models/docs/mii-consent.md
+++ b/packages/grz-pydantic-models/docs/mii-consent.md
@@ -1,0 +1,156 @@
+# MII research consent, explained
+
+A donor signs a consent form on paper: the **MII broad consent** ("breite Einwilligung" of the
+Medizininformatik-Initiative). The hospital records that decision in its consent management
+system, which exports it as a **FHIR `Consent` resource**. A GRZ submission carries that resource
+inside `researchConsents[].scope`, and this package answers two questions about it:
+
+1. **Is it well-formed?** Does it follow the MII's FHIR specification (validation)?
+2. **What does it say?** May the donor's data be used for research at a given date (evaluation)?
+
+Current version numbers live in the code constants and in the `example_terminology` README of
+`grz-pydantic-models-testing`.
+
+## Glossary
+
+| Term | In one sentence |
+| --- | --- |
+| MII broad consent | The standardized consent form a donor signs, allowing broad research use of their data. Exists in several document versions. |
+| KDS consent package | The MII's FHIR package (`de.medizininformatikinitiative.kerndatensatz.consent`) that defines how to represent such a consent digitally ([registry](https://packages2.fhir.org/packages/de.medizininformatikinitiative.kerndatensatz.consent)). |
+| Profile | The rulebook inside the package (`MII_PR_Consent_Einwilligung`): which fields a Consent resource must/may have. |
+| Policy CodeSystem | The catalogue of **permissions** ("use data scientifically", "contact again", …), one OID each, organized as modules with sub-items. |
+| Version & modules CodeSystem | The catalogue of **signable documents** (each broad consent version, withdrawal forms, additional modules), one OID each. |
+| GRZ metadata schema | BfArM's format for the whole submission; `researchConsents[]` is one small part of it. |
+
+## A consent, annotated
+
+```jsonc
+{
+  "resourceType": "Consent",
+  "status": "active",              // modifier: anything else means "not in force"
+  "scope": { "coding": [ { "system": ".../consentscope", "code": "research" } ] },
+  "category": [
+    { "coding": [ { "system": "http://loinc.org", "code": "57016-8" } ] },
+    { "coding": [ { /* the MII broad consent category */ } ] }
+  ],
+  "patient": { "reference": "Patient/..." },     // or an identifier with system + value
+  "dateTime": "2020-09-01",
+  "policy": [
+    { "uri": "urn:oid:2.16.840.1.113883.3.1937.777.24.2.184" }
+    // ^ WHICH document was signed (an OID from the version & modules CodeSystem)
+  ],
+  "provision": {                   // root provision: the opt-in frame
+    "type": "deny",                // nothing is allowed unless a nested rule permits it
+    "period": { "start": "2020-09-01", "end": "2050-08-31" },   // bounds ALL nested rules
+    "provision": [                 // the actual decisions, one per permission (group)
+      {
+        "type": "permit",
+        "period": { "start": "2020-09-01", "end": "2025-08-31" },
+        "code": [ { "coding": [ {
+          "code": "2.16.840.1.113883.3.1937.777.24.5.3.1"
+          // ^ WHAT is permitted (an OID from the policy CodeSystem)
+        } ] } ]
+      }
+    ]
+  }
+}
+```
+
+Two different OID catalogues meet here, and telling them apart is the key to everything else:
+
+- `policy[].uri` says **which document** the donor signed → version & modules CodeSystem.
+- `provision.provision[].code` says **what the donor allowed or refused** → policy CodeSystem.
+
+## Four version numbers that mean different things
+
+| Version of… | Where you see it | Source of truth in this repo |
+| --- | --- | --- |
+| the GRZ metadata schema | `$schema` URL of the submission | `is_supported_version`, `get_accepted_versions` |
+| the KDS consent package | `researchConsents[].schemaVersion` | `RESEARCH_CONSENT_SCHEMA_VERSIONS` |
+| each artefact inside the package (profile, CodeSystems) | inside the package files | `example_terminology/` file names + its README's mapping table |
+| the signed broad consent document | OIDs in `Consent.policy[].uri` | `BroadConsentVersion`, `BROAD_CONSENT_DOCUMENT_OIDS` |
+
+None of these implies another. The classic trap: **`schemaVersion` names the KDS package (the
+digital format), not the document the donor signed.** Which broad consent version the donor
+actually signed is derived from the policy OIDs (`Consent.broad_consent_versions`).
+
+Two facts that follow from the axes moving independently:
+
+- Most package releases only grow the terminology and leave the profile untouched, so one and the
+  same Consent stays valid under every accepted `schemaVersion` (a test asserts this).
+- The GRZ metadata schema sometimes lists a package version before the MII has released it; such
+  versions stay rejected until the release exists and its artefacts are vendored.
+
+## Question 1: is it well-formed?
+
+The model (`grz_pydantic_models/mii/consent.py`) enforces what the profile pins:
+
+| Element | Rule |
+| --- | --- |
+| `status` | required; only `active` marks the consent as in force |
+| `scope` | exactly one coding, and it must be `research` |
+| `category` | must contain the LOINC consent category and the MII broad consent category, one coding each; extra categories are allowed (open slicing) |
+| `patient` | must identify the patient: reference or identifier (identifier needs `system` + `value`) |
+| `policy` | at least one document OID, with or without the `urn:oid:` prefix |
+| `provision` (root) | `type` must be `deny` (opt-in), `period` required, `code` forbidden |
+| `provision.provision[]` | the decisions: `type`, `period`, at least one `code` |
+| a third provision level | forbidden |
+
+Two quirks worth knowing:
+
+- The MII renamed the category CodeSystem at one point but kept shipping examples in the old
+  spelling, so **both spellings are in the wild and both are accepted**
+  (`MII_CONSENT_CATEGORY_SYSTEMS`).
+- Newer profiles allow a `period` without an `end`: such a period never expires.
+
+Unknown fields are generally ignored (FHIR resources carry much more than we read), **except**
+where ignoring would silently drop a permission the evaluation never looks at: a `code` on the
+root provision, a third provision level, a wrong `resourceType`, an unidentified patient. Those
+are rejected so the submitter notices.
+
+## Question 1b: what was signed?
+
+Every OID the MII ships in the version & modules CodeSystem is classified in
+`BROAD_CONSENT_DOCUMENT_OIDS` as one of:
+
+- **consent**: the broad consent itself, per document version (incl. minor / legal-guardian variants)
+- **rejection**: the donor refused (Ablehnung)
+- **complete withdrawal**: everything revoked (Komplettwiderruf)
+- **partial withdrawal**: parts revoked (Teilwiderruf)
+- **additional module**: an add-on to the broad consent (Zusatzmodul)
+
+An OID we do not recognize (e.g. a future broad consent version) is **reported, never rejected**
+(`unknown_document_oids`): new document versions must not break submissions.
+
+## Question 2: does the donor consent to research?
+
+Research use requires one specific permission from the policy CodeSystem, and that catalogue is
+hierarchical: permissions live inside modules:
+
+```text
+…24.5.3.1  "PATDAT erheben, speichern, nutzen"      ← the module
+└── …24.5.3.8  "MDAT wissenschaftlich nutzen"       ← the permission research needs
+```
+
+Permitting the module includes everything inside it, so **either** OID being permitted grants
+research consent. That is why `ResearchConsentCodes` contains both.
+
+`consents_to_research(consents, date)` then applies these rules:
+
+1. A consent whose root provision period does not contain `date` contributes nothing, since the root
+   deny frame bounds every nested rule. Same for each nested provision's own period.
+2. Codes are matched on the OID alone, because the surrounding `system` is written
+   inconsistently in the wild (with and without `urn:oid:`).
+3. **Deny wins.** A permit of either research code grants, but a deny on either revokes, also
+   across multiple consents of the same donor. So a partial withdrawal that denies `…5.3.8`
+   revokes research use even while the module permit still stands.
+4. Date-only period bounds cover the whole day (a start begins at midnight, an end expires at the
+   end of that day); datetimes without a timezone are read as UTC.
+5. A consent that states neither research code grants nothing: silence is not consent.
+
+## How this stays correct over time
+
+Every assumption above (the OID classification, the research codes' existence and hierarchy, the
+profile's cardinalities and prohibitions) is re-checked against the MII's own artefacts, vendored
+in `example_terminology/` of `grz-pydantic-models-testing`. Its README describes the
+package-to-artefact mapping and the update workflow.

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
@@ -68,9 +68,9 @@ def _date_to_datetime(value: Any, time_of_day: time) -> Any:
 
 class Period(FhirElement):
     start: datetime
-    #: Optional here because profile 1.0.9 relaxed it and one model serves every profile version:
-    #: a period without an end never expires. ResearchConsent rejects one under the declared
-    #: schemaVersions whose profile still pins the end to 1..1.
+    #: Optional because one model serves every profile version and 1.0.9 relaxed this to 0..1. FHIR
+    #: reads a period without an end as still running, so ResearchConsent rejects one when the
+    #: declared schemaVersion ships a profile that still pins the end to 1..1.
     end: datetime | None = None
 
     # FHIR reads a date-only bound as the whole day: a start begins at midnight, an end expires
@@ -231,7 +231,7 @@ class ConsentDocumentKind(StrEnum):
     ADDITIONAL_MODULE = "additional module"
 
 
-#: What each code of the version and module CodeSystem declares. These OIDs identify the signed
+#: What each code of the version and modules CodeSystem declares. These OIDs identify the signed
 #: document and appear as Consent.policy[].uri, unlike schemaVersion, which names the KDS package.
 #: Unknown OIDs are reported, never rejected: a future broad consent version must not break
 #: submissions.
@@ -338,7 +338,10 @@ class Consent(StrictIgnoringBaseModel):
 
     @property
     def document_oids(self) -> frozenset[str]:
-        """Bare OIDs identifying the signed documents, from policy URIs and version/module categories."""
+        """
+        Bare OIDs identifying the signed documents, from policy URIs and from category codings in
+        the version and modules CodeSystem.
+        """
         from_policies = {_strip_oid_prefix(policy.uri) for policy in self.policy}
         from_categories = {
             coding.code
@@ -350,7 +353,7 @@ class Consent(StrictIgnoringBaseModel):
 
     @property
     def _known_documents(self) -> tuple[tuple[ConsentDocumentKind, BroadConsentVersion | None], ...]:
-        """The (kind, version) pairs of those document OIDs the version and module CodeSystem defines."""
+        """The (kind, version) pairs of those document OIDs the version and modules CodeSystem defines."""
         return tuple(
             BROAD_CONSENT_DOCUMENT_OIDS[oid] for oid in self.document_oids if oid in BROAD_CONSENT_DOCUMENT_OIDS
         )
@@ -368,7 +371,7 @@ class Consent(StrictIgnoringBaseModel):
     @property
     def unknown_document_oids(self) -> frozenset[str]:
         """
-        OIDs that are not part of the known version and module CodeSystem, e.g. a newer broad consent.
+        OIDs that are not part of the known version and modules CodeSystem, e.g. a newer broad consent.
 
         Policy URIs that are no OIDs at all are reported here unchanged.
         """

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
@@ -325,6 +325,16 @@ class Consent(StrictIgnoringBaseModel):
         return self
 
     @property
+    def is_in_force(self) -> bool:
+        """
+        Whether the consent's status marks it as currently valid.
+
+        Consent.status is a FHIR modifier element: every status other than 'active' marks the consent
+        as not in force, so its provisions must not be read as permissions.
+        """
+        return self.status == Status.ACTIVE
+
+    @property
     def document_oids(self) -> frozenset[str]:
         """Bare OIDs identifying the signed documents, from policy URIs and version/module categories."""
         from_policies = {_strip_oid_prefix(policy.uri) for policy in self.policy}

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
@@ -202,12 +202,12 @@ class Verification(StrictIgnoringBaseModel):
 EXPECTED_SCOPE_CODING_SYSTEM = "http://terminology.hl7.org/CodeSystem/consentscope"
 EXPECTED_SCOPE_CODING_CODE = "research"
 MII_BROAD_CONSENT_OID = "2.16.840.1.113883.3.1937.777.24.2.184"
-#: OIDs of the broad consent versions and additional modules, introduced in package 2026.0.0.
+# OIDs of the broad consent versions and additional modules, introduced in package 2026.0.0.
 MII_CONSENT_VERSION_MODULES_SYSTEM = (
     "https://www.medizininformatik-initiative.de/fhir/modul-consent/CodeSystem/mii-cs-consent-version-modules"
 )
-#: The category CodeSystem was renamed in package version 2026.0.0, but that package's own
-#: examples still use the old spelling, so both are in the wild.
+# The category CodeSystem was renamed in package version 2026.0.0, but that package's own
+# examples still use the old spelling, so both are in the wild.
 MII_CONSENT_CATEGORY_SYSTEMS = (
     "https://www.medizininformatik-initiative.de/fhir/modul-consent/CodeSystem/mii-cs-consent-consent_category",
     MII_CONSENT_VERSION_MODULES_SYSTEM,
@@ -229,22 +229,26 @@ class BroadConsentVersion(StrEnum):
 class ConsentDocumentKind(StrEnum):
     """What a broad consent document declares."""
 
-    #: Consent to the broad consent itself.
     CONSENT = "consent"
-    #: Refusal of the broad consent (Ablehnung).
+    """Consent to the broad consent itself."""
+
     REJECTION = "rejection"
-    #: Withdrawal of the entire broad consent (Komplettwiderruf).
+    """Refusal of the broad consent (Ablehnung)."""
+
     COMPLETE_WITHDRAWAL = "complete withdrawal"
-    #: Withdrawal of parts of the broad consent (Teilwiderruf).
+    """Withdrawal of the entire broad consent (Komplettwiderruf)."""
+
     PARTIAL_WITHDRAWAL = "partial withdrawal"
-    #: An additional module on top of the broad consent (Zusatzmodul).
+    """Withdrawal of parts of the broad consent (Teilwiderruf)."""
+
     ADDITIONAL_MODULE = "additional module"
+    """An additional module on top of the broad consent (Zusatzmodul)."""
 
 
-#: What each code of the version and modules CodeSystem declares. These OIDs identify the signed
-#: document and appear as Consent.policy[].uri, unlike schemaVersion, which names the KDS package.
-#: Unknown OIDs are reported, never rejected: a future broad consent version must not break
-#: submissions.
+# What each code of the version and modules CodeSystem declares. These OIDs identify the signed
+# document and appear as Consent.policy[].uri, unlike schemaVersion, which names the KDS package.
+# Unknown OIDs are reported, never rejected: a future broad consent version must not break
+# submissions.
 BROAD_CONSENT_DOCUMENT_OIDS: dict[str, tuple[ConsentDocumentKind, BroadConsentVersion | None]] = {
     MII_BROAD_CONSENT_OID: (ConsentDocumentKind.CONSENT, None),
     "2.16.840.1.113883.3.1937.777.24.2.1790": (ConsentDocumentKind.CONSENT, BroadConsentVersion.V1_6D),

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
@@ -68,7 +68,9 @@ def _date_to_datetime(value: Any, time_of_day: time) -> Any:
 
 class Period(FhirElement):
     start: datetime
-    #: Optional since MII consent package 2026.0.0: a period without an end never expires.
+    #: Optional here because profile 1.0.9 relaxed it and one model serves every profile version:
+    #: a period without an end never expires. ResearchConsent rejects one under the declared
+    #: schemaVersions whose profile still pins the end to 1..1.
     end: datetime | None = None
 
     # FHIR reads a date-only bound as the whole day: a start begins at midnight, an end expires

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
@@ -68,10 +68,12 @@ def _date_to_datetime(value: Any, time_of_day: time) -> Any:
 
 class Period(FhirElement):
     start: datetime
-    #: Optional because one model serves every profile version and 1.0.9 relaxed this to 0..1. FHIR
-    #: reads a period without an end as still running, so ResearchConsent rejects one when the
-    #: declared schemaVersion ships a profile that still pins the end to 1..1.
     end: datetime | None = None
+    """
+    Optional because one model serves every profile version and 1.0.9 relaxed this to 0..1. FHIR
+    reads a period without an end as still running, so ResearchConsent rejects one when the declared
+    schemaVersion ships a profile that still pins the end to 1..1.
+    """
 
     # FHIR reads a date-only bound as the whole day: a start begins at midnight, an end expires
     # at the end of that day.
@@ -133,8 +135,10 @@ class ConsentProvision(StrictIgnoringBaseModel):
     type: ProvisionType
     period: Period
     code: Annotated[list[CodeableConcept], Field(min_length=1)]
-    #: Forbidden by the profile (0..0), and rejected rather than ignored: evaluation never reads it.
     provision: list[Any] | None = None
+    """
+    Forbidden by the profile (0..0), and rejected rather than ignored: evaluation never reads it.
+    """
 
     @model_validator(mode="after")
     def reject_nested_provision(self):
@@ -148,11 +152,17 @@ class ConsentProvision(StrictIgnoringBaseModel):
 
 class RootConsentProvision(StrictIgnoringBaseModel):
     type: ProvisionType
-    #: Required by every profile version; only its end became optional in profile 1.0.9.
     period: Period
+    """
+    Required by every profile version; only its end became optional in profile 1.0.9.
+    """
+
     provision: list[ConsentProvision] = Field(default_factory=list)
-    #: The profile constrains Consent.provision.code to 0..0; permissions belong on the sub-provisions.
+
     code: list[Any] | None = None
+    """
+    The profile constrains Consent.provision.code to 0..0; permissions belong on the sub-provisions.
+    """
 
     @model_validator(mode="after")
     def reject_root_code(self):

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -415,7 +415,9 @@ class ResearchConsent(StrictBaseModel):
             # the scope fell back to dict, so nothing can be read from it
             return code2consent
 
-        if self.scope.provision is None:
+        # Consent.status is a modifier element: a consent that is not in force grants nothing,
+        # no matter what its provisions say.
+        if not self.scope.is_in_force or self.scope.provision is None:
             return code2consent
 
         # the root provision frames every nested rule: outside its period, none of them applies

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -26,7 +26,7 @@ from pydantic import (
 from pydantic.json_schema import GenerateJsonSchema
 
 from ...common import StrictBaseModel, as_aware_datetime
-from ...mii.consent import BroadConsentVersion, Consent, ProvisionType
+from ...mii.consent import BroadConsentVersion, Consent, ProvisionType, Status
 from .. import thresholds as thresholds_model
 from .versioning import Version
 
@@ -385,6 +385,19 @@ class ResearchConsent(StrictBaseModel):
                         f"Validation error of type '{error['type']}' at location '{'.'.join(str(l) for l in error['loc'])}': {error['msg']}"
                     )
 
+        return self
+
+    @model_validator(mode="after")
+    def warn_when_not_in_force(self):
+        """
+        A status other than active is easy to state by mistake, and otherwise surfaces only as a
+        consented flag reading False.
+        """
+        if isinstance(self.scope, Consent) and not self.scope.is_in_force:
+            log.warning(
+                f"Research consent has status '{self.scope.status}' rather than '{Status.ACTIVE}', "
+                "so it grants nothing regardless of its provisions."
+            )
         return self
 
     @staticmethod

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -288,11 +288,11 @@ class MvConsent(StrictBaseModel):
     """
 
 
-#: MII "Modul Consent" package versions the Consent model is checked against, in publication order,
-#: each mapped to the version of MII_PR_Consent_Einwilligung it ships. The profile version
-#: decides which cardinalities apply, so a package cannot be accepted without naming its profile.
-#: GRZ metadata schema 1.3.1 also lists 2026.0.1, which the MII has not released; add it here once it
-#: is, together with its artefacts in example_terminology.
+# MII "Modul Consent" package versions the Consent model is checked against, in publication order,
+# each mapped to the version of MII_PR_Consent_Einwilligung it ships. The profile version
+# decides which cardinalities apply, so a package cannot be accepted without naming its profile.
+# GRZ metadata schema 1.3.1 also lists 2026.0.1, which the MII has not released; add it here once it
+# is, together with its artefacts in example_terminology.
 RESEARCH_CONSENT_PACKAGE_PROFILES = {
     "2025.0.1": "1.0.8",
     "2025.0.2": "1.0.8",
@@ -303,10 +303,10 @@ RESEARCH_CONSENT_PACKAGE_PROFILES = {
 
 RESEARCH_CONSENT_SCHEMA_VERSIONS = tuple(RESEARCH_CONSENT_PACKAGE_PROFILES)
 
-#: Profile versions pinning both provision periods' end to 1..1. Profile 1.0.9 relaxed it to 0..1,
-#: so only there may a period stay open-ended. A profile absent from this set is taken not to
-#: require an end, so a future profile that re-tightens the bound has to be added here;
-#: test_model_matches_the_profile fails against the vendored artefacts until it is.
+# Profile versions pinning both provision periods' end to 1..1. Profile 1.0.9 relaxed it to 0..1,
+# so only there may a period stay open-ended. A profile absent from this set is taken not to
+# require an end, so a future profile that re-tightens the bound has to be added here;
+# test_model_matches_the_profile fails against the vendored artefacts until it is.
 PROFILES_REQUIRING_PERIOD_END = frozenset({"1.0.8"})
 
 
@@ -319,7 +319,7 @@ def _validate_research_consent_schema_version(value: str) -> str:
     return value
 
 
-#: Restated for JSON Schema, which cannot express a validator and would export a bare string.
+# Restated for JSON Schema, which cannot express a validator and would export a bare string.
 ResearchConsentSchemaVersion = Annotated[
     str,
     AfterValidator(_validate_research_consent_schema_version),

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -288,10 +288,24 @@ class MvConsent(StrictBaseModel):
     """
 
 
-#: MII "Modul Consent" package versions the Consent model is checked against, in publication order.
+#: MII "Modul Consent" package versions the Consent model is checked against, in publication order,
+#: each mapped to the version of Profile_MII_Consent_Einwilligung it ships. The profile version
+#: decides which cardinalities apply, so a package cannot be accepted without naming its profile.
 #: GRZ metadata schema 1.3.1 also lists 2026.0.1, which the MII has not released; add it here once it
 #: is, together with its artefacts in example_terminology.
-RESEARCH_CONSENT_SCHEMA_VERSIONS = ("2025.0.1", "2025.0.2", "2025.0.3", "2025.0.4", "2026.0.0")
+RESEARCH_CONSENT_PACKAGE_PROFILES = {
+    "2025.0.1": "1.0.8",
+    "2025.0.2": "1.0.8",
+    "2025.0.3": "1.0.8",
+    "2025.0.4": "1.0.8",
+    "2026.0.0": "1.0.9",
+}
+
+RESEARCH_CONSENT_SCHEMA_VERSIONS = tuple(RESEARCH_CONSENT_PACKAGE_PROFILES)
+
+#: Profile versions pinning both provision periods' end to 1..1. Profile 1.0.9 relaxed it to 0..1,
+#: so only there may a period stay open-ended.
+PROFILES_REQUIRING_PERIOD_END = frozenset({"1.0.8"})
 
 
 def _validate_research_consent_schema_version(value: str) -> str:
@@ -397,6 +411,33 @@ class ResearchConsent(StrictBaseModel):
             log.warning(
                 f"Research consent has status '{self.scope.status}' rather than '{Status.ACTIVE}', "
                 "so it grants nothing regardless of its provisions."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def ensure_period_end_where_the_profile_requires_it(self):
+        """
+        Reject an open-ended period under a package whose profile pins the period end to 1..1.
+
+        A period without an end never expires, so honouring one where the profile demands an end
+        would grant indefinitely a permission that was written to run out.
+        """
+        if self.schema_version is None or not isinstance(self.scope, Consent):
+            return self
+
+        profile = RESEARCH_CONSENT_PACKAGE_PROFILES[self.schema_version]
+        if profile not in PROFILES_REQUIRING_PERIOD_END or self.scope.provision is None:
+            return self
+
+        root = self.scope.provision
+        periods = [("provision.period", root.period)]
+        periods += [
+            (f"provision.provision[{index}].period", nested.period) for index, nested in enumerate(root.provision)
+        ]
+        if open_ended := [name for name, period in periods if period.end is None]:
+            raise ValueError(
+                f"researchConsent schemaVersion {self.schema_version} ships MII consent profile {profile}, "
+                f"which requires an end on every provision period; missing on {', '.join(open_ended)}"
             )
         return self
 

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -289,7 +289,7 @@ class MvConsent(StrictBaseModel):
 
 
 #: MII "Modul Consent" package versions the Consent model is checked against, in publication order,
-#: each mapped to the version of Profile_MII_Consent_Einwilligung it ships. The profile version
+#: each mapped to the version of MII_PR_Consent_Einwilligung it ships. The profile version
 #: decides which cardinalities apply, so a package cannot be accepted without naming its profile.
 #: GRZ metadata schema 1.3.1 also lists 2026.0.1, which the MII has not released; add it here once it
 #: is, together with its artefacts in example_terminology.
@@ -304,7 +304,9 @@ RESEARCH_CONSENT_PACKAGE_PROFILES = {
 RESEARCH_CONSENT_SCHEMA_VERSIONS = tuple(RESEARCH_CONSENT_PACKAGE_PROFILES)
 
 #: Profile versions pinning both provision periods' end to 1..1. Profile 1.0.9 relaxed it to 0..1,
-#: so only there may a period stay open-ended.
+#: so only there may a period stay open-ended. A profile absent from this set is taken not to
+#: require an end, so a future profile that re-tightens the bound has to be added here;
+#: test_model_matches_the_profile fails against the vendored artefacts until it is.
 PROFILES_REQUIRING_PERIOD_END = frozenset({"1.0.8"})
 
 
@@ -421,6 +423,9 @@ class ResearchConsent(StrictBaseModel):
 
         A period without an end never expires, so honouring one where the profile demands an end
         would grant indefinitely a permission that was written to run out.
+
+        A submission declaring no schemaVersion, which metadata 1.3 permits, names no package and
+        therefore no profile, so nothing is enforced here.
         """
         if self.schema_version is None or not isinstance(self.scope, Consent):
             return self

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -51,7 +51,9 @@ class ResearchConsentCodes(StrEnum):
     """
     Permissions consent to research is derived from. Neither has been retired by the MII.
 
-    A consent must state at least one of them and permit every one it states; see
+    Research use needs MDAT_WISSENSCHAFTLICH_NUTZEN_EU_DSGVO_NIVEAU, which the MII policy
+    CodeSystem places inside the PATDAT_ERHEBEN_SPEICHERN_NUTZEN module, so permitting the module
+    grants it as well. Either permit therefore suffices, while a deny on either revokes; see
     ``ResearchConsent.consents_to_research``.
 
     Matched on the OID alone: OIDs are globally unique, while the policy system is stated

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -1129,7 +1129,10 @@ def test_every_recorded_package_artefact_is_vendored():
 
 
 def test_research_consent_schema_version_json_schema_states_the_accepted_versions():
-    """The exported schema must state the accepted versions, to agree with the GRZ metadata schema."""
+    """
+    The published schema constrains schemaVersion only through the restated enum, so a dropped
+    restatement leaves it an unconstrained string.
+    """
     schema = GrzSubmissionMetadata.model_json_schema()
     # the field is optional, so pydantic wraps the declared schema in an anyOf with null
     schema_version = schema["$defs"]["ResearchConsent"]["properties"]["schemaVersion"]

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -787,6 +787,23 @@ def test_consent_in_force_still_grants():
     assert ResearchConsent.consents_to_research([research_consent], date=date(year=2024, month=1, day=1))
 
 
+def test_consent_not_in_force_warns(caplog):
+    """A status that refuses is easy to state by mistake, and otherwise shows up only as a False flag."""
+    consent_raw = _consent_raw("minimal_consented")
+    consent_raw["status"] = "rejected"
+
+    ResearchConsent(schemaVersion="2026.0.0", scope=Consent.model_validate(consent_raw))
+
+    assert "status 'rejected'" in caplog.text
+    assert "grants nothing" in caplog.text
+
+
+def test_consent_in_force_does_not_warn(caplog):
+    """A warning on every valid consent would train submitters to ignore it."""
+    ResearchConsent(schemaVersion="2026.0.0", scope=_consent("minimal_consented"))
+    assert "grants nothing" not in caplog.text
+
+
 @pytest.mark.parametrize("case", ("withdrawal_complete", "rejection_bc_v1_7_2", "status_rejected"))
 def test_withdrawal_and_rejection_do_not_consent_to_research(case: str):
     research_consent = ResearchConsent(schemaVersion="2026.0.0", scope=_consent(case))

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -651,25 +651,21 @@ _VERSIONS_REQUIRING_PERIOD_END = tuple(
     for version, profile in RESEARCH_CONSENT_PACKAGE_PROFILES.items()
     if profile in PROFILES_REQUIRING_PERIOD_END
 )
+# derived from the mapping under test, so an emptied mapping would silently leave nothing to run
+assert _VERSIONS_REQUIRING_PERIOD_END, "no accepted package ships a profile requiring a period end"
 
 
 @pytest.mark.parametrize("version", _VERSIONS_REQUIRING_PERIOD_END)
 def test_open_ended_period_rejected_where_the_profile_requires_an_end(version: str):
-    """A period without an end never expires, so honouring one would outlive what the donor signed."""
-    with pytest.raises(ValidationError, match="requires an end on every provision period"):
+    """
+    A period without an end never expires, so honouring one would outlive what the donor signed.
+
+    The submitter has to be told which periods to fix, not only that one of them is wrong.
+    """
+    with pytest.raises(ValidationError) as excinfo:
         ResearchConsent(schemaVersion=version, scope=_consent("minimal_consented_open_ended"))
 
-
-def test_open_ended_period_error_names_every_offending_period():
-    """The submitter has to be told which periods to fix, not only that one of them is wrong."""
-    consent_raw = _consent_raw("minimal_consented")
-    del consent_raw["provision"]["period"]["end"]
-    for provision in consent_raw["provision"]["provision"]:
-        del provision["period"]["end"]
-
-    with pytest.raises(ValidationError) as excinfo:
-        ResearchConsent(schemaVersion="2025.0.1", scope=Consent.model_validate(consent_raw))
-
+    assert "requires an end on every provision period" in str(excinfo.value)
     assert "provision.period" in str(excinfo.value)
     assert "provision.provision[0].period" in str(excinfo.value)
 
@@ -1033,11 +1029,6 @@ def _concept_subtree(nodes: list[dict], code: str) -> dict | None:
     return None
 
 
-def _descendant_codes(node: dict) -> set[str]:
-    children = node.get("concept", [])
-    return {child["code"] for child in children} | {c for child in children for c in _descendant_codes(child)}
-
-
 @pytest.mark.parametrize("name", _vendored("mii-cs-consent-policy."))
 def test_scientific_use_stays_within_the_patdat_module(name: str):
     """
@@ -1047,7 +1038,7 @@ def test_scientific_use_stays_within_the_patdat_module(name: str):
     """
     module = _concept_subtree(_load_vendored(name)["concept"], ResearchConsentCodes.PATDAT_ERHEBEN_SPEICHERN_NUTZEN)
     assert module is not None, f"{name} does not define the PATDAT module"
-    assert ResearchConsentCodes.MDAT_WISSENSCHAFTLICH_NUTZEN_EU_DSGVO_NIVEAU in _descendant_codes(module)
+    assert ResearchConsentCodes.MDAT_WISSENSCHAFTLICH_NUTZEN_EU_DSGVO_NIVEAU in _codesystem_concepts(module)
 
 
 def _differential(profile: dict) -> dict[str, dict]:
@@ -1112,18 +1103,14 @@ def test_model_matches_the_profile(name: str):
 
 def test_recorded_and_vendored_artefacts_agree():
     """
-    Every vendored artefact must be accounted for by some package and every version a package
-    claims must be vendored. An artefact no package ships is checked against a version nothing
-    declares, and a package naming an absent one is checked against nothing at all.
+    A vendored file no package lists would have the model checked against a version no accepted
+    schemaVersion can select; a version a package lists but nothing vendors would leave that
+    package checked against no artefact at all.
     """
-    vendored: dict[str, set[str]] = {}
-    for name in _vendored("mii-"):
-        vendored.setdefault(_artefact_prefix(name), set()).add(_declared_version(name))
-
-    recorded: dict[str, set[str]] = {}
-    for artefacts in _package_manifest().values():
-        for prefix, version in artefacts.items():
-            recorded.setdefault(prefix, set()).add(version)
+    vendored = {(_artefact_prefix(name), _declared_version(name)) for name in _vendored("mii-")}
+    recorded = {
+        (prefix, version) for artefacts in _package_manifest().values() for prefix, version in artefacts.items()
+    }
 
     assert recorded == vendored
 

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -787,7 +787,7 @@ def test_consent_in_force_still_grants():
     assert ResearchConsent.consents_to_research([research_consent], date=date(year=2024, month=1, day=1))
 
 
-@pytest.mark.parametrize("case", ("withdrawal_complete", "rejection_bc_v1_7_2"))
+@pytest.mark.parametrize("case", ("withdrawal_complete", "rejection_bc_v1_7_2", "status_rejected"))
 def test_withdrawal_and_rejection_do_not_consent_to_research(case: str):
     research_consent = ResearchConsent(schemaVersion="2026.0.0", scope=_consent(case))
     assert not ResearchConsent.consents_to_research([research_consent], date=date(year=2024, month=1, day=1))

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -959,9 +959,14 @@ def _declared_version(name: str) -> str:
 
     Artefacts are named after their own resource version rather than the package that ships them:
     several packages ship the same CodeSystem or profile version, and the mapping between the two
-    is recorded in the directory README.
+    is recorded in packages.json.
     """
     return name.removesuffix(".json").split(".", 1)[1]
+
+
+def _artefact_prefix(name: str) -> str:
+    """The artefact a vendored file name claims, e.g. 'mii-cs-consent-policy.1.1.0.json' -> 'mii-cs-consent-policy'."""
+    return name.removesuffix(".json").split(".", 1)[0]
 
 
 def _codesystem_concepts(codesystem: dict) -> dict[str, dict[str, object]]:
@@ -1105,10 +1110,22 @@ def test_model_matches_the_profile(name: str):
     assert Identifier.model_fields["value"].is_required()
 
 
-def test_every_accepted_package_names_a_vendored_profile():
-    """A package mapped to a profile nobody vendored would be accepted against no cardinalities."""
-    vendored = {_declared_version(name) for name in _vendored("mii-pr-consent-einwilligung.")}
-    assert set(RESEARCH_CONSENT_PACKAGE_PROFILES.values()) == vendored
+def test_recorded_and_vendored_artefacts_agree():
+    """
+    Every vendored artefact must be accounted for by some package and every version a package
+    claims must be vendored. An artefact no package ships is checked against a version nothing
+    declares, and a package naming an absent one is checked against nothing at all.
+    """
+    vendored: dict[str, set[str]] = {}
+    for name in _vendored("mii-"):
+        vendored.setdefault(_artefact_prefix(name), set()).add(_declared_version(name))
+
+    recorded: dict[str, set[str]] = {}
+    for artefacts in _package_manifest().values():
+        for prefix, version in artefacts.items():
+            recorded.setdefault(prefix, set()).add(version)
+
+    assert recorded == vendored
 
 
 def test_accepted_packages_ship_the_profiles_the_model_assumes():
@@ -1119,13 +1136,6 @@ def test_accepted_packages_ship_the_profiles_the_model_assumes():
     """
     shipped = {package: artefacts["mii-pr-consent-einwilligung"] for package, artefacts in _package_manifest().items()}
     assert RESEARCH_CONSENT_PACKAGE_PROFILES == shipped
-
-
-def test_every_recorded_package_artefact_is_vendored():
-    """A package may only claim artefacts that are here for the model to be checked against."""
-    for package, artefacts in _package_manifest().items():
-        for prefix, version in artefacts.items():
-            assert f"{prefix}.{version}.json" in _vendored(prefix), f"{package} claims an unvendored {prefix}"
 
 
 def test_research_consent_schema_version_json_schema_states_the_accepted_versions():

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -950,6 +950,33 @@ def test_evaluated_policy_codes_are_active(name: str):
         assert not properties.get("inactive"), f"{code.value} is inactive in {name}"
 
 
+def _concept_subtree(nodes: list[dict], code: str) -> dict | None:
+    """The concept carrying ``code``, searched at any depth."""
+    for node in nodes:
+        if node["code"] == code:
+            return node
+        if (found := _concept_subtree(node.get("concept", []), code)) is not None:
+            return found
+    return None
+
+
+def _descendant_codes(node: dict) -> set[str]:
+    children = node.get("concept", [])
+    return {child["code"] for child in children} | {c for child in children for c in _descendant_codes(child)}
+
+
+@pytest.mark.parametrize("name", _vendored("mii-cs-consent-policy."))
+def test_scientific_use_stays_within_the_patdat_module(name: str):
+    """
+    consents_to_research accepts a permit of either research code alone. That is sound only while
+    the MII keeps the scientific-use permission a descendant of the PATDAT module, so that a permit
+    of the module subsumes it.
+    """
+    module = _concept_subtree(_load_vendored(name)["concept"], ResearchConsentCodes.PATDAT_ERHEBEN_SPEICHERN_NUTZEN)
+    assert module is not None, f"{name} does not define the PATDAT module"
+    assert ResearchConsentCodes.MDAT_WISSENSCHAFTLICH_NUTZEN_EU_DSGVO_NIVEAU in _descendant_codes(module)
+
+
 def _differential(profile: dict) -> dict[str, dict]:
     return {element["id"]: element for element in profile["differential"]["element"]}
 

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -386,7 +386,7 @@ def _consent(case: str) -> Consent:
     return Consent.model_validate(_consent_raw(case))
 
 
-#: Example consents the MII consent profile permits; each must parse.
+# Example consents the MII consent profile permits; each must parse.
 VALID_CONSENT_CASES = (
     "minimal_consented",
     "minimal_consented_with_datetime",
@@ -412,7 +412,7 @@ VALID_CONSENT_CASES = (
     "rejection_bc_v1_7_2",
     "status_rejected",
 )
-#: Instances the MII consent profile forbids and whose contents would otherwise be dropped silently.
+# Instances the MII consent profile forbids and whose contents would otherwise be dropped silently.
 INVALID_CONSENT_CASES = (
     "invalid_missing_fields",
     "invalid_wrong_resource_type",

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -28,6 +28,8 @@ from grz_pydantic_models.submission.metadata import (
     get_accepted_versions,
 )
 from grz_pydantic_models.submission.metadata.v1 import (
+    PROFILES_REQUIRING_PERIOD_END,
+    RESEARCH_CONSENT_PACKAGE_PROFILES,
     RESEARCH_CONSENT_SCHEMA_VERSIONS,
     File,
     FileType,
@@ -644,6 +646,50 @@ def test_root_provision_period_caps_open_ended_sub_provisions():
     )
 
 
+_VERSIONS_REQUIRING_PERIOD_END = tuple(
+    version
+    for version, profile in RESEARCH_CONSENT_PACKAGE_PROFILES.items()
+    if profile in PROFILES_REQUIRING_PERIOD_END
+)
+
+
+@pytest.mark.parametrize("version", _VERSIONS_REQUIRING_PERIOD_END)
+def test_open_ended_period_rejected_where_the_profile_requires_an_end(version: str):
+    """A period without an end never expires, so honouring one would outlive what the donor signed."""
+    with pytest.raises(ValidationError, match="requires an end on every provision period"):
+        ResearchConsent(schemaVersion=version, scope=_consent("minimal_consented_open_ended"))
+
+
+def test_open_ended_period_error_names_every_offending_period():
+    """The submitter has to be told which periods to fix, not only that one of them is wrong."""
+    consent_raw = _consent_raw("minimal_consented")
+    del consent_raw["provision"]["period"]["end"]
+    for provision in consent_raw["provision"]["provision"]:
+        del provision["period"]["end"]
+
+    with pytest.raises(ValidationError) as excinfo:
+        ResearchConsent(schemaVersion="2025.0.1", scope=Consent.model_validate(consent_raw))
+
+    assert "provision.period" in str(excinfo.value)
+    assert "provision.provision[0].period" in str(excinfo.value)
+
+
+def test_open_ended_nested_period_alone_is_rejected():
+    """The profile pins the end at both levels, so a bounded root does not excuse an open nested one."""
+    consent_raw = _consent_raw("minimal_consented")
+    for provision in consent_raw["provision"]["provision"]:
+        del provision["period"]["end"]
+
+    with pytest.raises(ValidationError, match=r"provision\.provision\[0\]\.period"):
+        ResearchConsent(schemaVersion="2025.0.1", scope=Consent.model_validate(consent_raw))
+
+
+def test_open_ended_period_accepted_without_a_declared_schema_version():
+    """Metadata 1.3 onwards may omit the version, which leaves no profile to enforce."""
+    research_consent = ResearchConsent(scope=_consent("minimal_consented_open_ended"))
+    assert research_consent.scope.provision.period.end is None
+
+
 def test_research_consent_rejects_category_in_both_spellings():
     """The MII broad consent category must appear exactly once, even across both CodeSystem spellings."""
     consent_raw = _consent_raw("minimal_consented")
@@ -1028,10 +1074,15 @@ def test_model_matches_the_profile(name: str):
     assert elements["Consent.provision.code"]["max"] == "0"
     assert elements["Consent.provision.provision.provision"]["max"] == "0"
 
-    # a period bound the profile makes optional must not be required by the model, and vice versa
+    # the model must demand a period end exactly where the profile does, at both provision levels
+    requires_end = _declared_version(name) in PROFILES_REQUIRING_PERIOD_END
     for element_id in ("Consent.provision.period.end", "Consent.provision.provision.period.end"):
-        if elements[element_id]["min"] == 0:
-            assert not Period.model_fields["end"].is_required(), f"{name} makes {element_id} optional"
+        assert (elements[element_id]["min"] == 1) == requires_end, (
+            f"{name} and PROFILES_REQUIRING_PERIOD_END disagree on {element_id}"
+        )
+    # the field itself stays optional, since one model serves every profile version
+    assert not Period.model_fields["end"].is_required()
+
     for element_id in ("Consent.provision.period.start", "Consent.provision.provision.period.start"):
         assert elements[element_id]["min"] == 1
     assert Period.model_fields["start"].is_required()
@@ -1047,6 +1098,12 @@ def test_model_matches_the_profile(name: str):
         assert elements[element_id]["min"] == 1
     assert Identifier.model_fields["system"].is_required()
     assert Identifier.model_fields["value"].is_required()
+
+
+def test_every_accepted_package_names_a_vendored_profile():
+    """A package mapped to a profile nobody vendored would be accepted against no cardinalities."""
+    vendored = {_declared_version(name) for name in _vendored("mii-pr-consent-einwilligung.")}
+    assert set(RESEARCH_CONSENT_PACKAGE_PROFILES.values()) == vendored
 
 
 def test_research_consent_schema_version_json_schema_states_the_accepted_versions():

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -948,6 +948,11 @@ def _load_vendored(name: str) -> dict:
     return json.loads(importlib.resources.files(example_terminology).joinpath(name).read_text())
 
 
+def _package_manifest() -> dict[str, dict[str, str]]:
+    """Which version each artefact of a published package states, as the vendoring script recorded it."""
+    return json.loads(importlib.resources.files(example_terminology).joinpath("packages.json").read_text())
+
+
 def _declared_version(name: str) -> str:
     """
     The version a vendored file name claims, e.g. 'mii-cs-consent-policy.1.1.0.json' -> '1.1.0'.
@@ -1104,6 +1109,23 @@ def test_every_accepted_package_names_a_vendored_profile():
     """A package mapped to a profile nobody vendored would be accepted against no cardinalities."""
     vendored = {_declared_version(name) for name in _vendored("mii-pr-consent-einwilligung.")}
     assert set(RESEARCH_CONSENT_PACKAGE_PROFILES.values()) == vendored
+
+
+def test_accepted_packages_ship_the_profiles_the_model_assumes():
+    """
+    The profile a package ships decides which cardinalities apply, and it is stated by the package
+    rather than by the artefacts, which name only themselves. The mapping must repeat what the
+    vendoring script recorded, so that a newly released package cannot be classified from memory.
+    """
+    shipped = {package: artefacts["mii-pr-consent-einwilligung"] for package, artefacts in _package_manifest().items()}
+    assert RESEARCH_CONSENT_PACKAGE_PROFILES == shipped
+
+
+def test_every_recorded_package_artefact_is_vendored():
+    """A package may only claim artefacts that are here for the model to be checked against."""
+    for package, artefacts in _package_manifest().items():
+        for prefix, version in artefacts.items():
+            assert f"{prefix}.{version}.json" in _vendored(prefix), f"{package} claims an unvendored {prefix}"
 
 
 def test_research_consent_schema_version_json_schema_states_the_accepted_versions():

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -765,6 +765,28 @@ def test_research_consent_without_parsed_scope_has_no_broad_consent_version():
     assert research_consent.broad_consent_versions == frozenset()
 
 
+@pytest.mark.parametrize("status", ("draft", "proposed", "rejected", "inactive", "entered-in-error"))
+def test_consent_not_in_force_grants_nothing(status: str):
+    """
+    Consent.status is a FHIR modifier element: anything but 'active' marks the consent as not
+    currently valid, so its permit provisions must not be read as research consent.
+    """
+    consent_raw = _consent_raw("minimal_consented")
+    consent_raw["status"] = status
+    research_consent = ResearchConsent(schemaVersion="2026.0.0", scope=Consent.model_validate(consent_raw))
+
+    assert not research_consent.scope.is_in_force
+    assert research_consent.consent_by_code(date(year=2024, month=1, day=1)) == {}
+    assert not ResearchConsent.consents_to_research([research_consent], date=date(year=2024, month=1, day=1))
+
+
+def test_consent_in_force_still_grants():
+    """The status gate must not change the outcome for the active consents it guards."""
+    research_consent = ResearchConsent(schemaVersion="2026.0.0", scope=_consent("minimal_consented"))
+    assert research_consent.scope.is_in_force
+    assert ResearchConsent.consents_to_research([research_consent], date=date(year=2024, month=1, day=1))
+
+
 @pytest.mark.parametrize("case", ("withdrawal_complete", "rejection_bc_v1_7_2"))
 def test_withdrawal_and_rejection_do_not_consent_to_research(case: str):
     research_consent = ResearchConsent(schemaVersion="2026.0.0", scope=_consent(case))


### PR DESCRIPTION
`Consent.status` is a FHIR modifier element: `rejected`, `inactive`, `entered-in-error`, `draft` and `proposed` all mark a consent as not currently valid. Evaluation read only the provisions and ignored the status entirely, so a consent explicitly marked as rejected or withdrawn still reported the donor as consenting to research. Evaluation now grants nothing unless the status is `active`, and warns when a consent refuses through its status alone.

Also in this PR:
- grz-common and grz-db reuse the shared naive datetime coercion from grz-pydantic-models instead of carrying their own copies.
- `docs/mii-consent.md` explains how the MII consent artefacts (KDS package, profile, CodeSystems, broad consent documents) relate.
- A conformance test pins the policy-hierarchy assumption behind `ResearchConsentCodes`: deriving research consent from either code is sound only while the scientific-use permission stays inside the PATDAT module.
- A provision period without an `end` is now rejected under the 2025 packages, whose profile 1.0.8 pins both period ends to 1..1. It stays legal only under 2026.0.0, whose profile 1.0.9 relaxed the bound. Such a period never expires, so accepting one under 1.0.8 granted research indefinitely where the profile demanded an expiry.
- The vendoring script now records which artefact versions each MII consent package ships, in `example_terminology/packages.json`, and the package-to-profile mapping is checked against it. A package version appears nowhere inside the artefacts it ships, so that link previously rested on the README table alone, and a released package left unlisted would have been rejected as an unsupported `schemaVersion` with no test objecting.

Fixes: #641

Refs: #640

BREAKING CHANGE: ResearchConsent.consents_to_research, and with it the consented flag grz-db records for a submission, now returns False for every consent whose status is not active. Metadata that declares a 2025 researchConsent schemaVersion and leaves any provision period open-ended is now rejected rather than accepted.

fix(grz-common,grz-db): require grz-pydantic-models 3

fix(grz-pydantic-models-testing): require grz-pydantic-models 3
