### PR TITLE
feat(grz-db): ship reusable database fixtures for downstream tests

### DIFF
--- a/packages/grz-check/tests/test_python_bindings.py
+++ b/packages/grz-check/tests/test_python_bindings.py
@@ -65,10 +65,12 @@ def test_validate_fastq_gzip_raw_bytes() -> None:
     assert report.num_records == 2
 
 
-def test_validate_fastq_gzip_filelike_raw() -> None:
+def test_validate_fastq_gzip_filelike_raw(tmp_path: Path) -> None:
     """Passing a raw binary file handle to a .gz file — niffler decompresses transparently."""
-    gz_bytes = gzip.compress(FASTQ_BYTES)
-    report = grz_check.validate_fastq(io.BytesIO(gz_bytes))
+    gz = tmp_path / "reads.fastq.gz"
+    gz.write_bytes(gzip.compress(FASTQ_BYTES))
+    with open(gz, "rb") as handle:
+        report = grz_check.validate_fastq(handle)
     assert report.is_valid
     assert report.num_records == 2
 

--- a/packages/grz-cli/tests/test_submit.py
+++ b/packages/grz-cli/tests/test_submit.py
@@ -10,20 +10,27 @@ from pytest_mock import MockerFixture
 
 
 @pytest.fixture
-def stub_subcommands(mocker: MockerFixture) -> dict[str, object]:
+def stub_subcommands(mocker: MockerFixture):
     """Replace the subcommands ``submit`` invokes with no-op mocks.
 
     ``ctx.invoke`` accepts any callable when the target is not a click
     ``Command``, so swapping the module-level imports lets the real submit
     callback run end-to-end without executing real validation, encryption,
     or upload.
+
+    :returns: A parent mock recording every subcommand call, so their relative order is
+        observable. ``mock_calls`` names them, for example ``call.validate(...)``.
     """
     mocker.patch("grz_cli.commands.submit.check_version_and_exit_if_needed")
-    return {
-        "validate": mocker.patch("grz_cli.commands.submit.validate"),
-        "encrypt": mocker.patch("grz_cli.commands.submit.encrypt"),
-        "upload": mocker.patch("grz_cli.commands.submit.upload"),
-    }
+    recorder = mocker.MagicMock()
+    for name in ("validate", "encrypt", "upload"):
+        recorder.attach_mock(mocker.patch(f"grz_cli.commands.submit.{name}"), name)
+    return recorder
+
+
+def _called_subcommands(recorder) -> list[str]:
+    """Names of the subcommands *recorder* saw, in call order."""
+    return [call[0] for call in recorder.mock_calls]
 
 
 def _invoke_submit(*extra_args: str) -> click.testing.Result:
@@ -34,8 +41,9 @@ def _invoke_submit(*extra_args: str) -> click.testing.Result:
 def test_submit_runs_subcommands_in_order(
     s3_config_path: Path,
     submission_dir: Path,
-    stub_subcommands: dict[str, object],
+    stub_subcommands,
 ) -> None:
+    """Encrypting before validating, or uploading before encrypting, would ship bad data."""
     result = _invoke_submit(
         "--submission-dir",
         str(submission_dir),
@@ -44,16 +52,14 @@ def test_submit_runs_subcommands_in_order(
     )
 
     assert result.exit_code == 0, result.output
-    stub_subcommands["validate"].assert_called_once()
-    stub_subcommands["encrypt"].assert_called_once()
-    stub_subcommands["upload"].assert_called_once()
+    assert _called_subcommands(stub_subcommands) == ["validate", "encrypt", "upload"]
 
 
 def test_submit_accepts_multiple_config_files(
     tmp_path: Path,
     s3_config_path: Path,
     submission_dir: Path,
-    stub_subcommands: dict[str, object],
+    stub_subcommands,
 ) -> None:
     """Regression: repeated ``--config-file`` once produced a tuple that crashed config parsing."""
     override_path = tmp_path / "override.yaml"

--- a/packages/grz-cli/tests/test_submit.py
+++ b/packages/grz-cli/tests/test_submit.py
@@ -29,8 +29,13 @@ def stub_subcommands(mocker: MockerFixture):
 
 
 def _called_subcommands(recorder) -> list[str]:
-    """Names of the subcommands *recorder* saw, in call order."""
+    """Names of the subcommands ``recorder`` saw, in call order."""
     return [call[0] for call in recorder.mock_calls]
+
+
+def _subcommand_kwargs(recorder) -> dict[str, dict]:
+    """The keyword arguments each subcommand was called with, keyed by subcommand name."""
+    return {call[0]: call[2] for call in recorder.mock_calls}
 
 
 def _invoke_submit(*extra_args: str) -> click.testing.Result:
@@ -53,6 +58,29 @@ def test_submit_runs_subcommands_in_order(
 
     assert result.exit_code == 0, result.output
     assert _called_subcommands(stub_subcommands) == ["validate", "encrypt", "upload"]
+
+
+def test_submit_hands_each_subcommand_the_submission_it_was_given(
+    s3_config_path: Path,
+    submission_dir: Path,
+    stub_subcommands,
+) -> None:
+    """All three must act on the same directory, and encrypt must refuse to skip the validation logs."""
+    result = _invoke_submit(
+        "--submission-dir",
+        str(submission_dir),
+        "--config-file",
+        str(s3_config_path),
+    )
+    assert result.exit_code == 0, result.output
+
+    kwargs = _subcommand_kwargs(stub_subcommands)
+    assert {name: call["submission_dir"] for name, call in kwargs.items()} == {
+        "validate": submission_dir,
+        "encrypt": submission_dir,
+        "upload": submission_dir,
+    }
+    assert kwargs["encrypt"]["check_validation_logs"] is True, "submit must not encrypt unvalidated data"
 
 
 def test_submit_accepts_multiple_config_files(

--- a/packages/grz-db/pyproject.toml
+++ b/packages/grz-db/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "alembic[tz] >=1.16.1",
     "cryptography >=45.0.3,<49",
     "sqlmodel >=0.0.38",
-    "grz-pydantic-models >=2.7,<3",
+    "grz-pydantic-models >=3,<4",
     "psycopg[binary] ~=3.2"
 ]
 

--- a/packages/grz-db/pyproject.toml
+++ b/packages/grz-db/pyproject.toml
@@ -18,8 +18,15 @@ dependencies = [
     "alembic[tz] >=1.16.1",
     "cryptography >=45.0.3,<49",
     "sqlmodel >=0.0.38",
-    "grz-pydantic-models >=3,<4",
+    "grz-pydantic-models >=2.7,<3",
     "psycopg[binary] ~=3.2"
+]
+
+[project.optional-dependencies]
+# Fixtures in grz_db.testing, for downstream packages that provision a database in their tests.
+testing = [
+    "pytest",
+    "pytest-postgresql",
 ]
 
 

--- a/packages/grz-db/src/grz_db/testing.py
+++ b/packages/grz-db/src/grz_db/testing.py
@@ -14,16 +14,17 @@ Requires the ``testing`` extra. Import the fixtures into a ``conftest.py``::
         test_author,
     )
 
-The underscore-prefixed session fixtures are resolved by name at runtime, so they have to be
-imported too. Importing rather than declaring ``pytest_plugins`` is deliberate twice over: pytest
-only accepts that declaration in a conftest at the rootdir, and a rootdir declaration would load
-this module for every package in the workspace, including those whose environments have no
-pytest-postgresql. No ``pytest11`` entry point is registered for the same reason.
+The underscore-prefixed session fixtures are resolved by name at runtime, so they must be
+imported as well. They are imported rather than declared through ``pytest_plugins`` for two
+reasons: pytest only accepts that declaration in a conftest at the repository root, and a
+declaration there would load this module for every package in the workspace, including those
+that do not have pytest-postgresql installed. No ``pytest11`` entry point is registered for
+the same reason.
 
-Each database is cloned from a template migrated once per session, rather than migrated per test.
-The template is a real Alembic run because the partial unique indexes live in migrations rather
-than in the models, so a schema built from ``SQLModel.metadata.create_all`` would silently lack
-them.
+Each database is cloned from a template that is migrated once per session, rather than being migrated individually for each test.
+The template is created through a real Alembic migration run, ensuring that the test databases match the schema of the production databases.
+This is the same schema that the migrations are designed to build.
+Using ``SQLModel.metadata.create_all`` instead would create the schema based on the models as they are currently declared, which could lead to deviations from the actual production schema.
 """
 
 import itertools

--- a/packages/grz-db/src/grz_db/testing.py
+++ b/packages/grz-db/src/grz_db/testing.py
@@ -1,0 +1,208 @@
+"""Pytest fixtures for provisioning :class:`~grz_db.models.submission.SubmissionDb` databases.
+
+Requires the ``testing`` extra. Import the fixtures into a ``conftest.py``::
+
+    from grz_db.testing import (  # noqa: F401
+        _migrated_postgresql_template,
+        _migrated_sqlite_template,
+        _pg_test_dbnames,
+        db,
+        db_backend,
+        db_test_connection,
+        migrated_db_connection,
+        postgresql_proc,
+        test_author,
+    )
+
+The underscore-prefixed session fixtures are resolved by name at runtime, so they have to be
+imported too. Importing rather than declaring ``pytest_plugins`` is deliberate twice over: pytest
+only accepts that declaration in a conftest at the rootdir, and a rootdir declaration would load
+this module for every package in the workspace, including those whose environments have no
+pytest-postgresql. No ``pytest11`` entry point is registered for the same reason.
+
+Each database is cloned from a template migrated once per session, rather than migrated per test.
+The template is a real Alembic run because the partial unique indexes live in migrations rather
+than in the models, so a schema built from ``SQLModel.metadata.create_all`` would silently lack
+them.
+"""
+
+import itertools
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import psycopg
+import pytest
+import sqlalchemy
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from pytest_postgresql import factories
+
+from grz_db.models.author import Author
+from grz_db.models.submission import SubmissionDb
+
+__all__ = [
+    "db",
+    "db_test_connection",
+    "migrated_db_connection",
+    "postgresql_proc",
+    "test_author",
+]
+
+_PG_TEMPLATE_DBNAME = "grz_db_migrated_template"
+
+_BACKEND_PARAMS = [
+    "sqlite",
+    pytest.param(
+        "postgresql",
+        marks=pytest.mark.skipif(condition=shutil.which("pg_config") is None, reason="postgresql not detected"),
+    ),
+]
+
+# The cluster lives and dies with the test session, so crash safety protects nothing while an
+# fsync per commit costs most of the run.
+postgresql_proc = factories.postgresql_proc(
+    postgres_options="-c fsync=off -c synchronous_commit=off -c full_page_writes=off",
+)
+
+
+def _migrate(db_url: str) -> None:
+    """Bring *db_url* to the latest schema and release its connection pool.
+
+    :param db_url: SQLAlchemy URL of an empty database.
+    """
+    submission_db = SubmissionDb(db_url=db_url, author=None)
+    try:
+        submission_db.initialize_schema()
+    finally:
+        submission_db.engine.dispose()
+
+
+def _pg_url(proc, dbname: str) -> str:
+    """Build a SQLAlchemy URL for *dbname* on the cluster *proc* runs."""
+    return f"postgresql+psycopg://{proc.user}:@{proc.host}:{proc.port}/{dbname}"
+
+
+def _pg_admin_connect(proc) -> psycopg.Connection:
+    """Connect to the maintenance database, from which others can be created and dropped."""
+    return psycopg.connect(host=proc.host, port=proc.port, user=proc.user, dbname="postgres", autocommit=True)
+
+
+def skip_sqlite_fsync(engine: sqlalchemy.Engine) -> None:
+    """Stop SQLite flushing to disk on every commit.
+
+    These databases are discarded when the test ends, so the durability that ``synchronous=FULL``
+    buys protects nothing and costs an fsync per transaction. Tests that commit in a loop spend
+    almost all of their time there.
+
+    :param engine: Engine to configure. Engines on other backends are left alone.
+    """
+    if engine.dialect.name != "sqlite":
+        return
+
+    @sqlalchemy.event.listens_for(engine, "connect")
+    def _set_pragma(dbapi_connection, _connection_record):
+        dbapi_connection.execute("PRAGMA synchronous=OFF")
+
+
+@pytest.fixture(params=_BACKEND_PARAMS)
+def db_backend(request: pytest.FixtureRequest) -> str:
+    """The backend under test, one of ``sqlite`` or ``postgresql``.
+
+    Fixtures that provision a database take their parametrization from this one, so a test
+    requesting several of them still runs once per backend rather than once per combination.
+    """
+    return str(request.param)
+
+
+@pytest.fixture
+def db_test_connection(
+    db_backend: str, request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
+) -> Iterator[str]:
+    """Database URL of an empty database, one per supported backend.
+
+    For tests that drive the migrations themselves. Anything wanting the current schema should use
+    :func:`migrated_db_connection`, which is far cheaper per test.
+    """
+    if db_backend == "sqlite":
+        yield f"sqlite:///{tmp_path_factory.mktemp('db') / 'test.db'}"
+    else:
+        postgresql: psycopg.Connection = request.getfixturevalue("postgresql")
+        info = postgresql.info
+        yield f"postgresql+psycopg://{info.user}:@{info.host}:{info.port}/{info.dbname}"
+
+
+@pytest.fixture(scope="session")
+def _migrated_sqlite_template(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A migrated SQLite file that each test copies."""
+    template = tmp_path_factory.mktemp("grz-db-template") / "template.db"
+    _migrate(f"sqlite:///{template}")
+    return template
+
+
+@pytest.fixture(scope="session")
+def _migrated_postgresql_template(request: pytest.FixtureRequest) -> str:
+    """Name of a migrated database that each test clones."""
+    proc = request.getfixturevalue("postgresql_proc")
+    with _pg_admin_connect(proc) as conn:
+        conn.execute(f'DROP DATABASE IF EXISTS "{_PG_TEMPLATE_DBNAME}"')
+        conn.execute(f'CREATE DATABASE "{_PG_TEMPLATE_DBNAME}"')
+    _migrate(_pg_url(proc, _PG_TEMPLATE_DBNAME))
+    return _PG_TEMPLATE_DBNAME
+
+
+@pytest.fixture(scope="session")
+def _pg_test_dbnames() -> Iterator[int]:
+    """Source of database names unique within the session."""
+    return itertools.count()
+
+
+@pytest.fixture
+def migrated_db_connection(
+    db_backend: str, request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
+) -> Iterator[str]:
+    """Database URL of a database already on the latest schema, one per supported backend.
+
+    The schema is built once per session and cloned per test, so a test pays a file copy or a
+    ``CREATE DATABASE ... TEMPLATE`` rather than a full Alembic run.
+    """
+    if db_backend == "sqlite":
+        template: Path = request.getfixturevalue("_migrated_sqlite_template")
+        db_file = tmp_path_factory.mktemp("db") / "test.db"
+        shutil.copyfile(template, db_file)
+        yield f"sqlite:///{db_file}"
+    else:
+        template_dbname: str = request.getfixturevalue("_migrated_postgresql_template")
+        proc = request.getfixturevalue("postgresql_proc")
+        dbname = f"grz_db_test_{next(request.getfixturevalue('_pg_test_dbnames'))}"
+        with _pg_admin_connect(proc) as conn:
+            conn.execute(f'CREATE DATABASE "{dbname}" TEMPLATE "{template_dbname}"')
+        try:
+            yield _pg_url(proc, dbname)
+        finally:
+            # FORCE: a test that leaves a connection open would otherwise block the drop.
+            with _pg_admin_connect(proc) as conn:
+                conn.execute(f'DROP DATABASE IF EXISTS "{dbname}" WITH (FORCE)')
+
+
+@pytest.fixture
+def test_author() -> Author:
+    """An author signing as ``alice``, with a throwaway key."""
+    key = ed25519.Ed25519PrivateKey.generate()
+    private_key_bytes = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.OpenSSH,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return Author(name="alice", private_key_bytes=private_key_bytes, private_key_passphrase="")
+
+
+@pytest.fixture
+def db(migrated_db_connection: str, test_author: Author) -> Iterator[SubmissionDb]:
+    """A ``SubmissionDb`` on the latest schema, one per supported backend."""
+    submission_db = SubmissionDb(db_url=migrated_db_connection, author=test_author, debug=False)
+    skip_sqlite_fsync(submission_db.engine)
+    try:
+        yield submission_db
+    finally:
+        submission_db.engine.dispose()

--- a/packages/grz-db/tests/conftest.py
+++ b/packages/grz-db/tests/conftest.py
@@ -2,10 +2,19 @@
 
 import importlib.resources
 import json
-from shutil import which
 
-import psycopg
 import pytest
+from grz_db.testing import (  # noqa: F401
+    _migrated_postgresql_template,
+    _migrated_sqlite_template,
+    _pg_test_dbnames,
+    db,
+    db_backend,
+    db_test_connection,
+    migrated_db_connection,
+    postgresql_proc,
+    test_author,
+)
 from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
 from grz_pydantic_models_testing.example_metadata import grzctl as grzctl_metadata
 
@@ -17,23 +26,3 @@ def metadata() -> GrzSubmissionMetadata:
     """Load the wes_tumor_germline v1.2.1 example from grz-pydantic-models' own test resources."""
     with TEST_METADATA_PATH.open() as fh:
         return GrzSubmissionMetadata(**json.load(fh))
-
-
-@pytest.fixture(
-    params=[
-        "sqlite",
-        pytest.param(
-            "postgresql",
-            marks=pytest.mark.skipif(condition=which("pg_config") is None, reason="postgresql not detected"),
-        ),
-    ],
-)
-def db_test_connection(request: pytest.FixtureRequest):
-    if request.param == "sqlite":
-        tmpdir_factory: pytest.TempdirFactory = request.getfixturevalue("tmpdir_factory")
-        db_dir = tmpdir_factory.mktemp("db")
-        db_file = db_dir / "test.db"
-        yield f"sqlite:///{str(db_file)}"
-    elif request.param == "postgresql":
-        postgresql: psycopg.Connection = request.getfixturevalue("postgresql")
-        yield f"postgresql+psycopg://{postgresql.info.user}:@{postgresql.info.host}:{postgresql.info.port}/{postgresql.info.dbname}"

--- a/packages/grz-db/tests/test_failure_reason.py
+++ b/packages/grz-db/tests/test_failure_reason.py
@@ -1,34 +1,8 @@
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ed25519
 from grz_db.models.author import Author
 from grz_db.models.submission import FailureReasonEnum, SubmissionDb, SubmissionStateEnum
 
 SUBMITTER_ID = "123456789"
-
-
-@pytest.fixture(scope="function")
-def test_author() -> Author:
-    key = ed25519.Ed25519PrivateKey.generate()
-    private_key_bytes = key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.OpenSSH,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-    return Author(
-        name="alice",
-        private_key_bytes=private_key_bytes,
-        private_key_passphrase="",
-    )
-
-
-@pytest.fixture(scope="function")
-def db(tmp_path, test_author: Author) -> SubmissionDb:
-    db_path = tmp_path / "submissions.sqlite"
-    db_url = f"sqlite:///{db_path.resolve()}"
-    submission_db = SubmissionDb(db_url=db_url, author=test_author, debug=False)
-    submission_db.initialize_schema()
-    return submission_db
 
 
 @pytest.fixture(scope="function")
@@ -88,15 +62,13 @@ class TestFailureReasonPersistence:
         assert states[-1].failure_reason is None
         assert states[-2].failure_reason == FailureReasonEnum.DECRYPTION_ERROR
 
-    def test_failure_reason_persists_across_sessions(self, tmp_path, test_author: Author):
+    def test_failure_reason_persists_across_sessions(self, migrated_db_connection: str, test_author: Author):
         """failure_reason should survive closing and reopening the DB connection."""
-        db_path = tmp_path / "submissions.sqlite"
-        db_url = f"sqlite:///{db_path.resolve()}"
+        db_url = migrated_db_connection
 
         sid = f"{SUBMITTER_ID}_2025-01-01_00000000"
 
         db1 = SubmissionDb(db_url=db_url, author=test_author, debug=False)
-        db1.initialize_schema()
         db1.add_submission(sid)
         db1.update_submission_state(sid, SubmissionStateEnum.ERROR, failure_reason=FailureReasonEnum.NETWORK_ERROR)
 

--- a/packages/grz-db/tests/test_should_qc.py
+++ b/packages/grz-db/tests/test_should_qc.py
@@ -61,9 +61,7 @@ def _add_submission_with_history(
         current_timestamp += datetime.timedelta(seconds=1)
 
 
-def _add_submission_block(
-    db: SubmissionDb, base_date: datetime.date, start_time: datetime.datetime, count: int
-) -> list:
+def _add_qc_candidates(db: SubmissionDb, base_date: datetime.date, start_time: datetime.datetime, count: int) -> list:
     """Add *count* QC candidates ten minutes apart and return them in submission order."""
     submissions = []
     for i in range(count):
@@ -239,7 +237,7 @@ class TestQcStrategy:
         base_date = datetime.date(2025, 12, 1)
         start_time = datetime.datetime.combine(base_date, datetime.time(9, 0), tzinfo=datetime.UTC)
 
-        submissions = _add_submission_block(db, base_date, start_time, count=block_size * 2)
+        submissions = _add_qc_candidates(db, base_date, start_time, count=block_size * 2)
         # push the selected share far above the target so neither the month nor the quarter rule fires
         for submission in submissions[:block_size]:
             db.modify_submission(submission.id, "selected_for_qc", "true")
@@ -306,7 +304,7 @@ class TestQcStrategy:
         start_time = datetime.datetime.combine(base_date, datetime.time(8, 0), tzinfo=datetime.UTC)
         block_size = math.floor(1 / target_proportion)
 
-        submissions = _add_submission_block(db, base_date, start_time, count=block_size * 2)
+        submissions = _add_qc_candidates(db, base_date, start_time, count=block_size * 2)
 
         for block in range(2):
             offset = block * block_size
@@ -325,7 +323,7 @@ class TestQcStrategy:
         start_time = datetime.datetime.combine(base_date, datetime.time(8, 0), tzinfo=datetime.UTC)
         block_size = math.floor(1 / target_proportion)
 
-        submissions = _add_submission_block(db, base_date, start_time, count=block_size)
+        submissions = _add_qc_candidates(db, base_date, start_time, count=block_size)
 
         first = [db._is_randomly_selected_for_qc(s, submissions, target_proportion, salt) for s in submissions]
         second = [db._is_randomly_selected_for_qc(s, submissions, target_proportion, salt) for s in submissions]
@@ -336,7 +334,7 @@ class TestQcStrategy:
         base_date = datetime.date(2025, 7, 1)
         start_time = datetime.datetime.combine(base_date, datetime.time(8, 0), tzinfo=datetime.UTC)
 
-        submissions = _add_submission_block(db, base_date, start_time, count=5)
+        submissions = _add_qc_candidates(db, base_date, start_time, count=5)
 
         assert not any(db._is_randomly_selected_for_qc(s, submissions, 0.0, "test-salt") for s in submissions)
 

--- a/packages/grz-db/tests/test_should_qc.py
+++ b/packages/grz-db/tests/test_should_qc.py
@@ -161,44 +161,6 @@ class TestQcStrategy:
         assert submission is not None
         assert submission.selected_for_qc is True
 
-    def test_should_qc_persists_false_result(self, db: SubmissionDb):
-        target_percentage = 20.0
-        salt = "ratio-test"
-        base_date = datetime.date(2025, 12, 1)
-        start_time = datetime.datetime.combine(base_date, datetime.time(9, 0), tzinfo=datetime.UTC)
-
-        selected_submission_id = f"{SUBMITTER_ID}_{base_date}_00000000"
-        _add_submission_with_history(
-            db,
-            selected_submission_id,
-            SUBMITTER_ID,
-            base_date,
-            [*DEFAULT_HISTORY, "qcing"],
-            base_timestamp=start_time,
-            is_qced=False,
-        )
-        db.modify_submission(selected_submission_id, "selected_for_qc", "true")
-
-        candidate_submission_id = f"{SUBMITTER_ID}_{base_date}_00000001"
-        candidate_timestamp = start_time + datetime.timedelta(minutes=10)
-        _add_submission_with_history(
-            db,
-            candidate_submission_id,
-            SUBMITTER_ID,
-            base_date,
-            DEFAULT_HISTORY,
-            base_timestamp=candidate_timestamp,
-            is_qced=False,
-        )
-
-        should_run = db.should_qc(candidate_submission_id, target_percentage, salt)
-
-        # whichever way the decision goes, it is the value that must be persisted. Asserting a
-        # fixed False would hold only for as long as the random branch happens not to fire.
-        submission = db.get_submission(candidate_submission_id)
-        assert submission is not None
-        assert submission.selected_for_qc is should_run
-
     def test_should_qc_persists_a_negative_decision(self, db: SubmissionDb):
         """A zero target leaves no branch that can select, so the stored flag must go to False.
 
@@ -229,16 +191,19 @@ class TestQcStrategy:
         assert submission is not None
         assert submission.selected_for_qc is False
 
-    def test_should_qc_counts_historical_qcing_or_qced_states(self, db: SubmissionDb):
-        target_percentage = 20.0
-        salt = "ratio-test"
+    def test_a_submission_with_qc_history_counts_toward_the_target(self, db: SubmissionDb):
+        """A submission already QCed counts even though its selected_for_qc flag was never set.
+
+        Asserted on the counting rule rather than on should_qc's verdict: routing through the full
+        decision would leave the outcome resting on whether the random branch happened to fire.
+        """
         base_date = datetime.date(2025, 12, 1)
         start_time = datetime.datetime.combine(base_date, datetime.time(9, 0), tzinfo=datetime.UTC)
 
-        historical_qc_submission_id = f"{SUBMITTER_ID}_{base_date}_00000000"
+        qced_submission_id = f"{SUBMITTER_ID}_{base_date}_00000000"
         _add_submission_with_history(
             db,
-            historical_qc_submission_id,
+            qced_submission_id,
             SUBMITTER_ID,
             base_date,
             [*DEFAULT_HISTORY, "qcing", "qced", "cleaning", "cleaned"],
@@ -246,21 +211,45 @@ class TestQcStrategy:
             is_qced=True,
         )
 
-        candidate_submission_id = f"{SUBMITTER_ID}_{base_date}_00000001"
-        candidate_timestamp = start_time + datetime.timedelta(minutes=10)
+        untouched_submission_id = f"{SUBMITTER_ID}_{base_date}_00000001"
         _add_submission_with_history(
             db,
-            candidate_submission_id,
+            untouched_submission_id,
             SUBMITTER_ID,
             base_date,
             DEFAULT_HISTORY,
-            base_timestamp=candidate_timestamp,
-            is_qced=False,
+            base_timestamp=start_time + datetime.timedelta(minutes=10),
         )
 
-        should_run = db.should_qc(candidate_submission_id, target_percentage, salt)
+        qced = db.get_submission(qced_submission_id)
+        untouched = db.get_submission(untouched_submission_id)
+        assert qced is not None and untouched is not None
+        assert qced.selected_for_qc is not True, "the flag is unset; only the state history should count it"
+        assert db._submission_counts_as_selected_for_qc(qced) is True
+        assert db._submission_counts_as_selected_for_qc(untouched) is False
 
-        assert should_run is False
+    def test_should_qc_still_selects_once_per_block_when_the_target_is_already_met(self, db: SubmissionDb):
+        """With the target already exceeded, only the random branch can select, so it must still fire.
+
+        The month and quarter rules are both satisfied here, so this is the one place that proves
+        ``should_qc`` actually consults the random selection rather than merely returning early.
+        """
+        target_percentage = 20.0
+        block_size = math.floor(1 / (target_percentage / 100.0))
+        base_date = datetime.date(2025, 12, 1)
+        start_time = datetime.datetime.combine(base_date, datetime.time(9, 0), tzinfo=datetime.UTC)
+
+        submissions = _add_submission_block(db, base_date, start_time, count=block_size * 2)
+        # push the selected share far above the target so neither the month nor the quarter rule fires
+        for submission in submissions[:block_size]:
+            db.modify_submission(submission.id, "selected_for_qc", "true")
+
+        selected = [
+            submission.id
+            for submission in submissions[block_size:]
+            if db.should_qc(submission.id, target_percentage, "test-salt")
+        ]
+        assert len(selected) == 1, f"expected the random branch to pick exactly one, picked {selected}"
 
     def test_ratio_catchup_keeps_the_selected_share_at_or_above_target(self, db: SubmissionDb):
         """The running selected share must never drop below the target; that is what catch-up means.

--- a/packages/grz-db/tests/test_should_qc.py
+++ b/packages/grz-db/tests/test_should_qc.py
@@ -1,6 +1,5 @@
 import datetime
 import math
-import random
 
 import pytest
 from grz_db.errors import (
@@ -60,6 +59,28 @@ def _add_submission_with_history(
         state_enum = SubmissionStateEnum(state_str.capitalize())
         _update_submission_state(db, submission_id, state_enum, current_timestamp)
         current_timestamp += datetime.timedelta(seconds=1)
+
+
+def _add_submission_block(
+    db: SubmissionDb, base_date: datetime.date, start_time: datetime.datetime, count: int
+) -> list:
+    """Add *count* QC candidates ten minutes apart and return them in submission order."""
+    submissions = []
+    for i in range(count):
+        submission_id = f"{SUBMITTER_ID}_{base_date}_{i:0>8}"
+        _add_submission_with_history(
+            db,
+            submission_id,
+            SUBMITTER_ID,
+            base_date,
+            DEFAULT_HISTORY,
+            base_timestamp=start_time + datetime.timedelta(minutes=i * 10),
+            is_qced=False,
+        )
+        submission = db.get_submission(submission_id)
+        assert submission is not None
+        submissions.append(submission)
+    return submissions
 
 
 class TestQcStrategy:
@@ -172,7 +193,38 @@ class TestQcStrategy:
 
         should_run = db.should_qc(candidate_submission_id, target_percentage, salt)
 
-        assert should_run is False
+        # whichever way the decision goes, it is the value that must be persisted. Asserting a
+        # fixed False would hold only for as long as the random branch happens not to fire.
+        submission = db.get_submission(candidate_submission_id)
+        assert submission is not None
+        assert submission.selected_for_qc is should_run
+
+    def test_should_qc_persists_a_negative_decision(self, db: SubmissionDb):
+        """A zero target leaves no branch that can select, so the stored flag must go to False.
+
+        The month rule ignores the target and fires whenever nothing has been selected yet, so an
+        already-selected submission is needed for the decision to reach the target-driven branches.
+        """
+        base_date = datetime.date(2025, 12, 1)
+        start_time = datetime.datetime.combine(base_date, datetime.time(9, 0), tzinfo=datetime.UTC)
+
+        selected_submission_id = f"{SUBMITTER_ID}_{base_date}_00000000"
+        _add_submission_with_history(
+            db, selected_submission_id, SUBMITTER_ID, base_date, DEFAULT_HISTORY, base_timestamp=start_time
+        )
+        db.modify_submission(selected_submission_id, "selected_for_qc", "true")
+
+        candidate_submission_id = f"{SUBMITTER_ID}_{base_date}_00000001"
+        _add_submission_with_history(
+            db,
+            candidate_submission_id,
+            SUBMITTER_ID,
+            base_date,
+            DEFAULT_HISTORY,
+            base_timestamp=start_time + datetime.timedelta(minutes=10),
+        )
+
+        assert db.should_qc(candidate_submission_id, 0.0, "any-salt") is False
         submission = db.get_submission(candidate_submission_id)
         assert submission is not None
         assert submission.selected_for_qc is False
@@ -269,35 +321,22 @@ class TestQcStrategy:
         )
         assert should_run is True, "The first submission of the month must be selected for QC."
 
-    def test_quarterly_ratio_catchup(self, db: SubmissionDb):
-        """
-        Tests that the quarter selection combines ratio catchup and random selection.
-        Target: 20%.
+    def test_ratio_catchup_keeps_the_selected_share_at_or_above_target(self, db: SubmissionDb):
+        """The running selected share must never drop below the target; that is what catch-up means.
+
+        Asserted as a property of the outcome rather than by recomputing the selection formula:
+        a test that re-derives the seed would agree with a broken implementation.
         """
         target_percentage = 20.0
         target_proportion = target_percentage / 100.0
         salt = "ratio-test"
         base_date = datetime.date(2025, 12, 1)
         start_time = datetime.datetime.combine(base_date, datetime.time(9, 0), tzinfo=datetime.UTC)
-        block_size = math.floor(1 / target_proportion)
 
-        submission_id = f"{SUBMITTER_ID}_{base_date}_00000000"
-        _add_submission_with_history(
-            db,
-            submission_id,
-            SUBMITTER_ID,
-            base_date,
-            [*DEFAULT_HISTORY, "qcing", "qced"],
-            base_timestamp=start_time,
-            is_qced=True,
-        )
-
-        qced_count = 1
-        total_count = 1
-        for i in range(1, 10):
+        selected_count = 0
+        for i in range(12):
             submission_id = f"{SUBMITTER_ID}_{base_date}_{i:0>8}"
             submission_timestamp = start_time + datetime.timedelta(minutes=i * 10)
-
             _add_submission_with_history(
                 db,
                 submission_id,
@@ -308,26 +347,7 @@ class TestQcStrategy:
                 is_qced=False,
             )
 
-            total_count += 1
-            current_ratio = qced_count / total_count
-            is_ratio_trigger = current_ratio <= target_proportion
-
-            absolute_index = i
-            block_index = absolute_index // block_size
-            seed = f"{SUBMITTER_ID}-{base_date.year}-4-{block_index}-{salt}"
-            rng = random.Random(seed)
-            target_index_in_block = rng.randint(0, block_size - 1)
-            is_random_trigger = (absolute_index % block_size) == target_index_in_block
-
-            expect_qc = is_ratio_trigger or is_random_trigger
-            should_run = db.should_qc(submission_id, target_percentage, salt)
-
-            assert should_run is expect_qc, (
-                f"Index {i}: Expect={expect_qc}, Got={should_run}. "
-                f"(Ratio: {current_ratio:.3f} vs {target_proportion}, Stats: QCed={qced_count}, Total={total_count})"
-            )
-
-            if should_run:
+            if db.should_qc(submission_id, target_percentage, salt):
                 _update_submission_state(
                     db, submission_id, SubmissionStateEnum.QCING, submission_timestamp + datetime.timedelta(minutes=1)
                 )
@@ -335,112 +355,60 @@ class TestQcStrategy:
                     db, submission_id, SubmissionStateEnum.QCED, submission_timestamp + datetime.timedelta(minutes=2)
                 )
                 db.modify_submission(submission_id, "detailed_qc_passed", "true")
-                qced_count += 1
+                selected_count += 1
 
-    @pytest.mark.parametrize("target_percentage", [1.0, 2.0, 4.0, 5.0, 10.0, 20.0, 100.0])
-    def test_random_selection(self, db: SubmissionDb, target_percentage: float):
-        """
-        Test the random selection logic.
-        We simulate the logic (Month -> Ratio -> Random) to verify expectation.
-        """
-        salt = "test-salt"
-        base_date = datetime.date(2025, 7, 1)
-        start_time = datetime.datetime.combine(base_date, datetime.time(8, 0), tzinfo=datetime.UTC)
-
-        block_size = math.floor(1 / (target_percentage / 100.0))
-        limit = block_size * 2
-
-        qced_count = 0
-        total_count = 0
-
-        for i in range(limit):
-            submission_id = f"{SUBMITTER_ID}_{base_date}_{i:0>8}"
-            submission_timestamp = start_time + datetime.timedelta(minutes=i * 10)
-            total_count += 1
-
-            is_first_of_month_trigger = qced_count == 0
-
-            current_ratio = qced_count / total_count
-            is_ratio_trigger = current_ratio <= (target_percentage / 100.0)
-
-            absolute_index = i
-            block_index = absolute_index // block_size
-            seed = f"{SUBMITTER_ID}-{base_date.year}-3-{block_index}-{salt}"
-            rng = random.Random(seed)
-            target_index_in_block = rng.randint(0, block_size - 1)
-
-            is_random_trigger = (absolute_index % block_size) == target_index_in_block
-
-            expect_qc = False
-            if is_first_of_month_trigger:
-                expect_qc = True
-            elif is_ratio_trigger:
-                expect_qc = True
-            elif is_random_trigger:
-                expect_qc = True
-
-            _add_submission_with_history(
-                db,
-                submission_id,
-                SUBMITTER_ID,
-                base_date,
-                DEFAULT_HISTORY,
-                base_timestamp=submission_timestamp,
-                is_qced=False,
+            assert selected_count / (i + 1) >= target_proportion, (
+                f"after {i + 1} submissions only {selected_count} were selected, "
+                f"below the {target_proportion:.0%} target"
             )
 
-            should_run = db.should_qc(submission_id=submission_id, target_percentage=target_percentage, salt=salt)
+    @pytest.mark.parametrize("target_percentage", [2.0, 20.0])
+    def test_exactly_one_submission_per_block_is_randomly_selected(self, db: SubmissionDb, target_percentage: float):
+        """Each block of ``floor(1 / target)`` submissions must contribute exactly one selection.
 
-            assert should_run is expect_qc, (
-                f"Index {i}: Expect={expect_qc}, Got={should_run}. "
-                f"(Ratio: {current_ratio:.3f} vs {target_percentage / 100.0}, "
-                f"Stats: QCed={qced_count}, Total={total_count})"
-            )
-
-            if should_run:
-                _update_submission_state(
-                    db, submission_id, SubmissionStateEnum.QCING, submission_timestamp + datetime.timedelta(minutes=1)
-                )
-                _update_submission_state(
-                    db, submission_id, SubmissionStateEnum.QCED, submission_timestamp + datetime.timedelta(minutes=2)
-                )
-                db.modify_submission(submission_id, "detailed_qc_passed", "true")
-                qced_count += 1
-
-    def test_is_randomly_selected_for_qc_uses_block_relative_index_for_later_blocks(self, db: SubmissionDb):
-        target_percentage = 2.0
+        This is the guarantee the block scheme exists to provide, and it holds whatever seed the
+        implementation derives. Recomputing that seed here would instead make the test agree with
+        a broken implementation, since both sides would share the same mistake.
+        """
         target_proportion = target_percentage / 100.0
         salt = "test-salt"
         base_date = datetime.date(2025, 7, 1)
         start_time = datetime.datetime.combine(base_date, datetime.time(8, 0), tzinfo=datetime.UTC)
         block_size = math.floor(1 / target_proportion)
 
-        submissions = []
-        for i in range(block_size * 2):
-            submission_id = f"{SUBMITTER_ID}_{base_date}_{i:0>8}"
-            _add_submission_with_history(
-                db,
-                submission_id,
-                SUBMITTER_ID,
-                base_date,
-                DEFAULT_HISTORY,
-                base_timestamp=start_time + datetime.timedelta(minutes=i * 10),
-                is_qced=False,
-            )
-            submission = db.get_submission(submission_id)
-            assert submission is not None
-            submissions.append(submission)
+        submissions = _add_submission_block(db, base_date, start_time, count=block_size * 2)
 
-        absolute_index = block_size + 7
-        submission = submissions[absolute_index]
-        block_index = absolute_index // block_size
+        for block in range(2):
+            offset = block * block_size
+            selected = [
+                index
+                for index in range(offset, offset + block_size)
+                if db._is_randomly_selected_for_qc(submissions[index], submissions, target_proportion, salt)
+            ]
+            assert len(selected) == 1, f"block {block} selected {selected}, expected exactly one submission"
 
-        seed = f"{SUBMITTER_ID}-{base_date.year}-3-{block_index}-{salt}"
-        rng = random.Random(seed)
-        target_index_in_block = rng.randint(0, block_size - 1)
-        expected = (absolute_index % block_size) == target_index_in_block
+    def test_random_selection_is_reproducible(self, db: SubmissionDb):
+        """The selection is documented as random but reproducible, so the same inputs must agree."""
+        target_proportion = 0.02
+        salt = "test-salt"
+        base_date = datetime.date(2025, 7, 1)
+        start_time = datetime.datetime.combine(base_date, datetime.time(8, 0), tzinfo=datetime.UTC)
+        block_size = math.floor(1 / target_proportion)
 
-        assert db._is_randomly_selected_for_qc(submission, submissions, target_proportion, salt) is expected
+        submissions = _add_submission_block(db, base_date, start_time, count=block_size)
+
+        first = [db._is_randomly_selected_for_qc(s, submissions, target_proportion, salt) for s in submissions]
+        second = [db._is_randomly_selected_for_qc(s, submissions, target_proportion, salt) for s in submissions]
+        assert first == second
+
+    def test_no_submission_is_randomly_selected_at_zero_target(self, db: SubmissionDb):
+        """A zero target short-circuits the random branch, so nothing may be selected by it."""
+        base_date = datetime.date(2025, 7, 1)
+        start_time = datetime.datetime.combine(base_date, datetime.time(8, 0), tzinfo=datetime.UTC)
+
+        submissions = _add_submission_block(db, base_date, start_time, count=5)
+
+        assert not any(db._is_randomly_selected_for_qc(s, submissions, 0.0, "test-salt") for s in submissions)
 
     def test_should_qc_raises_on_missing_submission_date(self, db: SubmissionDb):
         """Verify SubmissionDateIsNoneError when submission_date is None."""

--- a/packages/grz-db/tests/test_should_qc.py
+++ b/packages/grz-db/tests/test_should_qc.py
@@ -1,50 +1,18 @@
 import datetime
 import math
 import random
-from pathlib import Path
 
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ed25519
 from grz_db.errors import (
     SubmissionBasicQCNotPassedError,
     SubmissionDateIsNoneError,
     SubmissionTypeIsNoneError,
 )
-from grz_db.models.author import Author
 from grz_db.models.submission import SubmissionDb, SubmissionStateEnum, SubmissionStateLog, SubmissionType
 from sqlmodel import Session
 
 SUBMITTER_ID = "123456789"
 DEFAULT_HISTORY = ["uploaded", "downloading", "downloaded", "decrypting", "decrypted", "validating", "validated"]
-
-
-@pytest.fixture(scope="function")
-def test_author() -> Author:
-    """Creates a test author with a valid temporary private key."""
-    key = ed25519.Ed25519PrivateKey.generate()
-    private_key_bytes = key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.OpenSSH,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-    return Author(
-        name="alice",
-        private_key_bytes=private_key_bytes,
-        private_key_passphrase="",
-    )
-
-
-@pytest.fixture(scope="function")
-def db(tmp_path: Path, test_author: Author) -> SubmissionDb:
-    """Create a clean database initialized with schema for each test function."""
-    db_path = tmp_path / "submissions.sqlite"
-    db_url = f"sqlite:///{db_path.resolve()}"
-
-    submission_db = SubmissionDb(db_url=db_url, author=test_author, debug=False)
-    submission_db.initialize_schema()
-
-    return submission_db
 
 
 def _update_submission_state(

--- a/packages/grz-db/tests/test_should_qc.py
+++ b/packages/grz-db/tests/test_should_qc.py
@@ -229,40 +229,6 @@ class TestQcStrategy:
         assert submission is not None
         assert submission.selected_for_qc is False
 
-    def test_should_qc_counts_existing_selected_for_qc_without_double_counting(self, db: SubmissionDb):
-        target_percentage = 20.0
-        salt = "ratio-test"
-        base_date = datetime.date(2025, 12, 1)
-        start_time = datetime.datetime.combine(base_date, datetime.time(9, 0), tzinfo=datetime.UTC)
-
-        selected_submission_id = f"{SUBMITTER_ID}_{base_date}_00000000"
-        _add_submission_with_history(
-            db,
-            selected_submission_id,
-            SUBMITTER_ID,
-            base_date,
-            [*DEFAULT_HISTORY, "qcing"],
-            base_timestamp=start_time,
-            is_qced=False,
-        )
-        db.modify_submission(selected_submission_id, "selected_for_qc", "true")
-
-        candidate_submission_id = f"{SUBMITTER_ID}_{base_date}_00000001"
-        candidate_timestamp = start_time + datetime.timedelta(minutes=10)
-        _add_submission_with_history(
-            db,
-            candidate_submission_id,
-            SUBMITTER_ID,
-            base_date,
-            DEFAULT_HISTORY,
-            base_timestamp=candidate_timestamp,
-            is_qced=False,
-        )
-
-        should_run = db.should_qc(candidate_submission_id, target_percentage, salt)
-
-        assert should_run is False
-
     def test_should_qc_counts_historical_qcing_or_qced_states(self, db: SubmissionDb):
         target_percentage = 20.0
         salt = "ratio-test"
@@ -295,31 +261,6 @@ class TestQcStrategy:
         should_run = db.should_qc(candidate_submission_id, target_percentage, salt)
 
         assert should_run is False
-
-    def test_first_of_month_always_runs(self, db: SubmissionDb):
-        """
-        Test that the first (validated, initial) submission of a month is always QCed.
-        """
-        test_date = datetime.date(2025, 12, 1)
-        base_timestamp = datetime.datetime.combine(test_date, datetime.time(10, 0), tzinfo=datetime.UTC)
-        submission_id = f"{SUBMITTER_ID}_{test_date}_00000000"
-
-        _add_submission_with_history(
-            db,
-            submission_id,
-            SUBMITTER_ID,
-            test_date,
-            DEFAULT_HISTORY,
-            base_timestamp=base_timestamp,
-            is_qced=False,
-        )
-
-        should_run = db.should_qc(
-            submission_id=submission_id,
-            target_percentage=2.0,
-            salt="any_salt",
-        )
-        assert should_run is True, "The first submission of the month must be selected for QC."
 
     def test_ratio_catchup_keeps_the_selected_share_at_or_above_target(self, db: SubmissionDb):
         """The running selected share must never drop below the target; that is what catch-up means.

--- a/packages/grz-db/tests/test_submission.py
+++ b/packages/grz-db/tests/test_submission.py
@@ -2,10 +2,7 @@ import datetime
 from collections.abc import Callable
 
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ed25519
 from grz_db.errors import DuplicateTanGError
-from grz_db.models.author import Author
 from grz_db.models.submission import Submission, SubmissionDb
 from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
 
@@ -15,24 +12,6 @@ SUBMISSION_ID_2 = "123456789_2024-01-02_abcdef02"
 SUBMISSION_ID_3 = "123456789_2024-01-03_abcdef03"
 TAN_G_1 = "a" * 64
 TAN_G_2 = "b" * 64
-
-
-@pytest.fixture(scope="function")
-def test_author() -> Author:
-    key = ed25519.Ed25519PrivateKey.generate()
-    private_key_bytes = key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.OpenSSH,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-    return Author(name="alice", private_key_bytes=private_key_bytes, private_key_passphrase="")
-
-
-@pytest.fixture(scope="function")
-def db(db_test_connection: str, test_author: Author) -> SubmissionDb:
-    submission_db = SubmissionDb(db_url=db_test_connection, author=test_author, debug=False)
-    submission_db.initialize_schema()
-    return submission_db
 
 
 @pytest.fixture(scope="function")

--- a/packages/grz-db/tests/test_submission.py
+++ b/packages/grz-db/tests/test_submission.py
@@ -128,14 +128,6 @@ def test_get_submissions_unknown_ids_map_to_none(db: SubmissionDb) -> None:
     assert result[1] is None
 
 
-def test_get_submissions_all_unknown(db: SubmissionDb) -> None:
-    """get_submissions returns all-None when none of the IDs exist."""
-    ids = ["000000000_2000-01-01_deadbeef", "000000000_2000-01-01_cafebabe"]
-    result = db.get_submissions(ids)
-
-    assert result == [None, None]
-
-
 def test_get_submissions_includes_states(db: SubmissionDb) -> None:
     """States relationship is eagerly loaded so it can be accessed outside the session."""
     from grz_db.models.submission import SubmissionStateEnum

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -237,6 +237,19 @@ def test_wgs_trio_1_3_fail_scope_and_justification_mutually_exclusive(version: s
     "version",
     [v for v in TESTED_VERSIONS if Version(v) >= Version("1.3.0")],
 )
+def test_wgs_trio_1_3_justification_replaces_scope(version: str):
+    """As of v1.3, a justification may stand in for a scope, with schemaVersion still present."""
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
+    metadata["donors"][0]["researchConsents"][0]["noScopeJustification"] = "patient unable to consent"
+    del metadata["donors"][0]["researchConsents"][0]["scope"]
+
+    GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+
+
+@pytest.mark.parametrize(
+    "version",
+    [v for v in TESTED_VERSIONS if Version(v) >= Version("1.3.0")],
+)
 def test_wgs_trio_1_3_schema_version_now_optional(version: str):
     """As of v1.3, researchConsent no longer requires schemaVersion."""
     metadata = json.loads(_metadata_raw("wgs_trio", version))

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -45,6 +45,16 @@ from pydantic import ValidationError
 TESTED_VERSIONS = ["1.2.1", "1.3.0"]
 
 
+def _metadata_raw(dataset: str, version: str) -> str:
+    """The raw JSON of an example metadata submission, for tests that mutate it before validation."""
+    return importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text()
+
+
+def _metadata(dataset: str, version: str) -> GrzSubmissionMetadata:
+    """An example metadata submission parsed as the model under test."""
+    return GrzSubmissionMetadata.model_validate_json(_metadata_raw(dataset, version))
+
+
 @pytest.mark.parametrize(
     "dataset,version",
     itertools.product(
@@ -60,17 +70,14 @@ TESTED_VERSIONS = ["1.2.1", "1.3.0"]
     ),
 )
 def test_examples(dataset: str, version: str):
-    metadata_str = importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text()
-    GrzSubmissionMetadata.model_validate_json(metadata_str)
+    _metadata(dataset, version)
 
 
 def test_wgs_trio_special_consent():
     """
     Broad Consent obtained before 2025-06-15 for non-index donors is allowed to stand in for mvConsent if missing
     """
-    metadata_str = (
-        importlib.resources.files(example_metadata).joinpath("wgs_trio", "v1.1.7.earlyBCException.json").read_text()
-    )
+    metadata_str = _metadata_raw("wgs_trio", "1.1.7.earlyBCException")
     GrzSubmissionMetadata.model_validate_json(metadata_str)
 
     # only non-index donors can have the special researchConsent exemption
@@ -92,7 +99,7 @@ def test_wgs_trio_no_vcf(version):
     """
     VCFs were downgraded from required to recommended for all submissions.
     """
-    metadata_str = importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
+    metadata_str = _metadata_raw("wgs_trio", version)
     GrzSubmissionMetadata.model_validate_json(metadata_str)
 
     metadata = json.loads(metadata_str)
@@ -103,95 +110,41 @@ def test_wgs_trio_no_vcf(version):
 
 
 @pytest.mark.parametrize(
-    "version",
-    TESTED_VERSIONS,
+    "genomic_study_subtype,deleted_subtype,should_raise",
+    (
+        ("tumor+germline", "germline", True),
+        ("tumor+germline", "somatic", True),
+        ("tumor-only", "germline", False),
+        ("tumor-only", "somatic", True),
+        ("germline-only", "germline", True),
+        ("germline-only", "somatic", False),
+    ),
 )
-def test_wgs_tumor_germline_missing_dna(version):
+@pytest.mark.parametrize("version", TESTED_VERSIONS)
+def test_wgs_tumor_germline_missing_dna(
+    version: str, genomic_study_subtype: str, deleted_subtype: str, should_raise: bool
+):
     """
-    Ensure that both tumor and germline DNA lab data are required for WGS tumor-germline submissions.
+    Ensure that both tumor and germline DNA lab data are required for WGS tumor-germline submissions,
+    except where the deleted subtype is not required by the declared genomicStudySubtype.
     """
-    metadata_str = (
-        importlib.resources.files(example_metadata).joinpath("wgs_tumor_germline", f"v{version}.json").read_text()
-    )
-
+    metadata = json.loads(_metadata_raw("wgs_tumor_germline", version))
     # The example predates the 04.12.2025 cutoff, before which a missing subtype only warns.
-    metadata = json.loads(metadata_str)
     metadata["submission"]["submissionDate"] = "2025-12-04"
-    metadata_str = json.dumps(metadata)
+    metadata["submission"]["genomicStudySubtype"] = genomic_study_subtype
 
-    ### tumor+germline
+    lab_datum_index = {"germline": 0, "somatic": 1}[deleted_subtype]
+    assert metadata["donors"][0]["labData"][lab_datum_index]["sequenceSubtype"] == deleted_subtype
+    del metadata["donors"][0]["labData"][lab_datum_index]
 
-    # delete germline DNA
-    metadata = json.loads(metadata_str)
-    assert metadata["donors"][0]["labData"][0]["sequenceSubtype"] == "germline"
-    del metadata["donors"][0]["labData"][0]
-
-    # missing germline DNA should fail
-    with pytest.raises(
-        ValidationError,
-        match=r"""Index donor is missing sequence subtypes for submission type 'tumor\+germline': germline""",
-    ):
+    if should_raise:
+        with pytest.raises(
+            ValidationError,
+            match=rf"""Index donor is missing sequence subtypes for submission type '{re.escape(genomic_study_subtype)}': {deleted_subtype}""",
+        ):
+            GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+    else:
         GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-
-    # delete tumor DNA
-    metadata = json.loads(metadata_str)
-    assert metadata["donors"][0]["labData"][1]["sequenceSubtype"] == "somatic"
-    del metadata["donors"][0]["labData"][1]
-
-    # missing tumor DNA should fail
-    with pytest.raises(
-        ValidationError,
-        match=r"""Index donor is missing sequence subtypes for submission type 'tumor\+germline': somatic""",
-    ):
-        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-
-    ### tumor-only
-
-    # delete germline DNA
-    metadata = json.loads(metadata_str)
-    metadata["submission"]["genomicStudySubtype"] = "tumor-only"
-    assert metadata["donors"][0]["labData"][0]["sequenceSubtype"] == "germline"
-    del metadata["donors"][0]["labData"][0]
-
-    # missing germline DNA should pass
-    GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-
-    # delete tumor DNA
-    metadata = json.loads(metadata_str)
-    metadata["submission"]["genomicStudySubtype"] = "tumor-only"
-    assert metadata["donors"][0]["labData"][1]["sequenceSubtype"] == "somatic"
-    del metadata["donors"][0]["labData"][1]
-
-    # missing tumor DNA should fail
-    with pytest.raises(
-        ValidationError,
-        match=r"""Index donor is missing sequence subtypes for submission type 'tumor-only': somatic""",
-    ):
-        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-
-    ### germline-only
-
-    # delete germline DNA
-    metadata = json.loads(metadata_str)
-    metadata["submission"]["genomicStudySubtype"] = "germline-only"
-    assert metadata["donors"][0]["labData"][0]["sequenceSubtype"] == "germline"
-    del metadata["donors"][0]["labData"][0]
-
-    # missing germline DNA should fail
-    with pytest.raises(
-        ValidationError,
-        match=r"""Index donor is missing sequence subtypes for submission type 'germline-only': germline""",
-    ):
-        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-
-    # delete tumor DNA
-    metadata = json.loads(metadata_str)
-    metadata["submission"]["genomicStudySubtype"] = "germline-only"
-    assert metadata["donors"][0]["labData"][1]["sequenceSubtype"] == "somatic"
-    del metadata["donors"][0]["labData"][1]
-
-    # missing tumor DNA should pass
-    GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
 
 @pytest.mark.parametrize("version", TESTED_VERSIONS)
@@ -201,9 +154,7 @@ def test_missing_sequence_subtype_warns_before_cutoff(version: str, caplog):
     Submissions predating that release must only warn, so that backfills and other operations
     replaying historical data do not fail retroactively.
     """
-    metadata = json.loads(
-        importlib.resources.files(example_metadata).joinpath("wgs_tumor_germline", f"v{version}.json").read_text()
-    )
+    metadata = json.loads(_metadata_raw("wgs_tumor_germline", version))
     metadata["submission"]["submissionDate"] = "2025-12-03"
     assert metadata["donors"][0]["labData"][0]["sequenceSubtype"] == "germline"
     del metadata["donors"][0]["labData"][0]
@@ -218,9 +169,7 @@ def test_missing_sequence_subtype_warns_before_cutoff(version: str, caplog):
 @pytest.mark.parametrize("version", TESTED_VERSIONS)
 def test_missing_sequence_subtype_raises_on_cutoff(version: str):
     """On the cutoff date itself the check is enforced."""
-    metadata = json.loads(
-        importlib.resources.files(example_metadata).joinpath("wgs_tumor_germline", f"v{version}.json").read_text()
-    )
+    metadata = json.loads(_metadata_raw("wgs_tumor_germline", version))
     metadata["submission"]["submissionDate"] = "2025-12-04"
     assert metadata["donors"][0]["labData"][0]["sequenceSubtype"] == "germline"
     del metadata["donors"][0]["labData"][0]
@@ -238,46 +187,78 @@ def test_missing_sequence_subtype_raises_on_cutoff(version: str):
 )
 def test_wgs_trio_1_3_fail_empty_consent_list(version: str):
     """As of v1.3, empty consent lists are no longer allowed."""
-    metadata_str = importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
-    metadata = json.loads(metadata_str)
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
     metadata["donors"][0]["researchConsents"] = []
-    with pytest.raises(ValidationError):
-        GrzSubmissionMetadata.model_validate_json(metadata)
+    with pytest.raises(ValidationError, match=r"Donors must have research consent as of metadata schema v1\.3"):
+        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
 
 @pytest.mark.parametrize(
     "version",
     [v for v in TESTED_VERSIONS if Version(v) >= Version("1.3.0")],
 )
-def test_wgs_trio_1_3_fail_malformed_consent(version: str):
-    """As of v1.3, non-empty scope or noScopeJustification must be provided."""
-    metadata_str = importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
-    metadata = json.loads(metadata_str)
-
-    # scope, if provided, must be a valid consent object
+def test_wgs_trio_1_3_fail_scope_must_be_a_consent(version: str):
+    """As of v1.3, a scope that fails to parse as a Consent is rejected."""
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
     del metadata["donors"][0]["researchConsents"][0]["scope"]["scope"]
+
     with pytest.raises(ValidationError, match=r"scope must be a valid MII Broad Consent as of metadata v1.3"):
         GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
-    # scope can't be an empty dict
+
+@pytest.mark.parametrize(
+    "version",
+    [v for v in TESTED_VERSIONS if Version(v) >= Version("1.3.0")],
+)
+def test_wgs_trio_1_3_fail_empty_scope(version: str):
+    """As of v1.3, scope can't be an empty dict."""
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
     metadata["donors"][0]["researchConsents"][0]["scope"] = {}
+
     with pytest.raises(ValidationError):
         GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
+
+@pytest.mark.parametrize(
+    "version",
+    [v for v in TESTED_VERSIONS if Version(v) >= Version("1.3.0")],
+)
+def test_wgs_trio_1_3_fail_scope_and_justification_mutually_exclusive(version: str):
+    """As of v1.3, scope, even if an empty dict, can't be provided along with noScopeJustification."""
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
+    metadata["donors"][0]["researchConsents"][0]["scope"] = {}
     metadata["donors"][0]["researchConsents"][0]["noScopeJustification"] = "patient unable to consent"
-    # scope, even if an empty dict, can't be provided along with noScopeJustification
+
     with pytest.raises(ValidationError):
         GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
+
+@pytest.mark.parametrize(
+    "version",
+    [v for v in TESTED_VERSIONS if Version(v) >= Version("1.3.0")],
+)
+def test_wgs_trio_1_3_schema_version_now_optional(version: str):
+    """As of v1.3, researchConsent no longer requires schemaVersion."""
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
+    metadata["donors"][0]["researchConsents"][0]["noScopeJustification"] = "patient unable to consent"
     del metadata["donors"][0]["researchConsents"][0]["scope"]
-    GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-
-    # schemaVersion can be missing now
     del metadata["donors"][0]["researchConsents"][0]["schemaVersion"]
+
     GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
-    # but presentationDate no longer can
+
+@pytest.mark.parametrize(
+    "version",
+    [v for v in TESTED_VERSIONS if Version(v) >= Version("1.3.0")],
+)
+def test_wgs_trio_1_3_fail_missing_presentation_date(version: str):
+    """As of v1.3, presentationDate is required even where schemaVersion is not."""
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
+    metadata["donors"][0]["researchConsents"][0]["noScopeJustification"] = "patient unable to consent"
+    del metadata["donors"][0]["researchConsents"][0]["scope"]
+    del metadata["donors"][0]["researchConsents"][0]["schemaVersion"]
     del metadata["donors"][0]["researchConsents"][0]["presentationDate"]
+
     with pytest.raises(ValidationError):
         GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
@@ -288,7 +269,7 @@ def test_wgs_trio_1_3_fail_malformed_consent(version: str):
 )
 def test_invalid_short_read_submission_with_bam(dataset: str, version: str):
     """BAM files should only be allowed in *_lr lab data"""
-    metadata = json.loads(importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text())
+    metadata = json.loads(_metadata_raw(dataset, version))
     # add a BAM file
     metadata["donors"][0]["labData"][0]["sequenceData"]["files"].append(
         {
@@ -308,9 +289,7 @@ def test_invalid_short_read_submission_with_bam(dataset: str, version: str):
 @pytest.mark.parametrize("version", TESTED_VERSIONS)
 def test_index_rna_without_dna(version: str):
     """Donors can only have RNA data if DNA data also present."""
-    metadata = json.loads(
-        importlib.resources.files(example_metadata).joinpath("wes_tumor_germline", f"v{version}.json").read_text()
-    )
+    metadata = json.loads(_metadata_raw("wes_tumor_germline", version))
     # reduce to a single lab datum
     metadata["donors"][0]["labData"] = [metadata["donors"][0]["labData"][0]]
     # set the library type to RNA
@@ -326,9 +305,7 @@ def test_index_rna_without_dna(version: str):
 @pytest.mark.parametrize("version", TESTED_VERSIONS)
 def test_index_rna_with_dna(version: str):
     """Donors can only have RNA data if DNA data also present."""
-    metadata = json.loads(
-        importlib.resources.files(example_metadata).joinpath("wes_tumor_germline", f"v{version}.json").read_text()
-    )
+    metadata = json.loads(_metadata_raw("wes_tumor_germline", version))
     # duplicate the last lab datum
     metadata["donors"][0]["labData"].append(copy.deepcopy(metadata["donors"][0]["labData"][-1]))
     # set the library type to RNA
@@ -347,9 +324,7 @@ def test_index_rna_with_dna(version: str):
 
 @pytest.mark.parametrize("version", TESTED_VERSIONS)
 def test_lab_datum(version: str):
-    metadata = GrzSubmissionMetadata.model_validate_json(
-        importlib.resources.files(example_metadata).joinpath("wes_tumor_germline", f"v{version}.json").read_text()
-    )
+    metadata = _metadata("wes_tumor_germline", version)
     with pytest.raises(ValueError, match=re.escape("Long read libraries can't be paired-end.")):
         metadata.donors[0].lab_data[0].library_type = "wes_lr"
 
@@ -526,7 +501,7 @@ def test_research_consent_schema_version_rejected(version: str):
 
 def test_metadata_declaring_schema_1_3_1_validates():
     """Schema 1.3.1 only widens the consent version enum, so it must validate like 1.3.0."""
-    metadata = json.loads(importlib.resources.files(example_metadata).joinpath("wgs_trio", "v1.3.0.json").read_text())
+    metadata = json.loads(_metadata_raw("wgs_trio", "1.3.0"))
     metadata["$schema"] = metadata["$schema"].replace("/v1.3.0/", "/v1.3.1/")
 
     submission = GrzSubmissionMetadata.model_validate(metadata)
@@ -557,8 +532,7 @@ def test_wgs_trio_accepts_renamed_consent_category_system(version: str, category
     Either category CodeSystem spelling must parse: the 2026.0.0 package renamed it but still
     ships examples using the old name.
     """
-    metadata_str = importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
-    metadata = json.loads(metadata_str)
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
     research_consent = metadata["donors"][0]["researchConsents"][0]
     mii_codings = [
         coding
@@ -590,8 +564,7 @@ def test_wgs_trio_accepts_renamed_consent_category_system(version: str, category
 )
 def test_example_research_consent_scopes_parse_as_consent(dataset: str, version: str):
     """The scope union falls back to dict silently, so every example scope must parse as a Consent."""
-    metadata_str = importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text()
-    submission = GrzSubmissionMetadata.model_validate_json(metadata_str)
+    submission = _metadata(dataset, version)
     for donor in submission.donors:
         for research_consent in donor.research_consents:
             assert research_consent.scope is None or isinstance(research_consent.scope, Consent)
@@ -1149,7 +1122,7 @@ def test_disease_type_rare_missing_wgs_raises(dataset: str, version: str):
     """
     These datasets natively use panel or wes. For rare diseases, they fail the wgs check.
     """
-    metadata = json.loads(importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text())
+    metadata = json.loads(_metadata_raw(dataset, version))
     metadata["submission"]["diseaseType"] = DiseaseType.rare.value
     metadata["submission"]["submissionDate"] = "2026-06-01"
 
@@ -1165,7 +1138,7 @@ def test_disease_type_rare_missing_wgs_raises(dataset: str, version: str):
 )
 def test_disease_type_rare_missing_wgs_warns_before_cutoff(dataset: str, version: str, caplog):
     """Before the cutoff, missing wgs for a rare disease should only log a warning."""
-    metadata = json.loads(importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text())
+    metadata = json.loads(_metadata_raw(dataset, version))
     metadata["submission"]["diseaseType"] = DiseaseType.rare.value
     metadata["submission"]["submissionDate"] = "2026-05-31"
 
@@ -1179,9 +1152,7 @@ def test_disease_type_rare_index_has_wgs_and_panel_passes(version: str):
     """
     If the index donor has at least WGS but additionally some panel data, it should still pass.
     """
-    metadata = json.loads(
-        importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
-    )
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
     metadata["submission"]["diseaseType"] = DiseaseType.rare.value
     metadata["submission"]["submissionDate"] = "2026-06-01"
 
@@ -1219,7 +1190,7 @@ def test_disease_type_rare_index_has_wgs_and_panel_passes(version: str):
 )
 def test_disease_type_rare_valid_library_passes(dataset: str, version: str):
     """These datasets natively use wgs or wgs_lr. For rare diseases, they must pass."""
-    metadata = json.loads(importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text())
+    metadata = json.loads(_metadata_raw(dataset, version))
     metadata["submission"]["diseaseType"] = DiseaseType.rare.value
     metadata["submission"]["submissionDate"] = "2026-06-01"
 
@@ -1229,9 +1200,7 @@ def test_disease_type_rare_valid_library_passes(dataset: str, version: str):
 @pytest.mark.parametrize("version", TESTED_VERSIONS)
 def test_disease_type_rare_non_index_unrestricted(version: str):
     """Non-index donors (e.g., parents in a trio) are exempt from the WGS rule."""
-    metadata = json.loads(
-        importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
-    )
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
     metadata["submission"]["diseaseType"] = DiseaseType.rare.value
     metadata["submission"]["submissionDate"] = "2026-06-01"
 
@@ -1262,9 +1231,7 @@ def test_disease_type_rare_non_index_unrestricted(version: str):
 )
 def test_no_scope_justification_tech_org_raises(version: str, justification: str):
     """LE_TECH and LE_ORG justifications should raise an error starting exactly 01.06.2026."""
-    metadata = json.loads(
-        importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
-    )
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
     metadata["submission"]["submissionDate"] = "2026-06-01"
 
     # Apply to all consents to be thorough
@@ -1286,9 +1253,7 @@ def test_no_scope_justification_tech_org_raises(version: str, justification: str
 )
 def test_no_scope_justification_tech_org_warns(version: str, justification: str, caplog):
     """LE_TECH and LE_ORG justifications should only warn strictly before 01.06.2026."""
-    metadata = json.loads(
-        importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
-    )
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
     metadata["submission"]["submissionDate"] = "2026-05-31"
 
     for donor in metadata["donors"]:
@@ -1315,9 +1280,7 @@ def test_no_scope_justification_tech_org_warns(version: str, justification: str,
 )
 def test_no_scope_justification_standard_passes_after_cutoff(version: str, justification: str):
     """Standard valid justifications should continue to pass seamlessly after 01.06.2026."""
-    metadata = json.loads(
-        importlib.resources.files(example_metadata).joinpath("wgs_trio", f"v{version}.json").read_text()
-    )
+    metadata = json.loads(_metadata_raw("wgs_trio", version))
     metadata["submission"]["submissionDate"] = "2026-06-01"
 
     for donor in metadata["donors"]:

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -209,10 +209,7 @@ def test_missing_sequence_subtype_warns_before_cutoff(version: str, caplog):
     del metadata["donors"][0]["labData"][0]
 
     # must not raise for this rule
-    try:
-        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-    except ValidationError as e:
-        assert "Index donor is missing sequence subtypes" not in str(e)
+    GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
     assert "Index donor is missing sequence subtypes" in caplog.text
     assert "starting 04.12.2025" in caplog.text
@@ -1172,10 +1169,7 @@ def test_disease_type_rare_missing_wgs_warns_before_cutoff(dataset: str, version
     metadata["submission"]["diseaseType"] = DiseaseType.rare.value
     metadata["submission"]["submissionDate"] = "2026-05-31"
 
-    try:
-        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-    except ValidationError as e:
-        assert "starting 01.06.2026" not in str(e)
+    GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
     assert "starting 01.06.2026" in caplog.text
 
@@ -1209,10 +1203,7 @@ def test_disease_type_rare_index_has_wgs_and_panel_passes(version: str):
 
     metadata["donors"][0]["labData"].append(panel_datum)
 
-    try:
-        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-    except ValidationError as e:
-        assert "starting 01.06.2026" not in str(e)
+    GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
 
 @pytest.mark.parametrize(
@@ -1232,10 +1223,7 @@ def test_disease_type_rare_valid_library_passes(dataset: str, version: str):
     metadata["submission"]["diseaseType"] = DiseaseType.rare.value
     metadata["submission"]["submissionDate"] = "2026-06-01"
 
-    try:
-        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-    except ValidationError as e:
-        assert "starting 01.06.2026" not in str(e)
+    GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
 
 @pytest.mark.parametrize("version", TESTED_VERSIONS)
@@ -1261,11 +1249,8 @@ def test_disease_type_rare_non_index_unrestricted(version: str):
             }
         )
 
-    try:
-        # should pass because the index donor still has WGS
-        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-    except ValidationError as e:
-        assert "starting 01.06.2026" not in str(e)
+    # should pass because the index donor still has WGS
+    GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
 
 @pytest.mark.parametrize(
@@ -1311,10 +1296,7 @@ def test_no_scope_justification_tech_org_warns(version: str, justification: str,
             consent["noScopeJustification"] = justification
             consent.pop("scope", None)
 
-    try:
-        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-    except ValidationError as e:
-        assert "is no longer allowed starting 01.06.2026" not in str(e)
+    GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
 
     assert "is no longer allowed starting 01.06.2026" in caplog.text
 
@@ -1343,7 +1325,4 @@ def test_no_scope_justification_standard_passes_after_cutoff(version: str, justi
             consent["noScopeJustification"] = justification
             consent.pop("scope", None)
 
-    try:
-        GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
-    except ValidationError as e:
-        assert "is no longer allowed starting 01.06.2026" not in str(e)
+    GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -46,7 +46,7 @@ TESTED_VERSIONS = ["1.2.1", "1.3.0"]
 
 
 def _metadata_raw(dataset: str, version: str) -> str:
-    """The raw JSON of an example metadata submission, for tests that mutate it before validation."""
+    """The raw JSON text of an example metadata submission."""
     return importlib.resources.files(example_metadata).joinpath(dataset, f"v{version}.json").read_text()
 
 
@@ -337,9 +337,9 @@ def test_index_rna_with_dna(version: str):
 
 @pytest.mark.parametrize("version", TESTED_VERSIONS)
 def test_lab_datum(version: str):
-    metadata = _metadata("wes_tumor_germline", version)
+    submission = _metadata("wes_tumor_germline", version)
     with pytest.raises(ValueError, match=re.escape("Long read libraries can't be paired-end.")):
-        metadata.donors[0].lab_data[0].library_type = "wes_lr"
+        submission.donors[0].lab_data[0].library_type = "wes_lr"
 
 
 def test_file_extensions():

--- a/packages/grz-pydantic-models/tests/test_metadata_failing.py
+++ b/packages/grz-pydantic-models/tests/test_metadata_failing.py
@@ -9,32 +9,24 @@ from pydantic import ValidationError
 
 resource_files = importlib.resources.files(failing_metadata)
 
-metadata_missing_read_order = resource_files.joinpath("missing-read-order.json")
-metadata_missing_vcf_file = resource_files.joinpath("missing-vcf-file.json")
-metadata_missing_fastq_r2 = resource_files.joinpath("missing-fastq-r2.json")
-metadata_no_target_regions = resource_files.joinpath("missing-target-regions.json")
-metadata_incompatible_reference_genomes = resource_files.joinpath("incompatible-reference-genomes.json")
-metadata_duplicate_run_id = resource_files.joinpath("duplicate-run-id.json")
+error_types = (ValueError, ValidationError, SystemExit)
 
 
-def test_submission_metadata_fails():
-    error_types = (ValueError, ValidationError, SystemExit)
-    with pytest.raises(error_types, match="No read order specified for FASTQ file"):
-        GrzSubmissionMetadata.model_validate_json(metadata_missing_read_order.read_text())
+@pytest.mark.parametrize(
+    "fixture_name,expected_match",
+    (
+        ("missing-read-order.json", "No read order specified for FASTQ file"),
+        ("missing-target-regions.json", "BED file missing for lab datum"),
+        ("missing-fastq-r2.json", "Paired end sequencing layout but not there is not exactly one R1 and one R2"),
+        ("incompatible-reference-genomes.json", "Incompatible reference genomes found"),
+        ("duplicate-run-id.json", "must have a unique combination of flowcell_id, lane_id, and read_order"),
+    ),
+)
+def test_submission_metadata_fails(fixture_name: str, expected_match: str):
+    with pytest.raises(error_types, match=expected_match):
+        GrzSubmissionMetadata.model_validate_json(resource_files.joinpath(fixture_name).read_text())
 
-    with pytest.raises(error_types, match="BED file missing for lab datum"):
-        GrzSubmissionMetadata.model_validate_json(metadata_no_target_regions.read_text())
 
-    # missing VCF is allowed
-    GrzSubmissionMetadata.model_validate_json(metadata_missing_vcf_file.read_text())
-
-    with pytest.raises(
-        error_types, match="Paired end sequencing layout but not there is not exactly one R1 and one R2"
-    ):
-        GrzSubmissionMetadata.model_validate_json(metadata_missing_fastq_r2.read_text())
-
-    with pytest.raises(error_types, match="Incompatible reference genomes found"):
-        GrzSubmissionMetadata.model_validate_json(metadata_incompatible_reference_genomes.read_text())
-
-    with pytest.raises(error_types, match="must have a unique combination of flowcell_id, lane_id, and read_order"):
-        GrzSubmissionMetadata.model_validate_json(metadata_duplicate_run_id.read_text())
+def test_submission_metadata_missing_vcf_file_passes():
+    """A missing VCF file is allowed."""
+    GrzSubmissionMetadata.model_validate_json(resource_files.joinpath("missing-vcf-file.json").read_text())

--- a/packages/grzctl/pyproject.toml
+++ b/packages/grzctl/pyproject.toml
@@ -65,5 +65,6 @@ test = [
     "numpy",
     "grz-common",
     "grz-cli",
+    "grz-db[testing]",
     "grz-pydantic-models-testing",
 ]

--- a/packages/grzctl/tests/cli/conftest.py
+++ b/packages/grzctl/tests/cli/conftest.py
@@ -62,15 +62,15 @@ def _write_config(tmp_path: Path, config: DbConfig) -> Path:
 
 
 @pytest.fixture
-def blank_database_config(tmp_path: Path, migrated_db_connection: str) -> DbConfig:
+def migrated_database_config(tmp_path: Path, migrated_db_connection: str) -> DbConfig:
     """Config for a database already on the latest schema, one per supported backend."""
     return _database_config(tmp_path, migrated_db_connection)
 
 
 @pytest.fixture
-def blank_database_config_path(tmp_path: Path, blank_database_config: DbConfig) -> Path:
+def migrated_database_config_path(tmp_path: Path, migrated_database_config: DbConfig) -> Path:
     """Path to a config file for a database on the latest schema."""
-    return _write_config(tmp_path, blank_database_config)
+    return _write_config(tmp_path, migrated_database_config)
 
 
 @pytest.fixture
@@ -83,7 +83,7 @@ def empty_database_config_path(tmp_path: Path, db_test_connection: str) -> Path:
 
 
 @pytest.fixture
-def blank_initial_database_config_path(empty_database_config_path: Path) -> Path:
+def initial_revision_database_config_path(empty_database_config_path: Path) -> Path:
     """Path to a config file for a database at :data:`INITIAL_REVISION`, ready to be upgraded."""
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()

--- a/packages/grzctl/tests/cli/conftest.py
+++ b/packages/grzctl/tests/cli/conftest.py
@@ -1,16 +1,17 @@
 import importlib.resources
-import shutil
 from pathlib import Path
 
 import click.testing
 import cryptography.hazmat.primitives.serialization as cryptser
 import grzctl.cli
-import psycopg
 import pytest
 import yaml
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from grz_pydantic_models_testing.example_metadata import grzctl as grzctl_metadata
 from grzctl.models.config import DbConfig
+
+#: The revision the schema-upgrade tests start from.
+INITIAL_REVISION = "1a9bd994df1b"
 
 
 @pytest.fixture
@@ -18,16 +19,8 @@ def test_metadata_path():
     return importlib.resources.files(grzctl_metadata).joinpath("metadata.json")
 
 
-@pytest.fixture(
-    params=[
-        "sqlite",
-        pytest.param(
-            "postgresql",
-            marks=pytest.mark.skipif(condition=shutil.which("pg_config") is None, reason="postgresql not detected"),
-        ),
-    ]
-)
-def blank_database_config(request: pytest.FixtureRequest, tmp_path: Path) -> DbConfig:
+def _database_config(tmp_path: Path, database_url: str) -> DbConfig:
+    """Build a config for *database_url*, signed by a throwaway key pair written under *tmp_path*."""
     private_key = Ed25519PrivateKey.generate()
     private_key_path = tmp_path / "alice.sec"
     with open(private_key_path, "wb") as private_key_file:
@@ -48,11 +41,6 @@ def blank_database_config(request: pytest.FixtureRequest, tmp_path: Path) -> DbC
         # add the comment too
         public_key_file.write(b" alice")
 
-    database_url = "sqlite:///" + str((tmp_path / "submission.db.sqlite").resolve())
-    if request.param == "postgresql":
-        postgresql: psycopg.Connection = request.getfixturevalue("postgresql")
-        database_url = f"postgresql+psycopg://{postgresql.info.user}:@{postgresql.info.host}:{postgresql.info.port}/{postgresql.info.dbname}"
-
     return DbConfig(
         db={
             "database_url": database_url,
@@ -66,27 +54,42 @@ def blank_database_config(request: pytest.FixtureRequest, tmp_path: Path) -> DbC
     )
 
 
-@pytest.fixture
-def blank_initial_database_config_path(tmp_path: Path, blank_database_config: DbConfig) -> Path:
+def _write_config(tmp_path: Path, config: DbConfig) -> Path:
     config_path = tmp_path / "config.db.yaml"
     with open(config_path, "w") as config_file:
-        config_file.write(yaml.dump(blank_database_config.model_dump(mode="json")))
-
-    runner = click.testing.CliRunner()
-    cli = grzctl.cli.build_cli()
-    _ = runner.invoke(cli, ["db", "--config-file", str(config_path), "upgrade", "--revision", "1a9bd994df1b"])
-
+        config_file.write(yaml.dump(config.model_dump(mode="json")))
     return config_path
+
+
+@pytest.fixture
+def blank_database_config(tmp_path: Path, migrated_db_connection: str) -> DbConfig:
+    """Config for a database already on the latest schema, one per supported backend."""
+    return _database_config(tmp_path, migrated_db_connection)
 
 
 @pytest.fixture
 def blank_database_config_path(tmp_path: Path, blank_database_config: DbConfig) -> Path:
-    config_path = tmp_path / "config.db.yaml"
-    with open(config_path, "w") as config_file:
-        config_file.write(yaml.dump(blank_database_config.model_dump(mode="json")))
+    """Path to a config file for a database on the latest schema."""
+    return _write_config(tmp_path, blank_database_config)
 
+
+@pytest.fixture
+def empty_database_config_path(tmp_path: Path, db_test_connection: str) -> Path:
+    """Path to a config file for a database with no schema at all.
+
+    For tests that drive ``db init`` or ``db upgrade`` themselves.
+    """
+    return _write_config(tmp_path, _database_config(tmp_path, db_test_connection))
+
+
+@pytest.fixture
+def blank_initial_database_config_path(empty_database_config_path: Path) -> Path:
+    """Path to a config file for a database at :data:`INITIAL_REVISION`, ready to be upgraded."""
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
-    _ = runner.invoke(cli, ["db", "--config-file", str(config_path), "init"])
+    result = runner.invoke(
+        cli, ["db", "--config-file", str(empty_database_config_path), "upgrade", "--revision", INITIAL_REVISION]
+    )
+    assert result.exit_code == 0, result.stderr
 
-    return config_path
+    return empty_database_config_path

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -1,8 +1,8 @@
 # Backfill unit tests — see .vbw-planning/phases/02-implement-grzctl-db-backfill-command/02-02-PLAN.md
 """Unit tests for `_backfill_submission`.
 
-The tests target `_backfill_submission` directly with a real SubmissionDb on SQLite
-and a moto-mocked S3. Live in `grzctl/tests/` (not `grz-db/tests/`) because `grzctl`
+The tests target `_backfill_submission` directly with a real SubmissionDb on every supported
+backend and a moto-mocked S3. Live in `grzctl/tests/` (not `grz-db/tests/`) because `grzctl`
 is not a dev/test dependency of `grz-db`, but `moto[s3]`, `pytest-postgresql`, and
 `grz-pydantic-models-testing` are all in `grzctl`'s [test] dependency group.
 """
@@ -15,9 +15,6 @@ from typing import Any
 
 import boto3
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ed25519
-from grz_db.models.author import Author
 from grz_db.models.submission import Submission, SubmissionDb
 from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
 from grz_pydantic_models_testing.example_metadata import grzctl as grzctl_metadata
@@ -43,25 +40,6 @@ def metadata() -> GrzSubmissionMetadata:
 @pytest.fixture(scope="session")
 def submission_id(metadata: GrzSubmissionMetadata) -> str:
     return metadata.submission_id
-
-
-@pytest.fixture
-def test_author() -> Author:
-    key = ed25519.Ed25519PrivateKey.generate()
-    private_key_bytes = key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.OpenSSH,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-    return Author(name="alice", private_key_bytes=private_key_bytes, private_key_passphrase="")
-
-
-@pytest.fixture
-def db(tmp_path, test_author: Author) -> SubmissionDb:
-    db_url = f"sqlite:///{tmp_path / 'backfill.db'}"
-    submission_db = SubmissionDb(db_url=db_url, author=test_author, debug=False)
-    submission_db.initialize_schema()
-    return submission_db
 
 
 @pytest.fixture

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -6,7 +6,6 @@ import datetime
 import hashlib
 import json
 import random
-import sqlite3
 from datetime import date
 from operator import attrgetter
 from pathlib import Path
@@ -829,15 +828,6 @@ def test_list_filter_modes_and_multiple_states(blank_database_config_path: Path)
     assert {item["id"] for item in parsed_error_any} == {sub_latest_error, sub_history_error_latest_uploaded}
     history_match = next(filter(lambda item: item["id"] == sub_history_error_latest_uploaded, parsed_error_any))
     assert history_match["latest_state"]["state"] == "Uploaded"
-
-    # filter mode parsing remains case-insensitive
-    result_error_any_upper = runner.invoke(
-        cli,
-        [*args_common, "list", "--json", "--state", "error", "--filter-mode", "ANY"],
-    )
-    assert result_error_any_upper.exit_code == 0, result_error_any_upper.stderr
-    parsed_error_any_upper = json.loads(result_error_any_upper.stdout)
-    assert {item["id"] for item in parsed_error_any_upper} == {sub_latest_error, sub_history_error_latest_uploaded}
 
     # multiple filters in default latest mode are OR-ed on latest state
     result_multi_latest = runner.invoke(
@@ -1677,47 +1667,6 @@ def test_submission_grzctl_version_different_versions(
         assert state["grzctl_versions"]["grzctl"] == expected_versions[i], (
             f"state {i} should carry the version recorded at write time, not the current one"
         )
-
-
-def test_failure_reason_migration(blank_initial_database_config_path):
-    """Test the failure_reason migration works correctly."""
-    # Set up test data before migration
-    config = DbConfig.from_path(blank_initial_database_config_path)
-
-    if not config.db.database_url.startswith("sqlite:///"):
-        pytest.skip("Test uses sqlite3 directly and only works with SQLite")
-
-    submission_id = "123456789_2024-11-08_d0f805c5"
-
-    with sqlite3.connect(config.db.database_url[len("sqlite:///") :]) as connection:
-        connection.execute(
-            "INSERT INTO submissions(id) VALUES(:id)",
-            {"id": submission_id},
-        )
-
-    # Test CLI commands fail before migration
-    runner = click.testing.CliRunner()
-    cli = grzctl.cli.build_cli()
-    args_common = ["db", "--config-file", blank_initial_database_config_path]
-
-    result_premature = runner.invoke(cli, [*args_common, "list"])
-    assert result_premature.exit_code != 0
-    assert "Database not at latest schema" in result_premature.stderr
-
-    # Run the migration
-    result_upgrade = runner.invoke(cli, [*args_common, "upgrade"])
-    assert result_upgrade.exit_code == 0, result_upgrade.stderr
-
-    # Test that failure_reason functionality works
-    result_update = runner.invoke(
-        cli, [*args_common, "submission", "update", submission_id, "Error", "--failure-reason", "decryption_error"]
-    )
-    assert result_update.exit_code == 0, result_update.stderr
-
-    # Verify the failure reason was stored
-    result_show = runner.invoke(cli, [*args_common, "submission", "show", submission_id])
-    assert result_show.exit_code == 0, result_show.stderr
-    assert "decryption_err" in result_show.stdout
 
 
 def test_submission_show_json_includes_failure_reason(blank_database_config_path: Path):

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -1503,7 +1503,9 @@ def test_submission_grzctl_versions_logging(blank_database_config_path: Path, te
         "grz-pydantic-models": "1.0.0",
         "grz-check": "1.0.0",
     }
-    monkeypatch.setattr("grzctl.get_versions", lambda: test_versions_dict)
+    # patch the binding the writer actually calls: db.cli imported the name, so patching it on the
+    # grzctl package would leave the real versions being recorded
+    monkeypatch.setattr("grzctl.commands.db.cli.get_versions", lambda: test_versions_dict)
 
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
@@ -1559,7 +1561,16 @@ def test_submission_grzctl_versions_logging(blank_database_config_path: Path, te
         assert "data_steward" in state
         assert "data_steward_signature" in state
 
-    # Test 2: Verify database records have the version
+    # Test 2: Verify grzctl_versions reaches the human-readable table too. The column is rendered
+    # wide enough to read only on a wide terminal; at the default width rich truncates it away.
+    wide_runner = click.testing.CliRunner(env={"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test", "COLUMNS": "500"})
+    result_show_table = wide_runner.invoke(cli, [*args_common, "submission", "show", metadata.submission_id])
+    assert result_show_table.exit_code == 0, result_show_table.stderr
+    # the cell holds a JSON blob that rich wraps, so compare with the layout whitespace removed
+    rendered = "".join(result_show_table.stdout.split())
+    assert test_version in rendered, "the Dependency Versions column should carry the versions"
+
+    # Test 3: Verify database records have the version
     config = DbConfig.from_path(blank_database_config_path)
     db = SubmissionDb(db_url=config.db.database_url, author=None)
     submission = db.get_submission(metadata.submission_id)
@@ -1600,7 +1611,7 @@ def test_submission_grzctl_version_different_versions(
 
     # State update #1 with version 0.1.0
     monkeypatch.setattr(
-        "grzctl.get_versions",
+        "grzctl.commands.db.cli.get_versions",
         lambda: {
             "grzctl": "0.1.0",
             "grz-cli": "1.0.0",
@@ -1617,7 +1628,7 @@ def test_submission_grzctl_version_different_versions(
 
     # State update #2 with version 0.1.1
     monkeypatch.setattr(
-        "grzctl.get_versions",
+        "grzctl.commands.db.cli.get_versions",
         lambda: {
             "grzctl": "0.1.1",
             "grz-cli": "1.0.0",
@@ -1634,7 +1645,7 @@ def test_submission_grzctl_version_different_versions(
 
     # State update #3 with version 0.2.0
     monkeypatch.setattr(
-        "grzctl.get_versions",
+        "grzctl.commands.db.cli.get_versions",
         lambda: {
             "grzctl": "0.2.0",
             "grz-cli": "1.0.0",
@@ -1657,14 +1668,15 @@ def test_submission_grzctl_version_different_versions(
     # Verify each state has grzctl_versions recorded
     assert len(parsed_json["states"]) == 3, "Expected 3 state transitions"
     expected_states = ["Downloading", "Downloaded", "QCing"]
+    expected_versions = ["0.1.0", "0.1.1", "0.2.0"]
     for i, state in enumerate(parsed_json["states"]):
         assert "grzctl_versions" in state, f"grzctl_versions missing in state {i}"
         assert state["state"] == expected_states[i], (
             f"Expected state {expected_states[i]}, got {state['state']} at index {i}"
         )
-        # Verify grzctl_versions structure (not checking specific versions due to import-time binding)
-        assert isinstance(state["grzctl_versions"], dict), f"grzctl_versions should be dict in state {i}"
-        assert "grzctl" in state["grzctl_versions"], f"grzctl missing in grzctl_versions for state {i}"
+        assert state["grzctl_versions"]["grzctl"] == expected_versions[i], (
+            f"state {i} should carry the version recorded at write time, not the current one"
+        )
 
 
 def test_failure_reason_migration(blank_initial_database_config_path):

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -36,10 +36,10 @@ def test_init_brings_an_empty_database_to_the_latest_schema(empty_database_confi
     assert result_list.exit_code == 0, result_list.stderr
 
 
-def test_all_migrations(blank_initial_database_config_path):
+def test_all_migrations(initial_revision_database_config_path):
     """Database migrations should work all the way from the oldest supported to the latest version."""
     # add some test data
-    config = DbConfig.from_path(blank_initial_database_config_path)
+    config = DbConfig.from_path(initial_revision_database_config_path)
     tan_g = "a2b6c3d9e8f7123456789abcdef0123456789abcdef0123456789abcdef01234"
     pseudonym = "CASE12345"
     submission_id = "123456789_2024-11-08_d0f805c5"
@@ -69,7 +69,7 @@ def test_all_migrations(blank_initial_database_config_path):
     # ensure db command raises appropriate error before migration
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
-    args_common = ["db", "--config-file", blank_initial_database_config_path]
+    args_common = ["db", "--config-file", initial_revision_database_config_path]
     result_premature_list = runner.invoke(cli, [*args_common, "list"])
     assert result_premature_list.exit_code != 0
     assert "Database not at latest schema" in result_premature_list.stderr
@@ -110,8 +110,8 @@ def test_all_migrations(blank_initial_database_config_path):
     assert latest_state.failure_reason == FailureReasonEnum.DECRYPTION_ERROR
 
 
-def test_populate(blank_database_config_path: Path, test_metadata_path: Path):
-    args_common = ["db", "--config-file", blank_database_config_path]
+def test_populate(migrated_database_config_path: Path, test_metadata_path: Path):
+    args_common = ["db", "--config-file", migrated_database_config_path]
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
     runner = click.testing.CliRunner(catch_exceptions=False)
@@ -129,7 +129,7 @@ def test_populate(blank_database_config_path: Path, test_metadata_path: Path):
     # shorter than tanG and less likely to be truncated in various terminal widths
     assert metadata.submission.local_case_id in result_show.stdout, result_show.stdout
 
-    config = DbConfig.from_path(blank_database_config_path)
+    config = DbConfig.from_path(migrated_database_config_path)
     db = SubmissionDb(db_url=config.db.database_url, author=None)
 
     submission = db.get_submission(metadata.submission_id)
@@ -149,8 +149,8 @@ def test_populate(blank_database_config_path: Path, test_metadata_path: Path):
     assert submission.submission_size == metadata.get_submission_size()
 
 
-def test_populate_date(blank_database_config_path: Path, test_metadata_path: Path):
-    db_args = ["db", "--config-file", blank_database_config_path]
+def test_populate_date(migrated_database_config_path: Path, test_metadata_path: Path):
+    db_args = ["db", "--config-file", migrated_database_config_path]
     changed_date = date(2026, 1, 1)
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
@@ -179,15 +179,15 @@ def test_populate_date(blank_database_config_path: Path, test_metadata_path: Pat
     # shorter than tanG and less likely to be truncated in various terminal widths
     assert metadata.submission.local_case_id in result_show.stdout, result_show.stdout
 
-    config = DbConfig.from_path(blank_database_config_path)
+    config = DbConfig.from_path(migrated_database_config_path)
     db = SubmissionDb(db_url=config.db.database_url, author=None)
 
     submission = db.get_submission(metadata.submission_id)
     assert submission.submission_uploaded_date == changed_date
 
 
-def test_populate_redacted(tmp_path: Path, blank_database_config_path: Path, test_metadata_path: Path):
-    args_common = ["db", "--config-file", blank_database_config_path]
+def test_populate_redacted(tmp_path: Path, migrated_database_config_path: Path, test_metadata_path: Path):
+    args_common = ["db", "--config-file", migrated_database_config_path]
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
     # compute submission ID _before_ tanG is redacted (changing the property return value)
@@ -212,7 +212,7 @@ def test_populate_redacted(tmp_path: Path, blank_database_config_path: Path, tes
         )
 
 
-def test_repopulate(blank_database_config_path: Path, tmp_path: Path, test_metadata_path: Path):
+def test_repopulate(migrated_database_config_path: Path, tmp_path: Path, test_metadata_path: Path):
     """
     Repopulating a database should work, including when:
     - two donors from different submitters have the same pseudonym.
@@ -222,7 +222,7 @@ def test_repopulate(blank_database_config_path: Path, tmp_path: Path, test_metad
     rng.seed(42)
     changed_date = date(2026, 1, 1)
 
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
 
@@ -296,8 +296,8 @@ def test_repopulate(blank_database_config_path: Path, tmp_path: Path, test_metad
     assert result_repopulate_s1.exit_code == 0, result_repopulate_s1.stderr
 
     # sanity check the database
-    with open(blank_database_config_path, encoding="utf-8") as blank_database_config_file:
-        config = yaml.load(blank_database_config_file, Loader=yaml.Loader)
+    with open(migrated_database_config_path, encoding="utf-8") as migrated_database_config_file:
+        config = yaml.load(migrated_database_config_file, Loader=yaml.Loader)
     db = SubmissionDb(db_url=config["db"]["database_url"], author=None)
 
     submissions = db.list_submissions(limit=None)
@@ -317,8 +317,8 @@ def test_repopulate(blank_database_config_path: Path, tmp_path: Path, test_metad
     assert len(donors_s2) == 2, "Expected two donors in submission 2"
 
 
-def test_populate_qc(blank_database_config_path: Path, tmp_path: Path, test_metadata_path: Path):
-    args_common = ["db", "--config-file", blank_database_config_path]
+def test_populate_qc(migrated_database_config_path: Path, tmp_path: Path, test_metadata_path: Path):
+    args_common = ["db", "--config-file", migrated_database_config_path]
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
     runner = click.testing.CliRunner(catch_exceptions=False)
@@ -366,8 +366,8 @@ def test_populate_qc(blank_database_config_path: Path, tmp_path: Path, test_meta
     )
     assert result_populate.exit_code == 0, result_populate.stderr
 
-    with open(blank_database_config_path, encoding="utf-8") as blank_database_config_file:
-        config = yaml.load(blank_database_config_file, Loader=yaml.Loader)
+    with open(migrated_database_config_path, encoding="utf-8") as migrated_database_config_file:
+        config = yaml.load(migrated_database_config_file, Loader=yaml.Loader)
     db = SubmissionDb(db_url=config["db"]["database_url"], author=None)
 
     results = db.get_detailed_qc_results(metadata.submission_id)
@@ -377,10 +377,10 @@ def test_populate_qc(blank_database_config_path: Path, tmp_path: Path, test_meta
 
 
 def test_populate_qc_with_qc_workflow_version_flag(
-    blank_database_config_path: Path, tmp_path: Path, test_metadata_path: Path
+    migrated_database_config_path: Path, tmp_path: Path, test_metadata_path: Path
 ):
     """Test populate-qc with --qc-workflow-version flag."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
     runner = click.testing.CliRunner(catch_exceptions=False)
@@ -425,8 +425,8 @@ def test_populate_qc_with_qc_workflow_version_flag(
     )
     assert result_populate_qc.exit_code == 0, result_populate_qc.stderr
 
-    with open(blank_database_config_path, encoding="utf-8") as blank_database_config_file:
-        config = yaml.load(blank_database_config_file, Loader=yaml.Loader)
+    with open(migrated_database_config_path, encoding="utf-8") as migrated_database_config_file:
+        config = yaml.load(migrated_database_config_file, Loader=yaml.Loader)
     db = SubmissionDb(db_url=config["db"]["database_url"], author=None)
 
     results = db.get_detailed_qc_results(metadata.submission_id)
@@ -435,10 +435,10 @@ def test_populate_qc_with_qc_workflow_version_flag(
 
 
 def test_populate_qc_with_qc_workflow_version_env_var(
-    blank_database_config_path: Path, tmp_path: Path, test_metadata_path: Path, monkeypatch
+    migrated_database_config_path: Path, tmp_path: Path, test_metadata_path: Path, monkeypatch
 ):
     """Test populate-qc with GRZCTL_QC_WORKFLOW_VERSION environment variable."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
     # Set the environment variable
@@ -484,8 +484,8 @@ def test_populate_qc_with_qc_workflow_version_env_var(
     )
     assert result_populate_qc.exit_code == 0, result_populate_qc.stderr
 
-    with open(blank_database_config_path, encoding="utf-8") as blank_database_config_file:
-        config = yaml.load(blank_database_config_file, Loader=yaml.Loader)
+    with open(migrated_database_config_path, encoding="utf-8") as migrated_database_config_file:
+        config = yaml.load(migrated_database_config_file, Loader=yaml.Loader)
     db = SubmissionDb(db_url=config["db"]["database_url"], author=None)
 
     results = db.get_detailed_qc_results(metadata.submission_id)
@@ -494,10 +494,10 @@ def test_populate_qc_with_qc_workflow_version_env_var(
 
 
 def test_populate_qc_missing_qc_workflow_version(
-    blank_database_config_path: Path, tmp_path: Path, test_metadata_path: Path
+    migrated_database_config_path: Path, tmp_path: Path, test_metadata_path: Path
 ):
     """Test populate-qc fails when qc_workflow_version is not provided."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
     runner = click.testing.CliRunner(catch_exceptions=False)
@@ -542,9 +542,9 @@ def test_populate_qc_missing_qc_workflow_version(
     assert "No QC workflow version found" in result_populate_qc.output
 
 
-def test_populate_qc_version_from_report(blank_database_config_path: Path, tmp_path: Path, test_metadata_path: Path):
+def test_populate_qc_version_from_report(migrated_database_config_path: Path, tmp_path: Path, test_metadata_path: Path):
     """populate-qc takes the version from the report's grzQcWorkflowVersion column when no flag is given."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
     runner = click.testing.CliRunner(catch_exceptions=False)
@@ -578,8 +578,8 @@ def test_populate_qc_version_from_report(blank_database_config_path: Path, tmp_p
     )
     assert result_populate_qc.exit_code == 0, result_populate_qc.stderr
 
-    with open(blank_database_config_path, encoding="utf-8") as blank_database_config_file:
-        config = yaml.load(blank_database_config_file, Loader=yaml.Loader)
+    with open(migrated_database_config_path, encoding="utf-8") as migrated_database_config_file:
+        config = yaml.load(migrated_database_config_file, Loader=yaml.Loader)
     db = SubmissionDb(db_url=config["db"]["database_url"], author=None)
 
     results = db.get_detailed_qc_results(metadata.submission_id)
@@ -587,9 +587,11 @@ def test_populate_qc_version_from_report(blank_database_config_path: Path, tmp_p
     assert results[0].qc_workflow_version == "2.1.0+nonredundant"
 
 
-def test_populate_qc_flag_report_mismatch(blank_database_config_path: Path, tmp_path: Path, test_metadata_path: Path):
+def test_populate_qc_flag_report_mismatch(
+    migrated_database_config_path: Path, tmp_path: Path, test_metadata_path: Path
+):
     """populate-qc errors when --qc-workflow-version disagrees with the report's grzQcWorkflowVersion."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
     runner = click.testing.CliRunner(catch_exceptions=False)
@@ -634,9 +636,9 @@ def test_populate_qc_flag_report_mismatch(blank_database_config_path: Path, tmp_
     assert "disagrees" in result_populate_qc.output
 
 
-def test_update_error_confirm(blank_database_config_path: Path, test_metadata_path: Path):
+def test_update_error_confirm(migrated_database_config_path: Path, test_metadata_path: Path):
     """Database should confirm before updating a submission from an Error state."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
     runner = click.testing.CliRunner()
@@ -660,13 +662,13 @@ def test_update_error_confirm(blank_database_config_path: Path, test_metadata_pa
     assert result_update3.exit_code == 0, result_update3.output
 
 
-def test_list_sort(blank_database_config_path: Path):
+def test_list_sort(migrated_database_config_path: Path):
     """
     List command should sort in the expected order:
     0. null latest state timestamp and null submission date
     1. latest state timestamp if not null, otherwise submission date
     """
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
 
     expected_ordering = [
         {"id": "123456789_2025-07-01_a1b2c3d4"},
@@ -699,12 +701,12 @@ def test_list_sort(blank_database_config_path: Path):
         assert submission["id"] == result_list_parsed[i]["id"]
 
 
-def test_submission_show_json(blank_database_config_path: Path, test_metadata_path: Path):
+def test_submission_show_json(migrated_database_config_path: Path, test_metadata_path: Path):
     """
     `grzctl db submission show --json` should return machine-readable JSON
     with submission metadata and state history.
     """
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
 
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
@@ -797,25 +799,25 @@ def _listed_ids(cli, args_common: list, *filter_args: str) -> set:
 
 
 @pytest.fixture
-def state_history_db(blank_database_config_path: Path):
-    """A database seeded with submissions covering every state-filter case."""
+def seeded_state_histories(migrated_database_config_path: Path):
+    """The CLI, its common arguments, and the IDs of submissions covering every state-filter case."""
     cli = grzctl.cli.build_cli()
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     return cli, args_common, _seed_state_histories(cli, args_common)
 
 
-def test_list_filters_on_the_latest_state_by_default(state_history_db):
+def test_list_filters_on_the_latest_state_by_default(seeded_state_histories):
     """Without --filter-mode only the current state counts, so an Error in history does not match."""
-    cli, args_common, ids = state_history_db
+    cli, args_common, ids = seeded_state_histories
 
     assert _listed_ids(cli, args_common) == set(vars(ids).values()), "an unfiltered list must return every submission"
     assert _listed_ids(cli, args_common, "--state", "error") == {ids.latest_error}
     assert _listed_ids(cli, args_common, "--state", "downloaded") == {ids.latest_downloaded}
 
 
-def test_list_any_mode_matches_states_anywhere_in_history(state_history_db):
+def test_list_any_mode_matches_states_anywhere_in_history(seeded_state_histories):
     """--filter-mode any is what finds submissions that recovered from a state."""
-    cli, args_common, ids = state_history_db
+    cli, args_common, ids = seeded_state_histories
 
     runner = click.testing.CliRunner()
     result = runner.invoke(cli, [*args_common, "list", "--json", "--state", "error", "--filter-mode", "any"])
@@ -827,9 +829,9 @@ def test_list_any_mode_matches_states_anywhere_in_history(state_history_db):
     assert recovered["latest_state"]["state"] == "Uploaded", "matching on history must not alter the reported state"
 
 
-def test_list_ors_repeated_state_filters(state_history_db):
+def test_list_ors_repeated_state_filters(seeded_state_histories):
     """Repeated --state values are OR-ed, in either filter mode."""
-    cli, args_common, ids = state_history_db
+    cli, args_common, ids = seeded_state_histories
 
     assert _listed_ids(cli, args_common, "--state", "error", "--state", "qced") == {ids.latest_error, ids.latest_qced}
     assert _listed_ids(cli, args_common, "--state", "error", "--state", "qced", "--filter-mode", "any") == {
@@ -860,8 +862,8 @@ def _add_submission(runner: click.testing.CliRunner, cli, args_common: list, sub
     assert result.exit_code == 0, result.stderr
 
 
-def test_change_request_delete_succeeds_with_yaml_data_file(blank_database_config_path: Path, tmp_path: Path):
-    args_common = ["db", "--config-file", blank_database_config_path]
+def test_change_request_delete_succeeds_with_yaml_data_file(migrated_database_config_path: Path, tmp_path: Path):
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -886,7 +888,7 @@ def test_change_request_delete_succeeds_with_yaml_data_file(blank_database_confi
     assert "has undergone a change request" in result.stderr.replace("\n", " ")
     assert "Delete" in result.stderr
 
-    config = DbConfig.from_path(blank_database_config_path)
+    config = DbConfig.from_path(migrated_database_config_path)
     db = SubmissionDb(db_url=config.db.database_url, author=None)
     submissions_with_changes = [s for s in db.list_change_requests() if s.id == submission_id]
     assert len(submissions_with_changes) == 1
@@ -896,9 +898,9 @@ def test_change_request_delete_succeeds_with_yaml_data_file(blank_database_confi
     assert changes[0].data is None
 
 
-def test_change_request_delete_succeeds_with_inline_data(blank_database_config_path: Path):
+def test_change_request_delete_succeeds_with_inline_data(migrated_database_config_path: Path):
     """`--data` accepts valid Delete data and stores it the same way `--data-file` does."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -918,15 +920,15 @@ def test_change_request_delete_succeeds_with_inline_data(blank_database_config_p
     )
     assert result.exit_code == 0, result.stderr
 
-    config = DbConfig.from_path(blank_database_config_path)
+    config = DbConfig.from_path(migrated_database_config_path)
     db = SubmissionDb(db_url=config.db.database_url, author=None)
     submissions_with_changes = [s for s in db.list_change_requests() if s.id == submission_id]
     _assert_audit_columns_match(submissions_with_changes[0].changes[0], _DELETE_CHANGE_REQUEST_DATA)
 
 
-def test_change_request_delete_inline_data_rejects_placeholder(blank_database_config_path: Path):
+def test_change_request_delete_inline_data_rejects_placeholder(migrated_database_config_path: Path):
     """`--data` is subject to the same placeholder rejection as `--data-file`."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -949,9 +951,9 @@ def test_change_request_delete_inline_data_rejects_placeholder(blank_database_co
     assert "FILL IN" in result.stderr or "placeholder" in result.stderr
 
 
-def test_change_request_delete_inline_data_rejects_missing_field(blank_database_config_path: Path):
+def test_change_request_delete_inline_data_rejects_missing_field(migrated_database_config_path: Path):
     """`--data` is subject to the same required-field check as `--data-file`."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -974,8 +976,8 @@ def test_change_request_delete_inline_data_rejects_missing_field(blank_database_
     assert "requester_email" in result.stderr
 
 
-def test_change_request_delete_fails_without_data(blank_database_config_path: Path):
-    args_common = ["db", "--config-file", blank_database_config_path]
+def test_change_request_delete_fails_without_data(migrated_database_config_path: Path):
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -988,8 +990,8 @@ def test_change_request_delete_fails_without_data(blank_database_config_path: Pa
     assert "request_email_content" in result.stderr
 
 
-def test_change_request_delete_fails_with_missing_field(blank_database_config_path: Path, tmp_path: Path):
-    args_common = ["db", "--config-file", blank_database_config_path]
+def test_change_request_delete_fails_with_missing_field(migrated_database_config_path: Path, tmp_path: Path):
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -1015,9 +1017,9 @@ def test_change_request_delete_fails_with_missing_field(blank_database_config_pa
     assert "requester_email" in result.stderr
 
 
-def test_change_request_delete_accepts_and_persists_extra_field(blank_database_config_path: Path, tmp_path: Path):
+def test_change_request_delete_accepts_and_persists_extra_field(migrated_database_config_path: Path, tmp_path: Path):
     """Extras are allowed alongside the required schema fields and stored verbatim."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -1041,7 +1043,7 @@ def test_change_request_delete_accepts_and_persists_extra_field(blank_database_c
     )
     assert result.exit_code == 0, result.stderr
 
-    config = DbConfig.from_path(blank_database_config_path)
+    config = DbConfig.from_path(migrated_database_config_path)
     db = SubmissionDb(db_url=config.db.database_url, author=None)
     submissions_with_changes = [s for s in db.list_change_requests() if s.id == submission_id]
     persisted = submissions_with_changes[0].changes[0]
@@ -1049,8 +1051,8 @@ def test_change_request_delete_accepts_and_persists_extra_field(blank_database_c
     assert persisted.data == {"internal_note": "received fax 2026-04-30"}
 
 
-def test_change_request_data_and_data_file_mutually_exclusive(blank_database_config_path: Path, tmp_path: Path):
-    args_common = ["db", "--config-file", blank_database_config_path]
+def test_change_request_data_and_data_file_mutually_exclusive(migrated_database_config_path: Path, tmp_path: Path):
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -1097,9 +1099,9 @@ def test_change_request_template_subcommand_prints_template():
     assert "data" in parsed
 
 
-def test_unmodified_template_fails_validation(blank_database_config_path: Path, tmp_path: Path):
+def test_unmodified_template_fails_validation(migrated_database_config_path: Path, tmp_path: Path):
     """A user who saves the template and submits it unchanged must not pass validation."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -1128,9 +1130,9 @@ def test_unmodified_template_fails_validation(blank_database_config_path: Path, 
     assert "requested_at" in result.stderr
 
 
-def test_template_with_only_date_filled_in_still_fails(blank_database_config_path: Path, tmp_path: Path):
+def test_template_with_only_date_filled_in_still_fails(migrated_database_config_path: Path, tmp_path: Path):
     """If the user fills in only the date but leaves text placeholders, validation must still fail."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -1228,8 +1230,8 @@ def test_change_request_validate_accepts_mislabeled_extension(tmp_path: Path):
     assert "valid" in result.stderr.lower()
 
 
-def test_change_request_dry_run_does_not_write(blank_database_config_path: Path, tmp_path: Path):
-    args_common = ["db", "--config-file", blank_database_config_path]
+def test_change_request_dry_run_does_not_write(migrated_database_config_path: Path, tmp_path: Path):
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -1256,14 +1258,14 @@ def test_change_request_dry_run_does_not_write(blank_database_config_path: Path,
     assert "would register change request" in result.stderr.replace("\n", " ")
     assert "Validated fields" in result.stderr
 
-    config = DbConfig.from_path(blank_database_config_path)
+    config = DbConfig.from_path(migrated_database_config_path)
     db = SubmissionDb(db_url=config.db.database_url, author=None)
     submissions_with_changes = list(db.list_change_requests())
     assert submissions_with_changes == []
 
 
-def test_change_request_dry_run_aborts_when_submission_missing(blank_database_config_path: Path, tmp_path: Path):
-    args_common = ["db", "--config-file", blank_database_config_path]
+def test_change_request_dry_run_aborts_when_submission_missing(migrated_database_config_path: Path, tmp_path: Path):
+    args_common = ["db", "--config-file", migrated_database_config_path]
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
     data_file = tmp_path / "delete.yaml"
@@ -1286,9 +1288,9 @@ def test_change_request_dry_run_aborts_when_submission_missing(blank_database_co
     assert "not found" in result.stderr
 
 
-def test_change_request_dry_run_validates_before_db_check(blank_database_config_path: Path, tmp_path: Path):
+def test_change_request_dry_run_validates_before_db_check(migrated_database_config_path: Path, tmp_path: Path):
     """Schema validation runs first; missing fields fail even with --dry-run."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
     incomplete = {k: v for k, v in _DELETE_CHANGE_REQUEST_DATA.items() if k != "requester_email"}
@@ -1312,9 +1314,9 @@ def test_change_request_dry_run_validates_before_db_check(blank_database_config_
     assert "requester_email" in result.stderr
 
 
-def test_change_request_modify_requires_audit_fields_too(blank_database_config_path: Path, tmp_path: Path):
+def test_change_request_modify_requires_audit_fields_too(migrated_database_config_path: Path, tmp_path: Path):
     """Audit fields are universal — Modify also requires them via --data/--data-file."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -1339,9 +1341,9 @@ def test_change_request_modify_requires_audit_fields_too(blank_database_config_p
     assert "Modify" in ok.stderr
 
 
-def test_change_request_with_raw_content_pdf(blank_database_config_path: Path, tmp_path: Path):
+def test_change_request_with_raw_content_pdf(migrated_database_config_path: Path, tmp_path: Path):
     """--raw-content provides the binary blob; type is identified from the content's magic bytes."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -1371,7 +1373,7 @@ def test_change_request_with_raw_content_pdf(blank_database_config_path: Path, t
     )
     assert result.exit_code == 0, result.stderr
 
-    config = DbConfig.from_path(blank_database_config_path)
+    config = DbConfig.from_path(migrated_database_config_path)
     db = SubmissionDb(db_url=config.db.database_url, author=None)
     persisted = next(s for s in db.list_change_requests() if s.id == submission_id).changes[0]
     assert persisted.request_email_content is None
@@ -1379,9 +1381,9 @@ def test_change_request_with_raw_content_pdf(blank_database_config_path: Path, t
     assert persisted.request_raw_content_type.value == "PDF"
 
 
-def test_change_request_raw_content_unrecognized_bytes_fail(blank_database_config_path: Path, tmp_path: Path):
+def test_change_request_raw_content_unrecognized_bytes_fail(migrated_database_config_path: Path, tmp_path: Path):
     """Content matching no supported type is rejected, regardless of the file's name."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -1411,9 +1413,11 @@ def test_change_request_raw_content_unrecognized_bytes_fail(blank_database_confi
     assert "not a recognized attachment" in result.stderr
 
 
-def test_change_request_raw_content_type_from_content_not_extension(blank_database_config_path: Path, tmp_path: Path):
+def test_change_request_raw_content_type_from_content_not_extension(
+    migrated_database_config_path: Path, tmp_path: Path
+):
     """The attachment type follows the magic bytes, not the extension: PNG bytes in a .pdf file store as PNG."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     submission_id = "260840108_2025-12-16_cc9973f0"
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -1442,14 +1446,14 @@ def test_change_request_raw_content_type_from_content_not_extension(blank_databa
     )
     assert result.exit_code == 0, result.stderr
 
-    config = DbConfig.from_path(blank_database_config_path)
+    config = DbConfig.from_path(migrated_database_config_path)
     db = SubmissionDb(db_url=config.db.database_url, author=None)
     persisted = next(s for s in db.list_change_requests() if s.id == submission_id).changes[0]
     assert persisted.request_raw_content == png_bytes
     assert persisted.request_raw_content_type.value == "PNG"
 
 
-def test_submission_grzctl_versions_logging(blank_database_config_path: Path, test_metadata_path: Path, monkeypatch):
+def test_submission_grzctl_versions_logging(migrated_database_config_path: Path, test_metadata_path: Path, monkeypatch):
     """
     Test that grzctl_versions is correctly logged on state transitions and appears in CLI output.
 
@@ -1459,7 +1463,7 @@ def test_submission_grzctl_versions_logging(blank_database_config_path: Path, te
     - grzctl_versions appears in human-readable table output
     - Versions are preserved across multiple state transitions
     """
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
 
     # Mock the version to a known test value for reproducibility
     test_version = "0.1.2-test"
@@ -1539,7 +1543,7 @@ def test_submission_grzctl_versions_logging(blank_database_config_path: Path, te
     assert test_version in rendered, "the Dependency Versions column should carry the versions"
 
     # Test 3: Verify database records have the version
-    config = DbConfig.from_path(blank_database_config_path)
+    config = DbConfig.from_path(migrated_database_config_path)
     db = SubmissionDb(db_url=config.db.database_url, author=None)
     submission = db.get_submission(metadata.submission_id)
 
@@ -1562,12 +1566,12 @@ def test_submission_grzctl_versions_logging(blank_database_config_path: Path, te
 
 
 def test_submission_grzctl_version_different_versions(
-    blank_database_config_path: Path, test_metadata_path: Path, monkeypatch
+    migrated_database_config_path: Path, test_metadata_path: Path, monkeypatch
 ):
     """
     Verify that state logs show their logged version, not the current runtime version.
     """
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
 
     runner = click.testing.CliRunner(env={"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test"})
@@ -1647,9 +1651,9 @@ def test_submission_grzctl_version_different_versions(
         )
 
 
-def test_submission_show_json_includes_failure_reason(blank_database_config_path: Path):
+def test_submission_show_json_includes_failure_reason(migrated_database_config_path: Path):
     """Submission show --json should include failure_reason in state history."""
-    args_common = ["db", "--config-file", blank_database_config_path]
+    args_common = ["db", "--config-file", migrated_database_config_path]
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
 

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -22,6 +22,20 @@ from grz_pydantic_models.submission.metadata import REDACTED_TAN, GrzSubmissionM
 from grzctl.models.config import DbConfig
 
 
+def test_init_brings_an_empty_database_to_the_latest_schema(empty_database_config_path):
+    """``db init`` is the only way an operator creates a schema, so it must reach head unaided."""
+    runner = click.testing.CliRunner()
+    cli = grzctl.cli.build_cli()
+    args_common = ["db", "--config-file", str(empty_database_config_path)]
+
+    result_init = runner.invoke(cli, [*args_common, "init"])
+    assert result_init.exit_code == 0, result_init.stderr
+
+    # 'list' refuses to run against anything short of the latest schema
+    result_list = runner.invoke(cli, [*args_common, "list"])
+    assert result_list.exit_code == 0, result_list.stderr
+
+
 def test_all_migrations(blank_initial_database_config_path):
     """Database migrations should work all the way from the oldest supported to the latest version."""
     # add some test data

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -1475,8 +1475,8 @@ def test_submission_grzctl_versions_logging(migrated_database_config_path: Path,
         "grz-pydantic-models": "1.0.0",
         "grz-check": "1.0.0",
     }
-    # patch the binding the writer actually calls: db.cli imported the name, so patching it on the
-    # grzctl package would leave the real versions being recorded
+    # Patch the binding the writer actually calls: the db.cli module imported the name, so patching
+    # it on the grzctl package would leave the real versions being recorded.
     monkeypatch.setattr("grzctl.commands.db.cli.get_versions", lambda: test_versions_dict)
 
     metadata = GrzSubmissionMetadata.model_validate_json(test_metadata_path.read_text())
@@ -1534,11 +1534,11 @@ def test_submission_grzctl_versions_logging(migrated_database_config_path: Path,
         assert "data_steward_signature" in state
 
     # Test 2: Verify grzctl_versions reaches the human-readable table too. The column is rendered
-    # wide enough to read only on a wide terminal; at the default width rich truncates it away.
+    # wide enough to read only on a wide terminal; at the default width Rich truncates it away.
     wide_runner = click.testing.CliRunner(env={"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test", "COLUMNS": "500"})
     result_show_table = wide_runner.invoke(cli, [*args_common, "submission", "show", metadata.submission_id])
     assert result_show_table.exit_code == 0, result_show_table.stderr
-    # the cell holds a JSON blob that rich wraps, so compare with the layout whitespace removed
+    # the cell holds a JSON blob that Rich wraps, so compare with the layout whitespace removed
     rendered = "".join(result_show_table.stdout.split())
     assert test_version in rendered, "the Dependency Versions column should carry the versions"
 

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -10,6 +10,7 @@ from datetime import date
 from operator import attrgetter
 from pathlib import Path
 from textwrap import dedent
+from types import SimpleNamespace
 
 import click.testing
 import grzctl.cli
@@ -753,112 +754,89 @@ def test_submission_show_json(blank_database_config_path: Path, test_metadata_pa
     }
 
 
-def test_list_filter_modes_and_multiple_states(blank_database_config_path: Path):
-    args_common = ["db", "--config-file", blank_database_config_path]
-
-    sub_latest_error = "123456789_2025-07-01_b1b2c3d1"
-    sub_latest_qced = "123456789_2025-07-01_b1b2c3d2"
-    sub_latest_downloaded = "123456789_2025-07-01_b1b2c3d3"
-    sub_history_error_latest_uploaded = "123456789_2025-07-01_b1b2c3d4"
-    sub_no_state = "123456789_2025-07-01_b1b2c3d5"
-
+def _seed_state_histories(cli, args_common: list) -> SimpleNamespace:
+    """Register five submissions covering every state-filter case and return their IDs."""
+    ids = SimpleNamespace(
+        latest_error="123456789_2025-07-01_b1b2c3d1",
+        latest_qced="123456789_2025-07-01_b1b2c3d2",
+        latest_downloaded="123456789_2025-07-01_b1b2c3d3",
+        history_error_latest_uploaded="123456789_2025-07-01_b1b2c3d4",
+        no_state="123456789_2025-07-01_b1b2c3d5",
+    )
     runner = click.testing.CliRunner()
-    cli = grzctl.cli.build_cli()
 
-    for submission_id in [
-        sub_latest_error,
-        sub_latest_qced,
-        sub_latest_downloaded,
-        sub_history_error_latest_uploaded,
-        sub_no_state,
-    ]:
+    for submission_id in vars(ids).values():
         result_add = runner.invoke(cli, [*args_common, "submission", "add", submission_id])
         assert result_add.exit_code == 0, result_add.stderr
 
-    update_invocations = [
-        [*args_common, "submission", "update", sub_latest_error, "Error"],
-        [*args_common, "submission", "update", sub_latest_qced, "QCed"],
-        [*args_common, "submission", "update", sub_latest_downloaded, "Downloaded"],
-        [*args_common, "submission", "update", sub_history_error_latest_uploaded, "Uploaded"],
-        [*args_common, "submission", "update", sub_history_error_latest_uploaded, "Error"],
-    ]
-    for invoke_args in update_invocations:
+    for invoke_args in (
+        [*args_common, "submission", "update", ids.latest_error, "Error"],
+        [*args_common, "submission", "update", ids.latest_qced, "QCed"],
+        [*args_common, "submission", "update", ids.latest_downloaded, "Downloaded"],
+        [*args_common, "submission", "update", ids.history_error_latest_uploaded, "Uploaded"],
+        [*args_common, "submission", "update", ids.history_error_latest_uploaded, "Error"],
+    ):
         result_update = runner.invoke(cli, invoke_args)
         assert result_update.exit_code == 0, result_update.stderr
 
-    # Special transition from Error -> Uploaded, explicitly allowed by flag.
+    # leaves an Error in history while the latest state is Uploaded
     result_ignore_error = runner.invoke(
         cli,
-        [
-            *args_common,
-            "submission",
-            "update",
-            "--ignore-error-state",
-            sub_history_error_latest_uploaded,
-            "Uploaded",
-        ],
+        [*args_common, "submission", "update", "--ignore-error-state", ids.history_error_latest_uploaded, "Uploaded"],
     )
     assert result_ignore_error.exit_code == 0, result_ignore_error.stderr
 
-    result_all = runner.invoke(cli, [*args_common, "list", "--json"])
-    assert result_all.exit_code == 0, result_all.stderr
-    parsed_all = json.loads(result_all.stdout)
-    assert {item["id"] for item in parsed_all} == {
-        sub_latest_error,
-        sub_latest_qced,
-        sub_latest_downloaded,
-        sub_history_error_latest_uploaded,
-        sub_no_state,
+    return ids
+
+
+def _listed_ids(cli, args_common: list, *filter_args: str) -> set:
+    runner = click.testing.CliRunner()
+    result = runner.invoke(cli, [*args_common, "list", "--json", *filter_args])
+    assert result.exit_code == 0, result.stderr
+    return {item["id"] for item in json.loads(result.stdout)}
+
+
+@pytest.fixture
+def state_history_db(blank_database_config_path: Path):
+    """A database seeded with submissions covering every state-filter case."""
+    cli = grzctl.cli.build_cli()
+    args_common = ["db", "--config-file", blank_database_config_path]
+    return cli, args_common, _seed_state_histories(cli, args_common)
+
+
+def test_list_filters_on_the_latest_state_by_default(state_history_db):
+    """Without --filter-mode only the current state counts, so an Error in history does not match."""
+    cli, args_common, ids = state_history_db
+
+    assert _listed_ids(cli, args_common) == set(vars(ids).values()), "an unfiltered list must return every submission"
+    assert _listed_ids(cli, args_common, "--state", "error") == {ids.latest_error}
+    assert _listed_ids(cli, args_common, "--state", "downloaded") == {ids.latest_downloaded}
+
+
+def test_list_any_mode_matches_states_anywhere_in_history(state_history_db):
+    """--filter-mode any is what finds submissions that recovered from a state."""
+    cli, args_common, ids = state_history_db
+
+    runner = click.testing.CliRunner()
+    result = runner.invoke(cli, [*args_common, "list", "--json", "--state", "error", "--filter-mode", "any"])
+    assert result.exit_code == 0, result.stderr
+    parsed = json.loads(result.stdout)
+
+    assert {item["id"] for item in parsed} == {ids.latest_error, ids.history_error_latest_uploaded}
+    recovered = next(item for item in parsed if item["id"] == ids.history_error_latest_uploaded)
+    assert recovered["latest_state"]["state"] == "Uploaded", "matching on history must not alter the reported state"
+
+
+def test_list_ors_repeated_state_filters(state_history_db):
+    """Repeated --state values are OR-ed, in either filter mode."""
+    cli, args_common, ids = state_history_db
+
+    assert _listed_ids(cli, args_common, "--state", "error", "--state", "qced") == {ids.latest_error, ids.latest_qced}
+    assert _listed_ids(cli, args_common, "--state", "error", "--state", "qced", "--filter-mode", "any") == {
+        ids.latest_error,
+        ids.latest_qced,
+        ids.history_error_latest_uploaded,
     }
-
-    # default mode is latest
-    result_error_latest_default = runner.invoke(cli, [*args_common, "list", "--json", "--state", "error"])
-    assert result_error_latest_default.exit_code == 0, result_error_latest_default.stderr
-    parsed_error_latest_default = json.loads(result_error_latest_default.stdout)
-    assert {item["id"] for item in parsed_error_latest_default} == {sub_latest_error}
-    assert parsed_error_latest_default[0]["latest_state"]["state"] == "Error"
-
-    # any mode includes submissions that had Error in history but not as latest state
-    result_error_any = runner.invoke(
-        cli,
-        [*args_common, "list", "--json", "--state", "error", "--filter-mode", "any"],
-    )
-    assert result_error_any.exit_code == 0, result_error_any.stderr
-    parsed_error_any = json.loads(result_error_any.stdout)
-    assert {item["id"] for item in parsed_error_any} == {sub_latest_error, sub_history_error_latest_uploaded}
-    history_match = next(filter(lambda item: item["id"] == sub_history_error_latest_uploaded, parsed_error_any))
-    assert history_match["latest_state"]["state"] == "Uploaded"
-
-    # multiple filters in default latest mode are OR-ed on latest state
-    result_multi_latest = runner.invoke(
-        cli,
-        [*args_common, "list", "--json", "--state", "error", "--state", "qced"],
-    )
-    assert result_multi_latest.exit_code == 0, result_multi_latest.stderr
-    parsed_multi_latest = json.loads(result_multi_latest.stdout)
-    assert {item["id"] for item in parsed_multi_latest} == {sub_latest_error, sub_latest_qced}
-
-    # multiple filters in any mode are OR-ed across all historic states
-    result_multi_any = runner.invoke(
-        cli,
-        [*args_common, "list", "--json", "--state", "error", "--state", "qced", "--filter-mode", "any"],
-    )
-    assert result_multi_any.exit_code == 0, result_multi_any.stderr
-    parsed_multi_any = json.loads(result_multi_any.stdout)
-    assert {item["id"] for item in parsed_multi_any} == {
-        sub_latest_error,
-        sub_history_error_latest_uploaded,
-        sub_latest_qced,
-    }
-
-    # "--state" supports repeated values
-    result_state_alias = runner.invoke(
-        cli,
-        [*args_common, "list", "--json", "--state", "downloaded"],
-    )
-    assert result_state_alias.exit_code == 0, result_state_alias.stderr
-    parsed_state_alias = json.loads(result_state_alias.stdout)
-    assert {item["id"] for item in parsed_state_alias} == {sub_latest_downloaded}
 
 
 _DELETE_CHANGE_REQUEST_DATA = {

--- a/packages/grzctl/tests/cli/test_db_populate.py
+++ b/packages/grzctl/tests/cli/test_db_populate.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from grz_db.errors import SubmissionNotFoundError
 from grz_db.models.submission import SubmissionDb
 from grz_db.models.submission.diff import DiffState, DonorDiff, DonorsDiffCollection, SubmissionDiffCollection
 from grz_pydantic_models.submission.metadata import REDACTED_LOCAL_CASE_ID, REDACTED_TAN, GrzSubmissionMetadata
@@ -25,6 +26,17 @@ def _parse(metadata_raw: dict) -> GrzSubmissionMetadata:
     return GrzSubmissionMetadata.model_validate_json(json.dumps(metadata_raw))
 
 
+def _db_ctx(config_path: Path, test_metadata_path: Path, *, register: bool) -> SimpleNamespace:
+    metadata_raw = json.loads(test_metadata_path.read_text())
+    metadata = _parse(metadata_raw)
+    submission_id = metadata.submission_id
+    config = DbConfig.from_path(config_path)
+    db = SubmissionDb(db_url=config.db.database_url, author=None)
+    if register:
+        db.add_submission(submission_id)
+    return SimpleNamespace(db=db, metadata=metadata, metadata_raw=metadata_raw, submission_id=submission_id)
+
+
 @pytest.fixture
 def db_ctx(blank_database_config_path: Path, test_metadata_path: Path) -> SimpleNamespace:
     """SubmissionDb + parsed metadata wired up for populate tests.
@@ -32,13 +44,39 @@ def db_ctx(blank_database_config_path: Path, test_metadata_path: Path) -> Simple
     The submission is registered in the database (``db.add_submission``) but not
     yet populated, so every field starts as NULL.
     """
-    metadata_raw = json.loads(test_metadata_path.read_text())
-    metadata = _parse(metadata_raw)
-    submission_id = metadata.submission_id
-    config = DbConfig.from_path(blank_database_config_path)
-    db = SubmissionDb(db_url=config.db.database_url, author=None)
-    db.add_submission(submission_id)
-    return SimpleNamespace(db=db, metadata=metadata, metadata_raw=metadata_raw, submission_id=submission_id)
+    return _db_ctx(blank_database_config_path, test_metadata_path, register=True)
+
+
+@pytest.fixture
+def unregistered_db_ctx(blank_database_config_path: Path, test_metadata_path: Path) -> SimpleNamespace:
+    """Like :func:`db_ctx`, but the submission was never added, as after a fresh download."""
+    return _db_ctx(blank_database_config_path, test_metadata_path, register=False)
+
+
+def test_populate_registers_an_unknown_submission_when_asked(unregistered_db_ctx: SimpleNamespace):
+    """``download`` populates submissions it has just fetched, which are not yet in the database.
+
+    That is the only mode production passes, so the default-covering tests above would leave it
+    untested.
+    """
+    ctx = unregistered_db_ctx
+
+    ctx.db.populate(ctx.submission_id, ctx.metadata, SUBMISSION_DATE, on_missing="create")
+
+    submission = ctx.db.get_submission(ctx.submission_id)
+    assert submission is not None
+    assert submission.submitter_id == ctx.metadata.submission.submitter_id
+    assert len(ctx.db.get_donors(ctx.submission_id)) == len(ctx.metadata.donors)
+
+
+def test_populate_refuses_an_unknown_submission_by_default(unregistered_db_ctx: SimpleNamespace):
+    """Defaulting to an error keeps a mistyped ID from quietly creating a second submission."""
+    ctx = unregistered_db_ctx
+
+    with pytest.raises(SubmissionNotFoundError):
+        ctx.db.populate(ctx.submission_id, ctx.metadata, SUBMISSION_DATE)
+
+    assert ctx.db.get_submission(ctx.submission_id) is None
 
 
 def test_populate_no_raise_on_additive_changes(db_ctx: SimpleNamespace):

--- a/packages/grzctl/tests/cli/test_db_populate.py
+++ b/packages/grzctl/tests/cli/test_db_populate.py
@@ -38,27 +38,23 @@ def _db_ctx(config_path: Path, test_metadata_path: Path, *, register: bool) -> S
 
 
 @pytest.fixture
-def db_ctx(blank_database_config_path: Path, test_metadata_path: Path) -> SimpleNamespace:
+def db_ctx(migrated_database_config_path: Path, test_metadata_path: Path) -> SimpleNamespace:
     """SubmissionDb + parsed metadata wired up for populate tests.
 
     The submission is registered in the database (``db.add_submission``) but not
     yet populated, so every field starts as NULL.
     """
-    return _db_ctx(blank_database_config_path, test_metadata_path, register=True)
+    return _db_ctx(migrated_database_config_path, test_metadata_path, register=True)
 
 
 @pytest.fixture
-def unregistered_db_ctx(blank_database_config_path: Path, test_metadata_path: Path) -> SimpleNamespace:
+def unregistered_db_ctx(migrated_database_config_path: Path, test_metadata_path: Path) -> SimpleNamespace:
     """Like :func:`db_ctx`, but the submission was never added, as after a fresh download."""
-    return _db_ctx(blank_database_config_path, test_metadata_path, register=False)
+    return _db_ctx(migrated_database_config_path, test_metadata_path, register=False)
 
 
 def test_populate_registers_an_unknown_submission_when_asked(unregistered_db_ctx: SimpleNamespace):
-    """``download`` populates submissions it has just fetched, which are not yet in the database.
-
-    That is the only mode production passes, so the default-covering tests above would leave it
-    untested.
-    """
+    """``download`` populates submissions it has just fetched, which are not yet in the database."""
     ctx = unregistered_db_ctx
 
     ctx.db.populate(ctx.submission_id, ctx.metadata, SUBMISSION_DATE, on_missing="create")

--- a/packages/grzctl/tests/cli/test_db_sync.py
+++ b/packages/grzctl/tests/cli/test_db_sync.py
@@ -14,11 +14,11 @@ from grz_db.models.submission import SubmissionDb, SubmissionStateEnum
 from grzctl.models.config import DbConfig
 
 
-def test_sync_from_inbox(blank_database_config_path, tmp_path):
+def test_sync_from_inbox(migrated_database_config_path, tmp_path):
     """
     Test that sync-from-inbox correctly updates the database based on inbox state.
     """
-    with open(blank_database_config_path, encoding="utf-8") as f:
+    with open(migrated_database_config_path, encoding="utf-8") as f:
         config_data = yaml.safe_load(f)
 
     config_data["s3"] = {
@@ -28,7 +28,7 @@ def test_sync_from_inbox(blank_database_config_path, tmp_path):
         "secret_access_key": "minioadmin",
     }
 
-    with open(blank_database_config_path, "w", encoding="utf-8") as f:
+    with open(migrated_database_config_path, "w", encoding="utf-8") as f:
         yaml.dump(config_data, f)
 
     old = datetime.fromisoformat("1970-01-01")
@@ -81,7 +81,7 @@ def test_sync_from_inbox(blank_database_config_path, tmp_path):
         submission_no_change,
     ]
 
-    db_config = DbConfig.from_path(blank_database_config_path)
+    db_config = DbConfig.from_path(migrated_database_config_path)
 
     with open(config_data["db"]["author"]["private_key_path"], "rb") as f:
         pk_bytes = f.read()
@@ -99,7 +99,7 @@ def test_sync_from_inbox(blank_database_config_path, tmp_path):
     cli = grzctl.cli.build_cli()
 
     with patch("grzctl.commands.db.cli.query_submissions", return_value=mock_s3_submissions) as mock_query:
-        result = runner.invoke(cli, ["db", "--config-file", str(blank_database_config_path), "sync-from-inbox"])
+        result = runner.invoke(cli, ["db", "--config-file", str(migrated_database_config_path), "sync-from-inbox"])
 
         assert result.exit_code == 0, result.stderr
         mock_query.assert_called_once()

--- a/packages/grzctl/tests/cli/test_db_tui.py
+++ b/packages/grzctl/tests/cli/test_db_tui.py
@@ -25,7 +25,7 @@ def captured_browser_args(monkeypatch):
     return captured
 
 
-def test_db_tui_passes_quarter_year(captured_browser_args, blank_database_config_path):
+def test_db_tui_passes_quarter_year(captured_browser_args, migrated_database_config_path):
     root_logger = logging.getLogger()
     old_handlers = list(root_logger.handlers)
     try:
@@ -36,7 +36,7 @@ def test_db_tui_passes_quarter_year(captured_browser_args, blank_database_config
             [
                 "db",
                 "--config-file",
-                str(blank_database_config_path),
+                str(migrated_database_config_path),
                 "tui",
                 "--quarter",
                 "2",
@@ -52,7 +52,7 @@ def test_db_tui_passes_quarter_year(captured_browser_args, blank_database_config
         root_logger.handlers[:] = old_handlers
 
 
-def test_db_tui_passes_none_when_quarter_year_omitted(captured_browser_args, blank_database_config_path):
+def test_db_tui_passes_none_when_quarter_year_omitted(captured_browser_args, migrated_database_config_path):
     root_logger = logging.getLogger()
     old_handlers = list(root_logger.handlers)
     try:
@@ -63,7 +63,7 @@ def test_db_tui_passes_none_when_quarter_year_omitted(captured_browser_args, bla
             [
                 "db",
                 "--config-file",
-                str(blank_database_config_path),
+                str(migrated_database_config_path),
                 "tui",
             ],
         )

--- a/packages/grzctl/tests/cli/test_report.py
+++ b/packages/grzctl/tests/cli/test_report.py
@@ -465,7 +465,3 @@ def test_quarterly_migrated_database(blank_database_config_path: Path, tmp_path:
         qc_reader = csv.reader(qc_file, delimiter="\t")
         # header + no detailed QC failures
         assert len(list(qc_reader)) == 1
-
-
-def test_date_to_quarter_year():
-    assert date_to_quarter_year(date(year=2025, month=9, day=22)) == (3, 2025)

--- a/packages/grzctl/tests/cli/test_report.py
+++ b/packages/grzctl/tests/cli/test_report.py
@@ -41,7 +41,7 @@ def test_quarter_determination():
         assert year == expected_year
 
 
-def test_quarterly_empty(blank_database_config_path: Path, tmp_path: Path):
+def test_quarterly_empty(migrated_database_config_path: Path, tmp_path: Path):
     """Quarterly reports should work on an empty database."""
     env = {
         "GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test",
@@ -54,7 +54,7 @@ def test_quarterly_empty(blank_database_config_path: Path, tmp_path: Path):
     with runner.isolated_filesystem(temp_dir=tmp_path) as report_tmp_dir:
         result_report = runner.invoke(
             cli,
-            ["report", "--config-file", blank_database_config_path, "quarterly", "--year", "2025", "--quarter", "3"],
+            ["report", "--config-file", migrated_database_config_path, "quarterly", "--year", "2025", "--quarter", "3"],
             catch_exceptions=False,
         )
         assert result_report.exit_code == 0, result_report.output
@@ -65,7 +65,7 @@ def test_quarterly_empty(blank_database_config_path: Path, tmp_path: Path):
 
 
 @pytest.fixture
-def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Path:
+def quarterly_report_dir(migrated_database_config_path: Path, tmp_path: Path) -> Path:
     """Seed three submissions and generate the Q3 2025 quarterly report.
 
     Seeds: an initial submission whose basic QC passes; a second submitter's
@@ -89,7 +89,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
     s1_metadata = GrzSubmissionMetadata.model_validate(s1_metadata_raw)
     s1_metadata_raw["submission"]["submissionType"] = "initial"
     result_add1 = runner.invoke(
-        cli, ["db", "--config-file", blank_database_config_path, "submission", "add", s1_metadata.submission_id]
+        cli, ["db", "--config-file", migrated_database_config_path, "submission", "add", s1_metadata.submission_id]
     )
     assert result_add1.exit_code == 0, result_add1.output
     s1_metadata_path = tmp_path / "submission1.metadata.json"
@@ -100,7 +100,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
         [
             "db",
             "--config-file",
-            blank_database_config_path,
+            migrated_database_config_path,
             "submission",
             "populate",
             "--no-confirm",
@@ -114,7 +114,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
         [
             "db",
             "--config-file",
-            blank_database_config_path,
+            migrated_database_config_path,
             "submission",
             "modify",
             s1_metadata.submission_id,
@@ -134,7 +134,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
     s2_metadata_raw["donors"][0]["researchConsents"][0]["noScopeJustification"] = "patient refuses to sign consent"
     s2_metadata = GrzSubmissionMetadata.model_validate(s2_metadata_raw)
     result_add2 = runner.invoke(
-        cli, ["db", "--config-file", blank_database_config_path, "submission", "add", s2_metadata.submission_id]
+        cli, ["db", "--config-file", migrated_database_config_path, "submission", "add", s2_metadata.submission_id]
     )
     assert result_add2.exit_code == 0, result_add2.output
     s2_metadata_path = tmp_path / "submission2.metadata.json"
@@ -145,7 +145,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
         [
             "db",
             "--config-file",
-            blank_database_config_path,
+            migrated_database_config_path,
             "submission",
             "populate",
             "--no-confirm",
@@ -159,7 +159,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
         [
             "db",
             "--config-file",
-            blank_database_config_path,
+            migrated_database_config_path,
             "submission",
             "modify",
             s2_metadata.submission_id,
@@ -173,7 +173,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
         [
             "db",
             "--config-file",
-            blank_database_config_path,
+            migrated_database_config_path,
             "submission",
             "modify",
             s2_metadata.submission_id,
@@ -196,7 +196,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
         [
             "db",
             "--config-file",
-            blank_database_config_path,
+            migrated_database_config_path,
             "submission",
             "populate-qc",
             s2_metadata.submission_id,
@@ -215,7 +215,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
     s3_metadata_raw["donors"][0]["researchConsents"][0]["scope"]["provision"]["provision"] = []
     s3_metadata = GrzSubmissionMetadata.model_validate(s3_metadata_raw)
     result_add3 = runner.invoke(
-        cli, ["db", "--config-file", blank_database_config_path, "submission", "add", s3_metadata.submission_id]
+        cli, ["db", "--config-file", migrated_database_config_path, "submission", "add", s3_metadata.submission_id]
     )
     assert result_add3.exit_code == 0, result_add3.output
     s3_metadata_path = tmp_path / "submission3.metadata.json"
@@ -226,7 +226,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
         [
             "db",
             "--config-file",
-            blank_database_config_path,
+            migrated_database_config_path,
             "submission",
             "populate",
             "--no-confirm",
@@ -240,7 +240,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
         [
             "db",
             "--config-file",
-            blank_database_config_path,
+            migrated_database_config_path,
             "submission",
             "modify",
             s3_metadata.submission_id,
@@ -254,7 +254,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
         [
             "db",
             "--config-file",
-            blank_database_config_path,
+            migrated_database_config_path,
             "submission",
             "change-request",
             s1_metadata.submission_id,
@@ -276,7 +276,7 @@ def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Pa
     with runner.isolated_filesystem(temp_dir=tmp_path) as report_tmp_dir:
         result_report = runner.invoke(
             cli,
-            ["report", "--config-file", blank_database_config_path, "quarterly", "--year", "2025", "--quarter", "3"],
+            ["report", "--config-file", migrated_database_config_path, "quarterly", "--year", "2025", "--quarter", "3"],
             catch_exceptions=False,
         )
         assert result_report.exit_code == 0, result_report.output
@@ -427,10 +427,10 @@ def test_quarterly_qc(quarterly_report_dir: Path):
     ]
 
 
-def test_quarterly_migrated_database(blank_database_config_path: Path, tmp_path: Path):
+def test_quarterly_migrated_database(migrated_database_config_path: Path, tmp_path: Path):
     """Quarterly reports should work on databases migrated from prior schema without backpopulating metadata."""
     # add some minimal test data
-    config = DbConfig.from_path(blank_database_config_path)
+    config = DbConfig.from_path(migrated_database_config_path)
     tan_g = "a2b6c3d9e8f7123456789abcdef0123456789abcdef0123456789abcdef01234"
     pseudonym = "CASE12345"
     submission_date = date(year=2025, month=9, day=14)
@@ -463,7 +463,7 @@ def test_quarterly_migrated_database(blank_database_config_path: Path, tmp_path:
     with runner.isolated_filesystem(temp_dir=tmp_path) as report_tmp_dir:
         result_report = runner.invoke(
             cli,
-            ["report", "--config-file", blank_database_config_path, "quarterly", "--year", "2025", "--quarter", "3"],
+            ["report", "--config-file", migrated_database_config_path, "quarterly", "--year", "2025", "--quarter", "3"],
         )
         assert result_report.exit_code == 0, result_report.output
 

--- a/packages/grzctl/tests/cli/test_report.py
+++ b/packages/grzctl/tests/cli/test_report.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import grzctl.cli
+import pytest
 import sqlalchemy
 from click.testing import CliRunner
 from grz_db.models.submission import Submission
@@ -63,8 +64,18 @@ def test_quarterly_empty(blank_database_config_path: Path, tmp_path: Path):
     assert (Path(report_tmp_dir) / "3-Detailprüfung_GRZX00000_3_2025.tsv").exists()
 
 
-def test_quarterly(blank_database_config_path: Path, tmp_path: Path):
-    """Small test case with a few submissions for quarterly reports."""
+@pytest.fixture
+def quarterly_report_dir(blank_database_config_path: Path, tmp_path: Path) -> Path:
+    """Seed three submissions and generate the Q3 2025 quarterly report.
+
+    Seeds: an initial submission whose basic QC passes; a second submitter's
+    submission whose basic QC passes but detailed QC fails (with a populated QC
+    report); and a correction submission for the first submitter that revokes the
+    index patient's consent, alongside a deletion change request against the
+    original submission.
+
+    Returns the directory containing the three generated TSV files.
+    """
     env = {
         "GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test",
         "GRZ_IDENTIFIERS__GRZ": "GRZX00000",
@@ -261,7 +272,7 @@ def test_quarterly(blank_database_config_path: Path, tmp_path: Path):
     )
     assert result_change1.exit_code == 0, result_change1.output
 
-    # generate and check quarterly report
+    # generate quarterly report
     with runner.isolated_filesystem(temp_dir=tmp_path) as report_tmp_dir:
         result_report = runner.invoke(
             cli,
@@ -270,7 +281,12 @@ def test_quarterly(blank_database_config_path: Path, tmp_path: Path):
         )
         assert result_report.exit_code == 0, result_report.output
 
-    overview_output_path = Path(report_tmp_dir) / "1-Gesamtübersicht_GRZX00000_3_2025.tsv"
+    return Path(report_tmp_dir)
+
+
+def test_quarterly_overview(quarterly_report_dir: Path):
+    """The overview TSV should have one row per submitter with aggregate counts."""
+    overview_output_path = quarterly_report_dir / "1-Gesamtübersicht_GRZX00000_3_2025.tsv"
     assert overview_output_path.exists()
     with open(overview_output_path, newline="", encoding="utf-8") as overview_file:
         overview_reader = csv.reader(overview_file, delimiter="\t")
@@ -313,7 +329,10 @@ def test_quarterly(blank_database_config_path: Path, tmp_path: Path):
         "0",
     ]
 
-    dataset_output_path = Path(report_tmp_dir) / "2-Infos_zu_Datensätzen_GRZX00000_3_2025.tsv"
+
+def test_quarterly_dataset(quarterly_report_dir: Path):
+    """The dataset TSV should have one row per submission with per-submission metadata."""
+    dataset_output_path = quarterly_report_dir / "2-Infos_zu_Datensätzen_GRZX00000_3_2025.tsv"
     assert dataset_output_path.exists()
     with open(dataset_output_path, newline="", encoding="utf-8") as dataset_file:
         dataset_reader = csv.reader(dataset_file, delimiter="\t")
@@ -379,7 +398,10 @@ def test_quarterly(blank_database_config_path: Path, tmp_path: Path):
         "germline;somatic",
     ]
 
-    qc_output_path = Path(report_tmp_dir) / "3-Detailprüfung_GRZX00000_3_2025.tsv"
+
+def test_quarterly_qc(quarterly_report_dir: Path):
+    """The QC TSV should have one row per lab datum that failed detailed QC."""
+    qc_output_path = quarterly_report_dir / "3-Detailprüfung_GRZX00000_3_2025.tsv"
     assert qc_output_path.exists()
     with open(qc_output_path, newline="", encoding="utf-8") as qc_file:
         qc_reader = csv.reader(qc_file, delimiter="\t")

--- a/packages/grzctl/tests/conftest.py
+++ b/packages/grzctl/tests/conftest.py
@@ -13,10 +13,11 @@ from grz_db.testing import (  # noqa: F401
     test_author,
 )
 
-# Rich decides whether to emit ANSI colour when a Console is constructed, which for the CLI modules
-# happens at import. TTY_COMPATIBLE=0 outranks both FORCE_COLOR and isatty detection, so captured
-# output stays plain whatever the developer's shell exports. Set at import: a fixture would run
-# after the test modules have already built their consoles.
+# Rich decides whether to emit ANSI colour when a Console is constructed, and for the CLI modules
+# that happens at import time. TTY_COMPATIBLE=0 outranks both FORCE_COLOR and isatty detection, so
+# captured output stays plain no matter what the developer's shell exports. This is set here, at
+# import time, because a fixture would only run after the test modules have already built their
+# consoles.
 os.environ["TTY_COMPATIBLE"] = "0"
 
 

--- a/packages/grzctl/tests/conftest.py
+++ b/packages/grzctl/tests/conftest.py
@@ -1,6 +1,23 @@
 import os
 
 import pytest
+from grz_db.testing import (  # noqa: F401
+    _migrated_postgresql_template,
+    _migrated_sqlite_template,
+    _pg_test_dbnames,
+    db,
+    db_backend,
+    db_test_connection,
+    migrated_db_connection,
+    postgresql_proc,
+    test_author,
+)
+
+# Rich decides whether to emit ANSI colour when a Console is constructed, which for the CLI modules
+# happens at import. TTY_COMPATIBLE=0 outranks both FORCE_COLOR and isatty detection, so captured
+# output stays plain whatever the developer's shell exports. Set at import: a fixture would run
+# after the test modules have already built their consoles.
+os.environ["TTY_COMPATIBLE"] = "0"
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/packages/grzctl/tests/test_dbcontext.py
+++ b/packages/grzctl/tests/test_dbcontext.py
@@ -79,12 +79,6 @@ class TestMapExceptionToFailureReason:
         result = db_context._map_exception_to_failure_reason(type(None), None)
         assert result == FailureReasonEnum.UNKNOWN
 
-    def test_file_not_found_takes_priority_over_os_error(self, db_context: DbContext):
-        """FileNotFoundError is a subclass of OSError — must map to FILE_NOT_FOUND not UNKNOWN."""
-        exc = FileNotFoundError("file missing")
-        result = db_context._map_exception_to_failure_reason(type(exc), exc)
-        assert result == FailureReasonEnum.FILE_NOT_FOUND
-
     def test_all_enum_values_are_covered(self, db_context: DbContext):
         """Ensures every FailureReasonEnum value except UNKNOWN is reachable via a mapped exception."""
         from pydantic import BaseModel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ test = [
     "numpy",
     "grz-common",
     "grz-cli",
-    "grz-db",
+    "grz-db[testing]",
     "grzctl",
     "grz-pydantic-models-testing",
     "grz-check",
@@ -256,6 +256,11 @@ packages = "grz_cli,grzctl,grz_pydantic_models,grz_db,grz_common"
 
 [[tool.mypy.overrides]]
 module = "crypt4gh.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Test-only imports, absent from the lint environment that runs mypy.
+module = ["pytest", "pytest_postgresql.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/tests/cli/common.py
+++ b/tests/cli/common.py
@@ -2,9 +2,24 @@
 Common methods/fixtures for CLI tests
 """
 
+import shutil
 from pathlib import Path
 
 import pytest
+
+SUBMISSION_DIR = Path("tests/mock_files/submissions/valid_submission")
+
+
+def copy_submission(working_dir_path: Path, *parts: str, source: Path = SUBMISSION_DIR) -> None:
+    """Copy the named parts of the example submission into the working directory.
+
+    With no parts given, the entire source directory is copied instead.
+    """
+    if not parts:
+        shutil.copytree(source, working_dir_path, dirs_exist_ok=True)
+        return
+    for part in parts:
+        shutil.copytree(source / part, working_dir_path / part, dirs_exist_ok=True)
 
 
 @pytest.fixture

--- a/tests/cli/test_archive.py
+++ b/tests/cli/test_archive.py
@@ -4,20 +4,19 @@ Tests for the Prüfbericht submission functionality.
 
 import importlib.resources
 import json
-import shutil
 
 import click.testing
 import grzctl
 from grz_pydantic_models.submission.metadata import REDACTED_TAN, GrzSubmissionMetadata
 
 from .. import mock_files
+from .common import copy_submission
 
 
 def test_archive(temp_s3_config_file_path, remote_bucket_with_version, working_dir_path, tmp_path):
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
-        shutil.copytree(submission_dir / "encrypted_files", working_dir_path / "encrypted_files", dirs_exist_ok=True)
-        shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+        copy_submission(working_dir_path, "encrypted_files", "metadata", source=submission_dir)
 
         with open(working_dir_path / "metadata" / "metadata.json", mode="r+") as metadata_file:
             metadata_json = json.load(metadata_file)

--- a/tests/cli/test_clean.py
+++ b/tests/cli/test_clean.py
@@ -4,7 +4,6 @@ Tests for the Prüfbericht submission functionality.
 
 import importlib.resources
 import json
-import shutil
 from unittest import mock
 
 import click.testing
@@ -13,14 +12,13 @@ from grz_common.progress import EncryptionState, FileProgressLogger
 from grz_common.workers.submission import Submission
 
 from .. import mock_files
+from .common import copy_submission
 
 
 def test_clean_and_list(temp_s3_config_file_path, remote_bucket_with_version, working_dir_path, tmp_path):
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
-        shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-        shutil.copytree(submission_dir / "encrypted_files", working_dir_path / "encrypted_files", dirs_exist_ok=True)
-        shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+        copy_submission(working_dir_path, "files", "encrypted_files", "metadata", source=submission_dir)
 
         # manually set successful encrypted state in progress logs since upload checks for this
         logs_dir = working_dir_path / "logs"

--- a/tests/cli/test_consent.py
+++ b/tests/cli/test_consent.py
@@ -1,15 +1,11 @@
-import shutil
-from pathlib import Path
-
 import grzctl.cli
 from click.testing import CliRunner
 
+from .common import copy_submission
+
 
 def test_consent_submission(working_dir_path):
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "files", "metadata")
 
     testargs = [
         "consent",

--- a/tests/cli/test_crypt.py
+++ b/tests/cli/test_crypt.py
@@ -1,6 +1,4 @@
 import re
-import shutil
-from pathlib import Path
 
 import grz_cli.cli
 import grzctl.cli
@@ -11,16 +9,15 @@ from grz_common.progress import FileProgressLogger, ValidationState
 from grz_common.utils.checksums import calculate_sha256
 from grz_common.workers.submission import Submission
 
+from .common import SUBMISSION_DIR, copy_submission
+
 
 def test_encrypt_submission_protect_overwrite(
     working_dir_path,
     temp_keys_config_file_path,
     tmpdir_factory: pytest.TempdirFactory,
 ):
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "files", "metadata")
 
     testargs = [
         "encrypt",
@@ -46,14 +43,7 @@ def test_encrypt_submission_protect_overwrite(
 
 
 def test_decrypt_submission(working_dir_path, temp_keys_config_file_path):
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-
-    shutil.copytree(
-        submission_dir / "encrypted_files",
-        working_dir_path / "encrypted_files",
-        dirs_exist_ok=True,
-    )
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "encrypted_files", "metadata")
 
     testargs = [
         "decrypt",
@@ -82,7 +72,7 @@ def test_decrypt_submission(working_dir_path, temp_keys_config_file_path):
         "bbbbbbbb11111111bbbbbbbb11111111bbbbbbbb11111111bbbbbbbb11111111_blood_normal.vcf",
         "target_regions.bed",
     ]:
-        expected_checksum = calculate_sha256(submission_dir / "files" / file)
+        expected_checksum = calculate_sha256(SUBMISSION_DIR / "files" / file)
         observed_checksum = calculate_sha256(working_dir_path / "files" / file)
 
         assert expected_checksum == observed_checksum
@@ -94,10 +84,7 @@ def test_encrypt_decrypt_submission(
     # crypt4gh_grz_private_key_file_path,
     tmpdir_factory: pytest.TempdirFactory,
 ):
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "files", "metadata")
 
     # first, encrypt the data
     testargs = [
@@ -140,7 +127,7 @@ def test_encrypt_decrypt_submission(
         "bbbbbbbb11111111bbbbbbbb11111111bbbbbbbb11111111bbbbbbbb11111111_blood_normal.read1.fastq.gz",
         "bbbbbbbb11111111bbbbbbbb11111111bbbbbbbb11111111bbbbbbbb11111111_blood_normal.read2.fastq.gz",
     ]:
-        expected_checksum = calculate_sha256(submission_dir / "files" / file)
+        expected_checksum = calculate_sha256(SUBMISSION_DIR / "files" / file)
         observed_checksum = calculate_sha256(working_dir_path / "files" / file)
 
         assert expected_checksum == observed_checksum
@@ -148,9 +135,7 @@ def test_encrypt_decrypt_submission(
 
 def test_encrypt_succeeds_with_valid_logs(working_dir_path, temp_keys_config_file_path):
     """Verify that the encrypt command succeeds if validation logs are present and mark all files as valid."""
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "files", "metadata")
     logs_dir = working_dir_path / "logs"
     logs_dir.mkdir()
 
@@ -197,9 +182,7 @@ def test_encrypt_succeeds_with_valid_logs(working_dir_path, temp_keys_config_fil
 
 def test_encrypt_aborts_on_incomplete_validation(working_dir_path, temp_keys_config_file_path):
     """Verify that the encrypt command fails if the validation log marks a file as not successful."""
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "files", "metadata")
     logs_dir = working_dir_path / "logs"
     logs_dir.mkdir()
 
@@ -248,9 +231,7 @@ def test_encrypt_aborts_on_incomplete_validation(working_dir_path, temp_keys_con
 
 def test_encrypt_aborts_if_validation_log_missing(working_dir_path, temp_keys_config_file_path):
     """Verify that the encrypt command fails if the validation log is missing entirely."""
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "files", "metadata")
     (working_dir_path / "logs").mkdir()  # create empty logs dir
 
     # Attempt encryption

--- a/tests/cli/test_crypt.py
+++ b/tests/cli/test_crypt.py
@@ -12,34 +12,6 @@ from grz_common.utils.checksums import calculate_sha256
 from grz_common.workers.submission import Submission
 
 
-def test_encrypt_submission(
-    working_dir_path,
-    temp_keys_config_file_path,
-    # crypt4gh_grz_private_key_file_path,
-    tmpdir_factory: pytest.TempdirFactory,
-):
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
-
-    # first, encrypt the data
-    testargs = [
-        "encrypt",
-        "--submission-dir",
-        str(working_dir_path),
-        "--config-file",
-        temp_keys_config_file_path,
-        "--no-check-validation-logs",
-    ]
-
-    runner = CliRunner()
-    cli = grz_cli.cli.build_cli()
-    result = runner.invoke(cli, testargs, catch_exceptions=False)
-
-    assert result.exit_code == 0, result.output
-
-
 def test_encrypt_submission_protect_overwrite(
     working_dir_path,
     temp_keys_config_file_path,

--- a/tests/cli/test_db_context.py
+++ b/tests/cli/test_db_context.py
@@ -18,13 +18,13 @@ from sqlmodel import Session, select
 @pytest.fixture
 def full_config_path(
     tmp_path,
-    db_config_content,
+    migrated_db_config_content,
     s3_config_content,
     keys_config_content,
     pruefbericht_config_content,
 ):
     config_data = {}
-    config_data.update(db_config_content)
+    config_data.update(migrated_db_config_content)
     config_data.update(s3_config_content)
     config_data.update(keys_config_content)
     config_data.update(pruefbericht_config_content)
@@ -35,11 +35,6 @@ def full_config_path(
     config_path = tmp_path / "config.yaml"
     with open(config_path, "w") as f:
         yaml.dump(config_data, f)
-
-    runner = click.testing.CliRunner()
-    cli = build_cli()
-    result = runner.invoke(cli, ["db", "--config-file", str(config_path), "init"])
-    assert result.exit_code == 0, f"DB Init failed: {result.output}"
 
     return config_path
 

--- a/tests/cli/test_get_id.py
+++ b/tests/cli/test_get_id.py
@@ -3,19 +3,18 @@ Tests for the grz-cli get-id subcommand.
 """
 
 import importlib.resources
-import shutil
 
 import click.testing
 import grz_cli
 
 from .. import mock_files
+from .common import copy_submission
 
 
 def test_get_id(working_dir_path):
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
-        shutil.copytree(submission_dir / "encrypted_files", working_dir_path / "encrypted_files", dirs_exist_ok=True)
-        shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+        copy_submission(working_dir_path, "encrypted_files", "metadata", source=submission_dir)
 
         runner = click.testing.CliRunner()
         cli = grz_cli.cli.build_cli()

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -4,7 +4,6 @@ Tests for the grzctl list functionality.
 
 import importlib.resources
 import json
-import shutil
 from unittest import mock
 
 import click.testing
@@ -13,14 +12,13 @@ from grz_common.progress import EncryptionState, FileProgressLogger
 from grz_common.workers.submission import Submission
 
 from .. import mock_files
+from .common import copy_submission
 
 
 def test_list(temp_s3_config_file_path, remote_bucket_with_version, working_dir_path, tmp_path):
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
-        shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-        shutil.copytree(submission_dir / "encrypted_files", working_dir_path / "encrypted_files", dirs_exist_ok=True)
-        shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+        copy_submission(working_dir_path, "files", "encrypted_files", "metadata", source=submission_dir)
 
         logs_dir = working_dir_path / "logs"
         logs_dir.mkdir(exist_ok=True)
@@ -75,9 +73,7 @@ def test_list_with_partial_env(temp_s3_config_file_path, remote_bucket_with_vers
     """If database configuration is partially-populated via environment variables, it should still be ignored."""
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
-        shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-        shutil.copytree(submission_dir / "encrypted_files", working_dir_path / "encrypted_files", dirs_exist_ok=True)
-        shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+        copy_submission(working_dir_path, "files", "encrypted_files", "metadata", source=submission_dir)
 
         logs_dir = working_dir_path / "logs"
         logs_dir.mkdir(exist_ok=True)

--- a/tests/cli/test_pruefbericht.py
+++ b/tests/cli/test_pruefbericht.py
@@ -4,7 +4,6 @@ Tests for the Prüfbericht submission functionality.
 
 import importlib.resources
 import json
-import shutil
 
 import click.testing
 import grzctl.cli
@@ -14,6 +13,7 @@ from grz_pydantic_models.pruefbericht.v0 import LibraryType
 from grz_pydantic_models.submission.metadata import REDACTED_TAN
 
 from .. import mock_files
+from .common import copy_submission
 
 TEST_SUBMISSION_ID = "123456789_1970-01-01_00000000"
 
@@ -222,7 +222,7 @@ def test_generate_pruefbericht_multiple_library_types(temp_pruefbericht_config_f
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
         # create and modify a temporary copy of the metadata JSON
-        shutil.copytree(submission_dir, tmp_path, dirs_exist_ok=True)
+        copy_submission(tmp_path, source=submission_dir)
         with open(tmp_path / "metadata" / "metadata.json", mode="r+") as metadata_file:
             metadata = json.load(metadata_file)
 
@@ -258,7 +258,7 @@ def test_generate_fails_with_invalid_library_type(temp_pruefbericht_config_file_
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
         # create and modify a temporary copy of the metadata JSON
-        shutil.copytree(submission_dir, tmp_path, dirs_exist_ok=True)
+        copy_submission(tmp_path, source=submission_dir)
         with open(tmp_path / "metadata" / "metadata.json", mode="r+") as metadata_file:
             metadata = json.load(metadata_file)
 
@@ -290,7 +290,7 @@ def test_refuse_redacted_tang(temp_pruefbericht_config_file_path, tmp_path):
     submission_dir_ptr = importlib.resources.files(mock_files).joinpath("submissions", "valid_submission")
     with importlib.resources.as_file(submission_dir_ptr) as submission_dir:
         # create and modify a temporary copy of the metadata JSON
-        shutil.copytree(submission_dir, tmp_path, dirs_exist_ok=True)
+        copy_submission(tmp_path, source=submission_dir)
         with open(tmp_path / "metadata" / "metadata.json", mode="r+") as metadata_file:
             metadata = json.load(metadata_file)
 

--- a/tests/cli/test_pruefbericht.py
+++ b/tests/cli/test_pruefbericht.py
@@ -334,19 +334,16 @@ def test_refuse_redacted_tang(temp_pruefbericht_config_file_path, tmp_path):
 
 
 @pytest.fixture
-def pruefbericht_db_config(tmp_path):
-    """Create a test database config for pruefbericht tests."""
+def pruefbericht_db_config(tmp_path, migrated_db_connection):
+    """Config file for a database already on the latest schema, one per supported backend."""
     import json
 
-    db_path = tmp_path / "test.db"
-    db_url = f"sqlite:///{db_path}"
-
-    config = {"db": {"database_url": db_url, "author": {"name": "test_author"}}}
+    config = {"db": {"database_url": migrated_db_connection, "author": {"name": "test_author"}}}
 
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps(config))
 
-    return {"db_path": db_path, "db_url": db_url, "config": config, "config_path": config_path}
+    return {"db_url": migrated_db_connection, "config": config, "config_path": config_path}
 
 
 def test_generate_from_database(temp_pruefbericht_config_file_path, pruefbericht_db_config):
@@ -372,7 +369,6 @@ def test_generate_from_database(temp_pruefbericht_config_file_path, pruefbericht
     config_path = pruefbericht_db_config["config_path"]
 
     db = SubmissionDb(db_url=db_url, author=None, debug=False)
-    db.initialize_schema()
 
     db.add_submission(TEST_SUBMISSION_ID)
     # Populate submission fields to match the mock data used in other tests
@@ -435,14 +431,8 @@ def test_generate_from_database(temp_pruefbericht_config_file_path, pruefbericht
 
 def test_generate_from_database_missing_submission(pruefbericht_db_config):
     """Test error when submission doesn't exist in database."""
-    from grz_db.models.submission import SubmissionDb
-
-    # Use the fixture
-    db_url = pruefbericht_db_config["db_url"]
+    # the schema is present but empty, so the submission is genuinely absent rather than unreachable
     config_path = pruefbericht_db_config["config_path"]
-
-    db = SubmissionDb(db_url=db_url, author=None, debug=False)
-    db.initialize_schema()
 
     runner = click.testing.CliRunner()
     cli = grzctl.cli.build_cli()
@@ -472,7 +462,6 @@ def test_generate_from_database_missing_fields(pruefbericht_db_config):
     config_path = pruefbericht_db_config["config_path"]
 
     db = SubmissionDb(db_url=db_url, author=None, debug=False)
-    db.initialize_schema()
 
     # Add submission without populating required fields
     db.add_submission(TEST_SUBMISSION_ID)
@@ -518,7 +507,6 @@ def test_generate_from_database_no_index_donor(pruefbericht_db_config):
     config_path = pruefbericht_db_config["config_path"]
 
     db = SubmissionDb(db_url=db_url, author=None, debug=False)
-    db.initialize_schema()
     db.add_submission(TEST_SUBMISSION_ID)
 
     # Populate all required fields (matching the pattern from test_generate_from_database)

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -6,7 +6,7 @@ import grzctl.cli
 from click.testing import CliRunner
 
 
-def test_report_processed(temp_db_config_file_path):
+def test_report_processed(temp_migrated_db_config_file_path):
     env = {
         "GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test",
         "GRZ_IDENTIFIERS__GRZ": "GRZX00000",
@@ -17,9 +17,7 @@ def test_report_processed(temp_db_config_file_path):
     cli = grzctl.cli.build_cli()
     execute = lambda args: runner.invoke(cli, args, catch_exceptions=False)
 
-    args_prefix = ["db", "--config-file", temp_db_config_file_path]
-    result = execute([*args_prefix, "init"])
-    assert result.exit_code == 0, result.output
+    args_prefix = ["db", "--config-file", temp_migrated_db_config_file_path]
 
     submission_id = "123456789_1970-01-01_a0b1c2d3"
     result = execute([*args_prefix, "submission", "add", submission_id])
@@ -52,7 +50,7 @@ def test_report_processed(temp_db_config_file_path):
     report_args = [
         "report",
         "--config-file",
-        temp_db_config_file_path,
+        temp_migrated_db_config_file_path,
         "processed",
         "--since",
         (today - datetime.timedelta(days=1)).isoformat(),

--- a/tests/cli/test_upload.py
+++ b/tests/cli/test_upload.py
@@ -1,6 +1,5 @@
 import filecmp
 import os
-import shutil
 from importlib.metadata import version
 from pathlib import Path
 from unittest import mock
@@ -12,6 +11,8 @@ from click.testing import CliRunner
 from grz_common.exceptions import IncompleteSubmissionError
 from grz_common.progress import EncryptionState, FileProgressLogger
 from grz_common.workers.submission import Submission
+
+from .common import SUBMISSION_DIR, copy_submission
 
 
 def are_dir_trees_equal(dir1, dir2):
@@ -46,16 +47,9 @@ def test_upload_download_submission(
     temp_s3_db_config_file_path,
     initiated_db_test_connection,  # necessary to initiate DB
 ):
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
     env = {"GRZ_DB__AUTHOR__PRIVATE_KEY_PASSPHRASE": "test"}
 
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(
-        submission_dir / "encrypted_files",
-        working_dir_path / "encrypted_files",
-        dirs_exist_ok=True,
-    )
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "files", "encrypted_files", "metadata")
 
     logs_dir = working_dir_path / "logs"
     logs_dir.mkdir()
@@ -143,9 +137,7 @@ def test_upload_download_submission(
 
 def test_upload_aborts_on_incomplete_encryption(working_dir_path, temp_s3_config_file_path, remote_bucket_with_version):
     """Verify that the upload command fails if the encryption log marks a file as not successful."""
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "files", "metadata")
     (working_dir_path / "encrypted_files").mkdir()
 
     logs_dir = working_dir_path / "logs"
@@ -203,9 +195,7 @@ def test_upload_aborts_if_encryption_log_missing(
     working_dir_path, temp_s3_config_file_path, remote_bucket_with_version
 ):
     """Verify that the upload command fails if the encryption log is missing entirely."""
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "files", "metadata")
     (working_dir_path / "encrypted_files").mkdir()
     (working_dir_path / "logs").mkdir()
 
@@ -245,12 +235,10 @@ def test_upload_workflow_succeeds_with_symlinks_to_real_test_files(
     End-to-end smoke test for LE submissions where `files/` entries are symlinks
     to real fixture files in tests/.
     """
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-
     # Create files/ directory with symlinks to real test fixture files
     (working_dir_path / "files").mkdir(parents=True, exist_ok=True)
-    for source_path in (submission_dir / "files").rglob("*"):
-        relative_path = source_path.relative_to(submission_dir / "files")
+    for source_path in (SUBMISSION_DIR / "files").rglob("*"):
+        relative_path = source_path.relative_to(SUBMISSION_DIR / "files")
         link_path = working_dir_path / "files" / relative_path
 
         if source_path.is_dir():
@@ -264,7 +252,7 @@ def test_upload_workflow_succeeds_with_symlinks_to_real_test_files(
             pytest.skip(f"Symlinks not supported in this environment: {e}")
 
     # Copy metadata (not symlinked since it's not validated by grz-check)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "metadata")
 
     runner = CliRunner()
     cli = grz_cli.cli.build_cli()

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -1,12 +1,12 @@
 import json
 import logging
-import shutil
-from pathlib import Path
 
 import grz_cli.cli
 import pytest
 from click.testing import CliRunner
 from grz_common.workers.submission import SubmissionValidationError
+
+from .common import copy_submission
 
 
 @pytest.mark.parametrize("grz_check_mmap", ["--mmap", "--no-mmap"])
@@ -16,10 +16,7 @@ def test_validate_submission(
     grz_check_mmap,
     caplog,
 ):
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "files", "metadata")
 
     testargs = [
         "validate",
@@ -51,10 +48,7 @@ def test_validate_submission_incorrect_grz_id(
     temp_identifiers_config_file_path,
     working_dir_path,
 ):
-    submission_dir = Path("tests/mock_files/submissions/valid_submission")
-
-    shutil.copytree(submission_dir / "files", working_dir_path / "files", dirs_exist_ok=True)
-    shutil.copytree(submission_dir / "metadata", working_dir_path / "metadata", dirs_exist_ok=True)
+    copy_submission(working_dir_path, "files", "metadata")
 
     with open(working_dir_path / "metadata" / "metadata.json", mode="r+") as metadata_file:
         metadata = json.load(metadata_file)

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -38,10 +38,11 @@ def test_validate_submission(
         assert "Starting file validation with `grz-check`..." in caplog.text
     caplog.clear()
 
-    # check if re-validation is skipped
+    # the recorded progress must be reused rather than the files re-checked. Asserting on the
+    # "Starting file validation" line would prove nothing: it is logged before that decision.
     with caplog.at_level(logging.INFO):
         result = runner.invoke(cli, testargs, catch_exceptions=False)
-        assert "Starting file validation with `grz-check`..." in caplog.text
+        assert "All files are already validated. Skipping `grz-check`." in caplog.text
 
     assert result.exit_code == 0, result.output
 

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -35,7 +35,7 @@ def test_validate_submission(
         assert "Starting file validation with `grz-check`..." in caplog.text
     caplog.clear()
 
-    # the recorded progress must be reused rather than the files re-checked. Asserting on the
+    # The recorded progress must be reused rather than the files being re-checked. Asserting on the
     # "Starting file validation" line would prove nothing: it is logged before that decision.
     with caplog.at_level(logging.INFO):
         result = runner.invoke(cli, testargs, catch_exceptions=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ import boto3
 import grz_cli.models.config
 import grz_common.models.s3
 import grzctl.models.config
-import numpy as np
 import pytest
 import yaml
 from grz_common.utils.crypt import Crypt4GH
@@ -134,24 +133,6 @@ def temp_small_file_sha256sum():
     return "78858035d88f0c66d27984789ddd8fa8a8fc633cf7689ac2b4b1e2e7b37ee3be"
 
 
-def create_large_file(content: str | bytes, output_file: str | PathLike, target_size: int) -> int:
-    """
-    Write some content repeatedly to a file until some target size is reached.
-
-    :param content: Content of the file. Will be repeatedly written to output_file until `target_size` is reached.
-    :param output_file: Path to the output file.
-    :param target_size: target size in bytes.
-    :return: Actual bytes written
-    """
-    # Initialize the size of the new file and open it for writing
-    current_size = 0
-    with open(output_file, "w") as outfile:
-        while current_size < target_size:
-            bytes_written = outfile.write(content)
-            current_size += bytes_written
-    return current_size
-
-
 @pytest.fixture
 def remote_bucket_with_version(remote_bucket):
     """Mock S3 bucket with version.json file at root."""
@@ -185,46 +166,23 @@ def remote_bucket_with_version(remote_bucket):
     return remote_bucket
 
 
-@pytest.fixture
-def temp_large_file_path(temp_data_dir_path) -> Path:
-    temp_large_file_path = temp_data_dir_path / "temp_large_input_file.bed"
-    target_size = 1024 * 1024 * 6  # create 5MB file, multiupload limit is 5MB
+def generate_fastq(file_path: str | PathLike, target_size: int) -> int:
+    """Create a FASTQ file of at least *target_size* bytes.
 
-    with open(small_file_input_path) as fd:
-        content = fd.read()
-
-    create_large_file(content, temp_large_file_path, target_size)
-
-    return temp_large_file_path
-
-
-def generate_random_fastq(file_path: str | PathLike, target_size: int) -> int:
-    """
-    Create a random FASTQ file.
+    The reads repeat rather than being sampled per base: the tests using this only round-trip the
+    file through S3 and compare checksums, so the content never has to look like real sequencing
+    data. The size does matter, being what pushes the transfer over the multipart threshold.
 
     :param file_path: Path to the FASTQ file.
     :param target_size: Target size in bytes.
     :return: Actual bytes written
     """
-    nucleotides = np.array(["A", "T", "C", "G"])
-    quality_scores = np.array(list("!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHI"))
-    bases_per_read = 100  # Length of each read
+    bases_per_read = 100
+    record = f"@SEQ_ID\n{'ACGT' * (bases_per_read // 4)}\n+\n{'I' * bases_per_read}\n"
+    repeats = -(-target_size // len(record))  # ceiling division
 
     with open(file_path, "w") as fastq_file:
-        total_bytes_written = 0
-
-        while total_bytes_written < target_size:
-            # Generate a random sequence of nucleotides using numpy
-            seq = "".join(np.random.choice(nucleotides, bases_per_read))
-            qual = "".join(np.random.choice(quality_scores, bases_per_read))
-
-            # FASTQ entry format
-            entry = f"@SEQ_ID_{np.random.randint(1, 10**6)}\n{seq}\n+\n{qual}\n"
-
-            actual_bytes_written = fastq_file.write(entry)
-            total_bytes_written += actual_bytes_written
-
-    return total_bytes_written
+        return fastq_file.write(record * repeats)
 
 
 @pytest.fixture
@@ -233,7 +191,7 @@ def temp_fastq_file_path(temp_data_dir_path) -> Path:
     temp_fastq_gz_path = temp_data_dir_path / file_name
     target_size = 1024 * 1024 * 6  # create 5MB file, multiupload limit is 5MB
 
-    generate_random_fastq(temp_fastq_gz_path, target_size)
+    generate_fastq(temp_fastq_gz_path, target_size)
 
     return temp_fastq_gz_path
 
@@ -273,12 +231,12 @@ def temp_fastq_file_sha256sum(temp_fastq_file_path):
 
 
 @pytest.fixture
-def temp_metadata_file_path(temp_data_dir_path, temp_large_file_path) -> Path:
+def temp_metadata_file_path(temp_data_dir_path) -> Path:
+    """Metadata naming a file that is never created: validation reads paths, it does not open them."""
     with open(metadata_path) as fd:
         metadata = json.load(fd)
 
-    # insert large file
-    metadata["donors"][0]["labData"][0]["sequenceData"]["files"][0]["filePath"] = temp_large_file_path.name
+    metadata["donors"][0]["labData"][0]["sequenceData"]["files"][0]["filePath"] = "temp_large_input_file.bed"
 
     metadata_file_path = temp_data_dir_path / "metadata.json"
     with open(metadata_file_path, "w") as fd:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,20 +6,30 @@ from datetime import datetime
 from importlib.metadata import version
 from os import PathLike
 from pathlib import Path
-from shutil import copyfile, which
+from shutil import copyfile
 
 import boto3
 import grz_cli.models.config
 import grz_common.models.s3
 import grzctl.models.config
 import numpy as np
-import psycopg
 import pytest
 import yaml
 from grz_common.utils.crypt import Crypt4GH
 from grz_common.workers.submission import EncryptedSubmission, SubmissionMetadata
+from grz_db import testing as grz_db_testing
 from grz_db.models.submission import SubmissionDb
 from moto import mock_aws
+
+# Bound by assignment rather than imported: fixtures below take ``db_test_connection`` as a
+# parameter, which ruff reads as redefining an imported name.
+db_backend = grz_db_testing.db_backend
+db_test_connection = grz_db_testing.db_test_connection
+migrated_db_connection = grz_db_testing.migrated_db_connection
+postgresql_proc = grz_db_testing.postgresql_proc
+_migrated_postgresql_template = grz_db_testing._migrated_postgresql_template
+_migrated_sqlite_template = grz_db_testing._migrated_sqlite_template
+_pg_test_dbnames = grz_db_testing._pg_test_dbnames
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -76,28 +86,13 @@ def db_known_keys_file_path():
     return Path(db_known_keys_file)
 
 
-@pytest.fixture(
-    params=[
-        "sqlite",
-        pytest.param(
-            "postgresql",
-            marks=pytest.mark.skipif(condition=which("pg_config") is None, reason="postgresql not detected"),
-        ),
-    ],
-)
-def db_test_connection(request: pytest.FixtureRequest):
-    if request.param == "sqlite":
-        tmpdir_factory: pytest.TempdirFactory = request.getfixturevalue("tmpdir_factory")
-        db_dir = tmpdir_factory.mktemp("db")
-        db_file = db_dir / "test.db"
-        yield f"sqlite:///{str(db_file)}"
-    elif request.param == "postgresql":
-        postgresql: psycopg.Connection = request.getfixturevalue("postgresql")
-        yield f"postgresql+psycopg://{postgresql.info.user}:@{postgresql.info.host}:{postgresql.info.port}/{postgresql.info.dbname}"
-
-
 @pytest.fixture()
 def initiated_db_test_connection(db_test_connection):
+    """The database behind :func:`db_config_content`, brought to the latest schema.
+
+    Not the shared ``migrated_db_connection``: that hands back a separate database, whereas the
+    tests here need the one their config file already points at.
+    """
     submission_db = SubmissionDb(db_test_connection, author=None)
     submission_db.initialize_schema()
     return db_test_connection
@@ -319,19 +314,34 @@ def s3_config_content():
     }
 
 
+def _db_config_content(private_key_path, known_keys_path, database_url):
+    return {
+        "db": {
+            "database_url": database_url,
+            "author": {"name": "Alice", "private_key_path": str(private_key_path)},
+            "known_public_keys": str(known_keys_path),
+        }
+    }
+
+
 @pytest.fixture
 def db_config_content(
     db_alice_private_key_file_path,
     db_known_keys_file_path,
     db_test_connection,
 ):
-    return {
-        "db": {
-            "database_url": db_test_connection,
-            "author": {"name": "Alice", "private_key_path": str(db_alice_private_key_file_path)},
-            "known_public_keys": str(db_known_keys_file_path),
-        }
-    }
+    """Config for a database with no schema, for tests that run ``db init`` themselves."""
+    return _db_config_content(db_alice_private_key_file_path, db_known_keys_file_path, db_test_connection)
+
+
+@pytest.fixture
+def migrated_db_config_content(
+    db_alice_private_key_file_path,
+    db_known_keys_file_path,
+    migrated_db_connection,
+):
+    """Config for a database already on the latest schema."""
+    return _db_config_content(db_alice_private_key_file_path, db_known_keys_file_path, migrated_db_connection)
 
 
 @pytest.fixture
@@ -372,6 +382,11 @@ def db_config_model(db_config_content):
 
 
 @pytest.fixture
+def migrated_db_config_model(migrated_db_config_content):
+    return grzctl.models.config.DbConfig(**migrated_db_config_content)
+
+
+@pytest.fixture
 def identifiers_config_model(identifiers_config_content):
     return grz_cli.models.config.ValidateConfig(**identifiers_config_content)
 
@@ -406,9 +421,19 @@ def temp_s3_config_file_path(temp_data_dir_path, s3_config_model) -> Path:
 
 @pytest.fixture
 def temp_db_config_file_path(temp_data_dir_path, db_config_model) -> Path:
+    """Config file for a database with no schema, for tests that run ``db init`` themselves."""
     config_file = temp_data_dir_path / "config.db.yaml"
     with open(config_file, "w") as fd:
         db_config_model.to_yaml(fd)
+    return config_file
+
+
+@pytest.fixture
+def temp_migrated_db_config_file_path(temp_data_dir_path, migrated_db_config_model) -> Path:
+    """Config file for a database already on the latest schema."""
+    config_file = temp_data_dir_path / "config.migrated_db.yaml"
+    with open(config_file, "w") as fd:
+        migrated_db_config_model.to_yaml(fd)
     return config_file
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,9 @@ from grz_db import testing as grz_db_testing
 from grz_db.models.submission import SubmissionDb
 from moto import mock_aws
 
-# Bound by assignment rather than imported: fixtures below take ``db_test_connection`` as a
-# parameter, which ruff reads as redefining an imported name.
+# These names are bound by assignment rather than imported directly, because fixtures below take
+# ``db_test_connection`` as a parameter name, which ruff would otherwise read as redefining an
+# imported name.
 db_backend = grz_db_testing.db_backend
 db_test_connection = grz_db_testing.db_test_connection
 migrated_db_connection = grz_db_testing.migrated_db_connection
@@ -89,8 +90,8 @@ def db_known_keys_file_path():
 def initiated_db_test_connection(db_test_connection):
     """The database behind :func:`db_config_content`, brought to the latest schema.
 
-    Not the shared ``migrated_db_connection``: that hands back a separate database, whereas the
-    tests here need the one their config file already points at.
+    This is not the shared ``migrated_db_connection`` fixture: that one hands back a separate
+    database, whereas the tests here need the specific database their config file already points at.
     """
     submission_db = SubmissionDb(db_test_connection, author=None)
     submission_db.initialize_schema()
@@ -171,7 +172,7 @@ def generate_fastq(file_path: str | PathLike, target_size: int) -> int:
 
     The reads repeat rather than being sampled per base: the tests using this only round-trip the
     file through S3 and compare checksums, so the content never has to look like real sequencing
-    data. The size does matter, being what pushes the transfer over the multipart threshold.
+    data. The size does matter: it is what pushes the transfer over the multipart threshold.
 
     :param file_path: Path to the FASTQ file.
     :param target_size: Target size in bytes.
@@ -232,7 +233,7 @@ def temp_fastq_file_sha256sum(temp_fastq_file_path):
 
 @pytest.fixture
 def temp_metadata_file_path(temp_data_dir_path) -> Path:
-    """Metadata naming a file that is never created: validation reads paths, it does not open them."""
+    """Metadata naming a file that is never created: validation reads paths; it does not open them."""
     with open(metadata_path) as fd:
         metadata = json.load(fd)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1008,6 +1008,12 @@ dependencies = [
     { name = "sqlmodel" },
 ]
 
+[package.optional-dependencies]
+testing = [
+    { name = "pytest" },
+    { name = "pytest-postgresql" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "tox" },
@@ -1029,8 +1035,11 @@ requires-dist = [
     { name = "cryptography", specifier = ">=45.0.3,<49" },
     { name = "grz-pydantic-models", editable = "packages/grz-pydantic-models" },
     { name = "psycopg", extras = ["binary"], specifier = "~=3.2" },
+    { name = "pytest", marker = "extra == 'testing'" },
+    { name = "pytest-postgresql", marker = "extra == 'testing'" },
     { name = "sqlmodel", specifier = ">=0.0.38" },
 ]
+provides-extras = ["testing"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1147,7 +1156,7 @@ test = [
     { name = "grz-check" },
     { name = "grz-cli" },
     { name = "grz-common" },
-    { name = "grz-db" },
+    { name = "grz-db", extra = ["testing"] },
     { name = "grz-pydantic-models-testing" },
     { name = "grzctl" },
     { name = "moto", extra = ["s3"] },
@@ -1207,7 +1216,7 @@ test = [
     { name = "grz-check", editable = "packages/grz-check" },
     { name = "grz-cli", editable = "packages/grz-cli" },
     { name = "grz-common", editable = "packages/grz-common" },
-    { name = "grz-db", editable = "packages/grz-db" },
+    { name = "grz-db", extras = ["testing"], editable = "packages/grz-db" },
     { name = "grz-pydantic-models-testing", editable = "packages/grz-pydantic-models-testing" },
     { name = "grzctl", editable = "packages/grzctl" },
     { name = "moto", extras = ["s3"] },
@@ -1238,6 +1247,7 @@ dev = [
 test = [
     { name = "grz-cli" },
     { name = "grz-common" },
+    { name = "grz-db", extra = ["testing"] },
     { name = "grz-pydantic-models-testing" },
     { name = "moto", extra = ["s3"] },
     { name = "numpy" },
@@ -1265,6 +1275,7 @@ dev = [
 test = [
     { name = "grz-cli", editable = "packages/grz-cli" },
     { name = "grz-common", editable = "packages/grz-common" },
+    { name = "grz-db", extras = ["testing"], editable = "packages/grz-db" },
     { name = "grz-pydantic-models-testing", editable = "packages/grz-pydantic-models-testing" },
     { name = "moto", extras = ["s3"] },
     { name = "numpy" },


### PR DESCRIPTION
grz-db now ships the pytest fixtures its own tests use, under a
`testing` extra, so grzctl and the root suite provision databases the
same way instead of each rolling its own. `grz_db/testing.py` is the
only new shipped code; nothing else changes production behaviour.

Every suite previously brought up a database by running a full Alembic
upgrade per test. The fixtures migrate one template per backend per
session and clone it, by file copy on SQLite and `CREATE DATABASE ...
TEMPLATE` on PostgreSQL. The template is a real Alembic run rather than
`metadata.create_all`, because the partial unique indexes exist only in
migrations and a schema built from the models would silently lack them.

Consumers import the fixtures rather than naming them in
`pytest_plugins`: pytest accepts that declaration only in a conftest at
the rootdir, and a rootdir declaration would load the module for
packages whose environments have no pytest-postgresql. No `pytest11`
entry point is registered for the same reason.

Also in this PR:
- Several modules shadowed the shared fixtures with SQLite-only ones, so
the QC selection strategy, failure-reason persistence, backfill and
Prüfbericht generation had never run against PostgreSQL. They now run on
both.
- `submit`'s ordering test asserted only that each subcommand ran once,
so any order satisfied it, and it never checked the arguments they were
handed.
- The grzctl version tests patched `grzctl.get_versions` while `db.cli`
had imported the name, so the real versions were recorded and every
version-specific claim went unchecked. One test had already been
weakened to accommodate this.
- The re-validation test asserted a line that is logged before the
decision to skip is taken.
- The QC selection tests recomputed the seed formula and asserted the
implementation matched their own copy, which cannot catch a formula
wrong in both places. They now assert the guarantees the block scheme
provides: one selection per block, reproducibility, nothing at a zero
target, and a catch-up floor. Nothing previously checked that
`should_qc` consults the random branch at all.
- An empty-consent test passed a dict to `model_validate_json`, which
takes JSON text, so pydantic raised on the input type before any rule
ran. A gzip test passed a `BytesIO` where its docstring described a file
handle, making it identical to the test above it.
- Nine tests asserting a strict subset of a sibling were removed, and
bundled tests that chained several independent behaviours through one
body were split, so a failure names the behaviour that broke.
- Both branches of `populate`'s `on_missing` are now covered, where
previously neither was, including the `create` mode that `download` is
the only caller of.
- Around 12MB of file data generated per run and never read is gone: one
fixture existed so that its file's name could be spliced into metadata
that validation never opens.

The suite runs in roughly 100s rather than 255s, 652 passing with
nothing skipped.
