### PR TITLE
fix(grz-cli)!: require grz-common 3

### DIFF
--- a/packages/grz-cli/pyproject.toml
+++ b/packages/grz-cli/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 dynamic = ["version"]
 dependencies = [
     "packaging >=23,<27",
-    "grz-common >=2.1,<3",
+    "grz-common >=3,<4",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/packages/grzctl/pyproject.toml
+++ b/packages/grzctl/pyproject.toml
@@ -14,8 +14,8 @@ authors = [
 dynamic = ["version"]
 dependencies = [
     "requests >=2.32.3,<3",
-    "grz-db >=2.1.2,<3",
-    "grz-cli >=1.7,<2",
+    "grz-db >=3,<4",
+    "grz-cli >=2,<3",
     "textual~=5.3"
 ]
 classifiers = [


### PR DESCRIPTION
grz-cli and grzctl still declared the pre-3.0.0 bounds, so installing
either from PyPI resolves grz-common 2.x and grz-db 2.x, and with them
grz-pydantic-models 2.x. Neither tool reaches the FHIR dateTime and
research-consent behavior that grz-pydantic-models 3 introduced, even
though grzctl 3.0.0 already lists those changes among its own breaking
changes.

`uv.lock` is unchanged, as it records no specifier for an
intra-workspace dependency.

BREAKING CHANGE: grz-cli requires grz-common 3. Metadata naming a
consent dateTime outside the FHIR grammar, or leaving a 2025
researchConsent provision period open-ended, is now rejected rather than
accepted.

fix(grzctl)!: require grz-db 3 and grz-cli 2
  BREAKING CHANGE: grzctl requires grz-db 3 and grz-cli 2, and so
  applies the same consent rules when it reads or backfills submission
  metadata.

