### PR TITLE
ci(repo): harden publish workflows and pin actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    # Actions are pinned to commit SHAs, so Dependabot is what keeps them
+    # current. `include: scope` yields titles like "ci(deps): bump ...", which
+    # satisfies the requireScope rule enforced by check-pr.yml.
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,5 +1,22 @@
 name: "Conventional commit PRs"
 
+# SECURITY NOTE: this workflow runs on `pull_request_target`, so it executes in
+# the context of the BASE branch with a token that is available even when the
+# pull request comes from a fork.
+#
+# That is only safe because this workflow:
+#   - never checks out or executes PR code (no actions/checkout),
+#   - never interpolates PR-controlled data (title, body, branch name) into a
+#     `run:` script; the only expression used in one is `needs.main.result`,
+#     which is a fixed enum,
+#   - grants nothing by default (`permissions: {}` below), so the job that
+#     needs the PR title opts in to `pull-requests: read` and nothing else.
+#
+# DO NOT add a checkout of PR code, or run any PR-provided content, here. Doing
+# so would let a fork execute arbitrary code with write access to this
+# repository (a "pwn request"). If code from a PR ever needs to be tested, use
+# a separate workflow on the plain `pull_request` trigger.
+
 on:
   pull_request_target:
     types:
@@ -12,6 +29,9 @@ on:
   # Merge queue: the workflow must run on merge_group so the required
   # "Conventional commit PRs" check reports on the queue's merge commit.
   merge_group:
+
+# Default-deny; each job opts in to what it needs. The aggregator needs nothing.
+permissions: {}
 
 jobs:
   main:

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -44,7 +44,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         with:
           scopes: |
             grz-common

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         with:
           scopes: |
             grz-common

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,14 @@ jobs:
       has_rust_changes: ${{ steps.generate_matrix.outputs.has_rust_changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           lfs: true
 
       - name: Get changed files within packages
         id: changed_package_files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
           files: packages/**
 
@@ -131,12 +131,12 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           version-file: "pyproject.toml"
           enable-cache: true
@@ -165,10 +165,10 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: rustfmt, clippy
@@ -190,10 +190,10 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           cache-workspaces: ${{ env.GRZ_CHECK_WORKSPACE }}
@@ -203,7 +203,7 @@ jobs:
         run: cargo build --manifest-path packages/grz-check/Cargo.toml
 
       - name: Upload grz-check binary as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: grz-check-binary
           path: packages/grz-check/target/debug/grz-check
@@ -219,10 +219,10 @@ jobs:
         package: ${{ fromJson(needs.determine-changes.outputs.rust_matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           cache-workspaces: ${{ env.GRZ_CHECK_WORKSPACE }}
@@ -248,7 +248,7 @@ jobs:
     if: ${{ !cancelled() && (github.event_name == 'pull_request' || github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && needs.build-grz-check-binary.result == 'success' && (needs.test-changed-packages-rust.result == 'success' || needs.test-changed-packages-rust.result == 'skipped') }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           lfs: true
 
@@ -256,7 +256,7 @@ jobs:
         run: sudo apt-get --update install postgresql
 
       - name: Download grz-check binary artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: grz-check-binary
           path: ${{ github.workspace }}/bin
@@ -268,7 +268,7 @@ jobs:
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           version-file: "pyproject.toml"
           enable-cache: true
@@ -299,12 +299,12 @@ jobs:
           - "3.13"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           lfs: true
 
       - name: Download grz-check binary artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: grz-check-binary
           path: ${{ github.workspace }}/bin
@@ -316,7 +316,7 @@ jobs:
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           version-file: "pyproject.toml"
           enable-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,14 @@ jobs:
       has_rust_changes: ${{ steps.generate_matrix.outputs.has_rust_changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           lfs: true
 
       - name: Get changed files within packages
         id: changed_package_files
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: packages/**
 
@@ -131,12 +131,12 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: "pyproject.toml"
           enable-cache: true
@@ -165,7 +165,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -190,7 +190,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -203,7 +203,7 @@ jobs:
         run: cargo build --manifest-path packages/grz-check/Cargo.toml
 
       - name: Upload grz-check binary as an artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grz-check-binary
           path: packages/grz-check/target/debug/grz-check
@@ -219,7 +219,7 @@ jobs:
         package: ${{ fromJson(needs.determine-changes.outputs.rust_matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -248,7 +248,7 @@ jobs:
     if: ${{ !cancelled() && (github.event_name == 'pull_request' || github.event_name == 'merge_group' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && needs.build-grz-check-binary.result == 'success' && (needs.test-changed-packages-rust.result == 'success' || needs.test-changed-packages-rust.result == 'skipped') }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
 
@@ -256,7 +256,7 @@ jobs:
         run: sudo apt-get --update install postgresql
 
       - name: Download grz-check binary artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: grz-check-binary
           path: ${{ github.workspace }}/bin
@@ -268,7 +268,7 @@ jobs:
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: "pyproject.toml"
           enable-cache: true
@@ -299,12 +299,12 @@ jobs:
           - "3.13"
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
 
       - name: Download grz-check binary artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: grz-check-binary
           path: ${{ github.workspace }}/bin
@@ -316,7 +316,7 @@ jobs:
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: "pyproject.toml"
           enable-cache: true

--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -21,15 +21,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.ref }}
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
 
       - name: Publish grz-check to crates.io
         working-directory: packages/grz-check
-        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+        # Passed via env rather than on the command line: an argument is visible
+        # in the runner's process list, and cargo reads this variable natively.
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish

--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/pypi-rust.yml
+++ b/.github/workflows/pypi-rust.yml
@@ -14,14 +14,14 @@ jobs:
         target: [x86_64, aarch64]
     steps:
       # actions/checkout v6.0.2
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # actions/setup-python v6.2.0
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
       - name: Build wheels
         # PyO3/maturin-action v1.51.0
-        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # actions/checkout v6.0.2
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build sdist
         # PyO3/maturin-action v1.51.0
-        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: sdist
           args: --out dist
@@ -73,6 +73,6 @@ jobs:
           merge-multiple: true
       - name: Publish to PyPI
         # pypa/gh-action-pypi-publish release/v1
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -20,30 +20,42 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           lfs: true
           ref: ${{ github.ref }} # Checkout the specific tag
 
       - name: Extract package name from tag
         id: extract_package_info
+        # Tag-derived values are passed through env, never interpolated into the
+        # script body: a tag matching the trigger glob may still contain shell
+        # metacharacters, and this job holds id-token: write.
+        env:
+          TAG_NAME: ${{ github.ref_name }} # e.g., grz-cli-v1.2.3
+          RUN_ID: ${{ github.run_id }}
         run: |
-          TAG_NAME="${{ github.ref_name }}" # e.g., grz-cli-v1.2.3
-          PKG_NAME=$(echo "$TAG_NAME" | sed -E 's/-v[0-9]+\.[0-9]+\.[0-9]+.*//')
-          echo "name=$PKG_NAME" >> $GITHUB_OUTPUT
-          echo "artifact_name=${PKG_NAME}-build-${{ github.run_id }}" >> $GITHUB_OUTPUT
+          PKG_NAME=$(printf '%s' "$TAG_NAME" | sed -E 's/-v[0-9]+\.[0-9]+\.[0-9]+.*//')
+          # Fail closed rather than pass an unexpected name on to the build.
+          if ! printf '%s' "$PKG_NAME" | grep -qE '^[a-z0-9][a-z0-9-]*$'; then
+            echo "Refusing to build: '$PKG_NAME' (from tag '$TAG_NAME') is not a plain package name." >&2
+            exit 1
+          fi
+          echo "name=$PKG_NAME" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=${PKG_NAME}-build-${RUN_ID}" >> "$GITHUB_OUTPUT"
           echo "Extracted package name: $PKG_NAME from tag $TAG_NAME"
 
       - name: Update Environment URL
         id: update_env_url
         # Only run if PKG_NAME was successfully extracted
         if: steps.extract_package_info.outputs.name != ''
+        env:
+          PKG_NAME: ${{ steps.extract_package_info.outputs.name }}
         run: |
-          echo "PYPI_PACKAGE_URL=https://pypi.org/p/${{ steps.extract_package_info.outputs.name }}" >> $GITHUB_OUTPUT
-          echo "PyPI Environment URL will be set to: https://pypi.org/p/${{ steps.extract_package_info.outputs.name }}"
+          echo "PYPI_PACKAGE_URL=https://pypi.org/p/${PKG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "PyPI Environment URL will be set to: https://pypi.org/p/${PKG_NAME}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           version-file: "pyproject.toml"
           enable-cache: true
@@ -54,18 +66,20 @@ jobs:
       - name: Build package ${{ steps.extract_package_info.outputs.name }}
         id: build_step
         if: steps.extract_package_info.outputs.name != '' # Ensure PKG_NAME is not empty
+        env:
+          PKG_NAME: ${{ steps.extract_package_info.outputs.name }}
         run: |
-          echo "Building package: ${{ steps.extract_package_info.outputs.name }}"
+          echo "Building package: $PKG_NAME"
           OUTPUT_DIR="dist_for_upload"
-          mkdir -p $OUTPUT_DIR
-          uv build --sdist --wheel --project "packages/${{ steps.extract_package_info.outputs.name }}" --out-dir $OUTPUT_DIR
+          mkdir -p "$OUTPUT_DIR"
+          uv build --sdist --wheel --project "packages/$PKG_NAME" --out-dir "$OUTPUT_DIR"
 
           echo "Contents of $OUTPUT_DIR:"
-          ls -l $OUTPUT_DIR
-          echo "dist_path=$OUTPUT_DIR" >> $GITHUB_OUTPUT
+          ls -l "$OUTPUT_DIR"
+          echo "dist_path=$OUTPUT_DIR" >> "$GITHUB_OUTPUT"
 
       - name: Publish ${{ steps.extract_package_info.outputs.name }} to PyPI
         if: steps.build_step.outputs.dist_path != '' && steps.extract_package_info.outputs.name != ''
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages_dir: ${{ steps.build_step.outputs.dist_path }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           lfs: true
           ref: ${{ github.ref }} # Checkout the specific tag
@@ -55,7 +55,7 @@ jobs:
           echo "PyPI Environment URL will be set to: https://pypi.org/p/${PKG_NAME}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: "pyproject.toml"
           enable-cache: true
@@ -80,6 +80,6 @@ jobs:
 
       - name: Publish ${{ steps.extract_package_info.outputs.name }} to PyPI
         if: steps.build_step.outputs.dist_path != '' && steps.extract_package_info.outputs.name != ''
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages_dir: ${{ steps.build_step.outputs.dist_path }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,11 +22,11 @@ jobs:
       prs: ${{ steps.release.outputs.prs }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run Release Please
         id: release
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
@@ -45,13 +45,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout release PR branch
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ fromJSON(needs.release-please.outputs.prs)[0].headBranchName }}
           token: ${{ secrets.RELEASE_PLEASE_PAT }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: "pyproject.toml"
           enable-cache: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,11 +22,11 @@ jobs:
       prs: ${{ steps.release.outputs.prs }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Run Release Please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
@@ -45,13 +45,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout release PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ fromJSON(needs.release-please.outputs.prs)[0].headBranchName }}
           token: ${{ secrets.RELEASE_PLEASE_PAT }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           version-file: "pyproject.toml"
           enable-cache: true


### PR DESCRIPTION
## Summary

Three workflow hardening changes, plus Dependabot so the pinning stays
current. No behaviour change to what gets built or published.

## Stop interpolating tag-derived values into the publish script

`pypi.yml` built its shell script by substituting `github.ref_name`, and
then the package name derived from it, directly into the `run:` body.
Expressions are pasted into the script text before bash parses it, and
the trigger glob `*-v[0-9]+.[0-9]+.[0-9]+*` still matches tags that
contain quotes, semicolons, `$()` or backticks. Git permits all of those
in a ref name (it forbids `*`, `?`, `[`, `~`, `^`, `:` and spaces, but
not these).

This is the sharpest of the three because the job holds `id-token: write`
for trusted publishing, and the `pypi` environment currently has no
protection rules, so there are no required reviewers in the path. A
crafted tag could reach the OIDC token and publish arbitrary releases.

Both tainted values now travel through `env:` and are referenced as
`"$TAG_NAME"` and `"$PKG_NAME"`. The extracted name must also match
`^[a-z0-9][a-z0-9-]*$`, so a malformed tag fails the job rather than
being passed on to the build.

Two shapes were checked against the old and new logic. A payload after
the version segment (`grz-cli-v1.2.3";...;"`) executes under the old
code; under the new one it is stripped by the existing `sed` and builds
`grz-cli` as normal. A payload before it (`evil";...;"-v1.2.3`) also
executes under the old code, and is rejected by the new validation.

## Pass the crates.io token via env instead of argv

`cargo publish --token <secret>` puts the token in the runner's process
list. Cargo reads `CARGO_REGISTRY_TOKEN` natively, so it moves to `env:`
and off the command line.

## Pin the remaining actions to commit SHAs

`pypi-rust.yml` already pins every action it uses. The other five
workflows tracked floating tags, so this completes what was started
there rather than introducing a new convention.

Worth noting `tj-actions/changed-files` is the action whose tags were
retroactively repointed at a malicious commit in CVE-2025-30066, which is
exactly the failure mode tag-tracking exposes. `release-please.yml` also
runs with a PAT rather than the scoped `GITHUB_TOKEN`.

Each action is pinned at the major it already used, so no versions
change. `pypa/gh-action-pypi-publish` reuses the exact SHA
`pypi-rust.yml` already pins.

One thing for a maintainer to decide separately: `pypi-rust.yml` sits on
newer majors than the rest (checkout v6, upload-artifact v7,
download-artifact v8, against v4 elsewhere). Converging those is a real
upgrade with behaviour differences, so it is deliberately not part of
this PR.

## Dependabot

Pinned SHAs do not update themselves. Grouped monthly, with
`include: scope` so titles read `ci(deps): bump ...` and satisfy the
`requireScope` rule in `check-pr.yml`. Drop this commit if you would
rather bump by hand.
