### PR TITLE
feat(grz-pydantic-models,grz-common): keep a parsed submission lossless and redact it by one rule

### DIFF
--- a/packages/grz-common/pyproject.toml
+++ b/packages/grz-common/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pydantic >=2.12,<3",
     "pydantic-settings >=2.11.0,<3",
     "platformdirs >=4.3.6,<5",
-    "grz-pydantic-models >=3,<4",
+    "grz-pydantic-models >=3.1,<4",
     "grz-check >=0.3.1",
 ]
 classifiers = [

--- a/packages/grz-common/src/grz_common/workers/upload.py
+++ b/packages/grz-common/src/grz_common/workers/upload.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, override
 import botocore.handlers
 from boto3.s3.transfer import S3Transfer, TransferConfig  # type: ignore[import-untyped]
 from grz_common.exceptions import UploadError
-from grz_pydantic_models.submission.metadata import REDACTED_TAN
+from grz_pydantic_models.submission.metadata import redact_metadata_dict
 from tqdm.auto import tqdm
 
 from ..constants import TQDM_DEFAULTS
@@ -278,23 +278,15 @@ class S3BotoUploadWorker(UploadWorker):
                 self.__log.error("Upload failed for '%s'", str(file_path))
                 raise e
 
+        # The archived metadata.json is the record of what the submitter sent, so the redaction is
+        # applied to the raw file rather than to a re-serialisation of the parsed model. The rule
+        # itself is shared with GrzSubmissionMetadata.to_redacted_dict() so the two cannot drift.
         with tempfile.NamedTemporaryFile(mode="w") as redacted_metadata_tmpfile:
             # read original metadata
             with open(metadata_file_path) as fd:
                 metadata = json.load(fd)
 
-            # redact tanG as all zeros
-            metadata["submission"]["tanG"] = REDACTED_TAN
-
-            # redact local case ID
-            metadata["submission"]["localCaseId"] = ""
-
-            for donor in metadata["donors"]:
-                if donor["relation"] == "index":
-                    # redact index donorPseudonym (which can be the tanG)
-                    donor["donorPseudonym"] = "index"
-
-            json.dump(metadata, redacted_metadata_tmpfile, indent=2)
+            json.dump(redact_metadata_dict(metadata), redacted_metadata_tmpfile, indent=2)
             # ensure all data is written to disk before upload
             redacted_metadata_tmpfile.flush()
 

--- a/packages/grz-db/src/grz_db/models/submission/__init__.py
+++ b/packages/grz-db/src/grz_db/models/submission/__init__.py
@@ -654,16 +654,33 @@ class SubmissionDb:
         """
         self.engine = create_engine(db_url, echo=debug)
         self._author = author
+        self._schema_confirmed = False
 
     @contextmanager
-    def _get_session(self) -> Generator[Session, Any, None]:
-        """Get an sqlmodel session."""
-        if not self._at_latest_schema():
-            raise OutdatedDatabaseSchemaError(
-                "Database not at latest schema. Please backup the database and then attempt a migration with `grzctl db upgrade`."
-            )
-        with Session(self.engine) as session:
+    def transaction(self, session: Session | None = None) -> Generator[Session, Any, None]:
+        """Open a session that commits when its body completes, or join one already open.
+
+        Joining is what lets a caller apply several writes as one transaction: whoever opened
+        the session is the one that commits it, so a write that joins leaves that decision to
+        its caller, and a rejected write discards everything done under it. A write therefore
+        only ever flushes, which is also what puts it in front of the indices while the
+        handler that can name what they rejected is still in scope.
+
+        ``expire_on_commit=False`` keeps returned instances readable after the commit: the
+        flush has already fetched what the database assigns, such as autoincrement primary
+        keys, and nothing is computed later.
+
+        :param session: A session to join, or ``None`` to open one.
+        :raises OutdatedDatabaseSchemaError: if a session is opened here and the database is
+            not at the latest revision. A joined session is not re-checked.
+        """
+        if session is not None:
             yield session
+            return
+        self._confirm_schema()
+        with Session(self.engine, expire_on_commit=False) as own_session:
+            yield own_session
+            own_session.commit()
 
     def _get_alembic_config(self) -> AlembicConfig:
         """
@@ -676,6 +693,28 @@ class SubmissionDb:
         alembic_cfg.set_main_option("script_location", "grz_db:migrations")
         alembic_cfg.set_main_option("sqlalchemy.url", str(self.engine.url))
         return alembic_cfg
+
+    def _confirm_schema(self) -> None:
+        """Confirm, once, that the database is at the revision this code expects.
+
+        Asking costs a scan of the migration directory and a connection of its own, and one
+        pass over a submission opens several sessions, so the answer is kept. Nothing makes
+        it stale in a way that helps: migrating is an operator action, downgrades are not
+        supported.
+
+        Only a confirmation is kept, never a failure. That is what lets ``db init`` and
+        ``db upgrade`` build this object while the schema is behind, which is the one situation
+        they exist for, and use it once they have fixed it.
+
+        :raises OutdatedDatabaseSchemaError: if the database is not at the latest revision.
+        """
+        if self._schema_confirmed:
+            return
+        if not self._at_latest_schema():
+            raise OutdatedDatabaseSchemaError(
+                "Database not at latest schema. Please backup the database and then attempt a migration with `grzctl db upgrade`."
+            )
+        self._schema_confirmed = True
 
     def _at_latest_schema(self) -> bool:
         directory = AlembicScriptDirectory.from_config(self._get_alembic_config())
@@ -717,7 +756,7 @@ class SubmissionDb:
         Returns:
             An instance of Submission.
         """
-        with self._get_session() as session:
+        with self.transaction() as session:
             existing_submission = session.get(Submission, submission_id)
             if existing_submission:
                 raise DuplicateSubmissionError(submission_id)
@@ -726,16 +765,8 @@ class SubmissionDb:
             db_submission = Submission.model_validate(submission_create)
 
             session.add(db_submission)
-            try:
-                session.commit()
-                session.refresh(db_submission)
-                return db_submission
-            except IntegrityError as e:
-                session.rollback()
-                raise e
-            except Exception:
-                session.rollback()
-                raise
+            session.flush()
+            return db_submission
 
     @staticmethod
     def _is_tan_g_unique_violation(e: IntegrityError) -> bool:
@@ -750,44 +781,49 @@ class SubmissionDb:
                 return getattr(diag, "constraint_name", None) == "ix_submissions_tan_g"
         return False
 
-    def modify_submission(self, submission_id: str, key: str, value: Any) -> Submission:  # noqa: C901
+    def modify_submission(  # noqa: C901
+        self, submission_id: str, key: str, value: Any, session: Session | None = None
+    ) -> Submission:
+        """Set one column of a submission.
+
+        :param session: Transaction to join; a fresh one is opened and committed when absent.
+        """
         if key not in SubmissionBase.model_fields:
             raise ValueError(f"Unknown column key '{key}'")
         elif key in SubmissionBase.immutable_fields:
             raise ValueError(f"Column '{key}' is read-only and cannot be modified.")
 
-        with self._get_session() as session:
-            submission = session.get(Submission, submission_id)
+        with self.transaction(session) as active_session:
+            submission = active_session.get(Submission, submission_id)
             if submission is None:
                 raise SubmissionNotFoundError(submission_id)
 
             setattr(submission, key, value)
             if key == "basic_qc_passed":
                 # Basic QC state changed -> Align the in-depth QC queue to the new state
-                queue_entry = session.get(QCQueueEntry, submission_id)
+                queue_entry = active_session.get(QCQueueEntry, submission_id)
 
                 if submission.basic_qc_passed is True and queue_entry is None:
                     # Basic QC passed -> Ensure that submission is tracked in the in-depth QC queue
-                    session.add(QCQueueEntry(submission_id=submission_id))
+                    active_session.add(QCQueueEntry(submission_id=submission_id))
                 elif submission.basic_qc_passed is not True and queue_entry is not None:
                     # Basic QC failed -> Ensure that submission is absent from the in-depth QC queue
-                    session.delete(queue_entry)
+                    active_session.delete(queue_entry)
 
                 # Keep selection flag aligned with failed basic QC.
                 if submission.basic_qc_passed is False:
                     submission.selected_for_qc = False
-            session.add(submission)
+            active_session.add(submission)
             try:
-                session.commit()
-                session.refresh(submission)
+                active_session.flush()
                 return submission
             except IntegrityError as e:
-                session.rollback()
+                active_session.rollback()
                 if self._is_tan_g_unique_violation(e) and key == "tan_g":
                     raise DuplicateTanGError() from e
                 raise
             except Exception:
-                session.rollback()
+                active_session.rollback()
                 raise
 
     def update_submission(self, submission: Submission) -> Submission:
@@ -797,7 +833,7 @@ class SubmissionDb:
         :param submission: The Submission instance with updated field values.
         :return: The updated Submission instance.
         """
-        with self._get_session() as session:
+        with self.transaction() as session:
             db_submission = session.get(Submission, submission.id)
             if db_submission is None:
                 raise SubmissionNotFoundError(submission.id)
@@ -809,8 +845,7 @@ class SubmissionDb:
 
             session.add(db_submission)
             try:
-                session.commit()
-                session.refresh(db_submission)
+                session.flush()
                 return db_submission
             except IntegrityError as e:
                 session.rollback()
@@ -836,7 +871,7 @@ class SubmissionDb:
         start_date: datetime.date,
         end_date: datetime.date,
     ) -> Sequence[Submission]:
-        with self._get_session() as session:
+        with self.transaction() as session:
             return session.exec(
                 select(Submission)
                 .options(selectinload(Submission.states))  # type: ignore[arg-type]
@@ -916,7 +951,7 @@ class SubmissionDb:
         Returns:
             An instance of SubmissionStateLog.
         """
-        with self._get_session() as session:
+        with self.transaction() as session:
             submission = session.get(Submission, submission_id)
             if not submission:
                 raise SubmissionNotFoundError(submission_id)
@@ -936,46 +971,45 @@ class SubmissionDb:
             state_log_create = SubmissionStateLogCreate(**state_log_payload.model_dump(), signature=signature.hex())
             db_state_log = SubmissionStateLog.model_validate(state_log_create)
             session.add(db_state_log)
+            session.flush()
+            return db_state_log
 
-            try:
-                session.commit()
-                session.refresh(db_state_log)
-                return db_state_log
-            except Exception:
-                session.rollback()
-                raise
+    def get_donors(
+        self, submission_id: str, pseudonym: str | None = None, session: Session | None = None
+    ) -> tuple[Donor, ...]:
+        """Retrieve all donors for a given submission, or, optionally, only for a specific pseudonym.
 
-    def get_donors(self, submission_id: str, pseudonym: str | None = None) -> tuple[Donor, ...]:
-        """Retrieve all donors for a given submission, or, optionally, only for a specific pseudonym."""
-        with self._get_session() as session:
+        :param session: Transaction to join; a fresh one is opened and committed when absent.
+        """
+        with self.transaction(session) as active_session:
             statement = select(Donor).where(Donor.submission_id == submission_id)
             if pseudonym is not None:
                 statement = statement.where(Donor.pseudonym == pseudonym)
-            donors = tuple(session.exec(statement).all())
+            donors = tuple(active_session.exec(statement).all())
         return donors
 
-    def add_donor(self, donor: Donor) -> Donor:
-        """Add a donor to the database."""
-        with self._get_session() as session:
-            session.add(donor)
+    def add_donor(self, donor: Donor, session: Session | None = None) -> Donor:
+        """Add a donor to the database.
 
-            try:
-                session.commit()
-                session.refresh(donor)
-                return donor
-            except Exception as e:
-                session.rollback()
-                raise e
+        :param session: Transaction to join; a fresh one is opened and committed when absent.
+        """
+        with self.transaction(session) as active_session:
+            active_session.add(donor)
+            active_session.flush()
+            return donor
 
-    def update_donor(self, updated_donor: Donor) -> Donor:
-        """Update a donor in the database."""
-        with self._get_session() as session:
+    def update_donor(self, updated_donor: Donor, session: Session | None = None) -> Donor:
+        """Update a donor in the database.
+
+        :param session: Transaction to join; a fresh one is opened and committed when absent.
+        """
+        with self.transaction(session) as active_session:
             statement = (
                 select(Donor)
                 .where(Donor.submission_id == updated_donor.submission_id)
                 .where(Donor.pseudonym == updated_donor.pseudonym)
             )
-            db_donor = session.exec(statement).first()
+            db_donor = active_session.exec(statement).first()
 
             if db_donor is None:
                 raise RuntimeError("Cannot update a donor that doesn't yet exist in the database.")
@@ -990,46 +1024,33 @@ class SubmissionDb:
                 if old_value != new_value:
                     setattr(db_donor, field, new_value)
 
-            session.add(db_donor)
+            active_session.add(db_donor)
+            active_session.flush()
+            return db_donor
 
-            try:
-                session.commit()
-                session.refresh(db_donor)
-                return db_donor
-            except Exception as e:
-                session.rollback()
-                raise e
+    def delete_donor(self, donor: Donor, session: Session | None = None) -> None:
+        """Delete a donor from the database.
 
-    def delete_donor(self, donor: Donor) -> None:
-        """Delete a donor from the database."""
-        with self._get_session() as session:
-            session.delete(donor)
-
-            try:
-                session.commit()
-            except Exception as e:
-                session.rollback()
-                raise e
+        :param session: Transaction to join; a fresh one is opened and committed when absent.
+        """
+        with self.transaction(session) as active_session:
+            active_session.delete(donor)
+            active_session.flush()
 
     def get_detailed_qc_results(self, submission_id: str) -> tuple[DetailedQCResult, ...]:
         """Retrieve all detailed QC results for a given submission."""
-        with self._get_session() as session:
+        with self.transaction() as session:
             statement = select(DetailedQCResult).where(DetailedQCResult.submission_id == submission_id)
             results = tuple(session.exec(statement).all())
         return results
 
     def add_detailed_qc_result(self, result: DetailedQCResult) -> DetailedQCResult:
         """Add or update a detailed QC result to/in the database."""
-        with self._get_session() as session:
+        with self.transaction() as session:
             session.add(result)
 
-            try:
-                session.commit()
-                session.refresh(result)
-                return result
-            except Exception as e:
-                session.rollback()
-                raise e
+            session.flush()
+            return result
 
     def add_change_request(  # noqa: PLR0913
         self,
@@ -1061,7 +1082,7 @@ class SubmissionDb:
         Returns:
             An instance of ChangeRequestLog.
         """
-        with self._get_session() as session:
+        with self.transaction() as session:
             submission = session.get(Submission, submission_id)
             if not submission:
                 raise SubmissionNotFoundError(submission_id)
@@ -1087,14 +1108,8 @@ class SubmissionDb:
             )
             db_change_request_log = ChangeRequestLog.model_validate(change_request_log_create)
             session.add(db_change_request_log)
-
-            try:
-                session.commit()
-                session.refresh(db_change_request_log)
-                return db_change_request_log
-            except Exception:
-                session.rollback()
-                raise
+            session.flush()
+            return db_change_request_log
 
     def get_submission(self, submission_id: str) -> Submission | None:
         """
@@ -1106,7 +1121,7 @@ class SubmissionDb:
         Returns:
             An instance of Submission or None.
         """
-        with self._get_session() as session:
+        with self.transaction() as session:
             statement = (
                 select(Submission).where(Submission.id == submission_id).options(selectinload(Submission.states))  # type: ignore[arg-type]
             )
@@ -1122,7 +1137,7 @@ class SubmissionDb:
         """
         if not submission_ids:
             return []
-        with self._get_session() as session:
+        with self.transaction() as session:
             statement = (
                 select(Submission)
                 .where(Submission.id.in_(submission_ids))  # type: ignore[attr-defined]
@@ -1145,7 +1160,7 @@ class SubmissionDb:
             submission state timestamp if not null, otherwise use submission
             date, with submissions missing both of these sorting first.
         """
-        with self._get_session() as session:
+        with self.transaction() as session:
             latest_state_per_submission = (
                 select(
                     SubmissionStateLog.submission_id.label("submission_id"),  # type: ignore[attr-defined]
@@ -1205,7 +1220,7 @@ class SubmissionDb:
         Lists all submissions processed between the given start and end dates, inclusive.
         Processed is defined as either reported (Prüfbericht submitted) or detailed QC finished.
         """
-        with self._get_session() as session:
+        with self.transaction() as session:
             reported_within_window = (
                 select(SubmissionStateLog.submission_id)
                 .where(SubmissionStateLog.state.in_([SubmissionStateEnum.REPORTED, SubmissionStateEnum.QCED]))  # type: ignore[attr-defined]
@@ -1228,7 +1243,7 @@ class SubmissionDb:
         Returns:
             A list of all submissions in the database, ordered by their ID.
         """
-        with self._get_session() as session:
+        with self.transaction() as session:
             statement = (
                 select(Submission)
                 .where(Submission.changes.any())  # type: ignore[attr-defined]
@@ -1408,27 +1423,30 @@ class SubmissionDb:
         submission_diff: SubmissionDiffCollection | None = None,
         donors_diff: DonorsDiffCollection | None = None,
     ) -> None:
-        """Write all pending metadata and donor diffs to the database.
-        Can be obtained by calling :func:`diff`
+        """Write all pending metadata and donor diffs to the database, as one transaction.
 
-        :param db: Database service instance to write to.
+        The diffs are one answer to one metadata file, so they are applied whole or not at all:
+        writing them piecemeal would leave a rejected write with the earlier parts stored, and
+        re-running would then preview a different starting state than the one just shown.
+
         :param submission_id: ID of the submission being updated.
         :param submission_diff: Diff result from :func:`diff_metadata`.
         :param donors_diff: Diff result from :func:`build_donor_diff`.
         """
-        if submission_diff is not None:
-            for field_diff in submission_diff.pending:
-                self.modify_submission(submission_id, field_diff.key, field_diff.diff.after)
-        if donors_diff is not None:
-            for donor_diff in donors_diff.added:
-                assert donor_diff.after is not None, "Added NoneType donor, this should not happen"  # noqa: S101
-                self.add_donor(donor_diff.after)
-            for donor_diff in donors_diff.updated:
-                assert donor_diff.after is not None, "Updated NoneType donor, this should not happen"  # noqa: S101
-                self.update_donor(donor_diff.after)
-            for donor_diff in donors_diff.deleted:
-                assert donor_diff.before is not None, "Removed NoneType donor, this should not happen"  # noqa: S101
-                self.delete_donor(donor_diff.before)
+        with self.transaction() as session:
+            if submission_diff is not None:
+                for field_diff in submission_diff.pending:
+                    self.modify_submission(submission_id, field_diff.key, field_diff.diff.after, session=session)
+            if donors_diff is not None:
+                for donor_diff in donors_diff.added:
+                    assert donor_diff.after is not None, "Added NoneType donor, this should not happen"  # noqa: S101
+                    self.add_donor(donor_diff.after, session=session)
+                for donor_diff in donors_diff.updated:
+                    assert donor_diff.after is not None, "Updated NoneType donor, this should not happen"  # noqa: S101
+                    self.update_donor(donor_diff.after, session=session)
+                for donor_diff in donors_diff.deleted:
+                    assert donor_diff.before is not None, "Removed NoneType donor, this should not happen"  # noqa: S101
+                    self.delete_donor(donor_diff.before, session=session)
 
     @staticmethod
     def _log_pending_changes(

--- a/packages/grz-db/src/grz_db/testing.py
+++ b/packages/grz-db/src/grz_db/testing.py
@@ -44,6 +44,7 @@ from grz_db.models.submission import SubmissionDb
 
 __all__ = [
     "db",
+    "db_backend",
     "db_test_connection",
     "migrated_db_connection",
     "postgresql_proc",

--- a/packages/grz-pydantic-models-testing/README.md
+++ b/packages/grz-pydantic-models-testing/README.md
@@ -20,14 +20,11 @@ import grz_pydantic_models_testing
 from grz_pydantic_models_testing import example_metadata, failing_metadata
 
 # Read an example metadata file
-json_text = (
-    importlib.resources.files(example_metadata)
-    .joinpath("wes_tumor_germline", "v1.2.1.json")
-    .read_text()
-)
+json_text = importlib.resources.files(example_metadata).joinpath("wes_tumor_germline", "v1.2.1.json").read_text()
 
 # Parse it directly
 from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
+
 metadata = GrzSubmissionMetadata.model_validate_json(json_text)
 ```
 

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/oncomine_panel_tumor_only/v1.2.1.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/oncomine_panel_tumor_only/v1.2.1.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "a2b6c3d9e8f7123456789abcdef0123456789abcdef0123456789abcdef01234",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/oncomine_panel_tumor_only/v1.3.0.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/oncomine_panel_tumor_only/v1.3.0.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "a2b6c3d9e8f7123456789abcdef0123456789abcdef0123456789abcdef01234",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/panel_tumor_only/v1.2.1.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/panel_tumor_only/v1.2.1.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "a2b6c3d9e8f7123456789abcdef0123456789abcdef0123456789abcdef01234",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/panel_tumor_only/v1.3.0.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/panel_tumor_only/v1.3.0.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "a2b6c3d9e8f7123456789abcdef0123456789abcdef0123456789abcdef01234",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wes_tumor_germline/v1.2.1.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wes_tumor_germline/v1.2.1.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "a2b6c3d9e8f7123456789abcdef0123456789abcdef0123456789abcdef01234",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wes_tumor_germline/v1.3.0.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wes_tumor_germline/v1.3.0.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "a2b6c3d9e8f7123456789abcdef0123456789abcdef0123456789abcdef01234",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wgs_lr_tumor_only/v1.2.1.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wgs_lr_tumor_only/v1.2.1.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "a2b6c3d9e8f7123456789abcdef0123456789abcdef0123456789abcdef01234",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wgs_lr_tumor_only/v1.3.0.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wgs_lr_tumor_only/v1.3.0.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "a2b6c3d9e8f7123456789abcdef0123456789abcdef0123456789abcdef01234",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wgs_trio/v1.2.1.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wgs_trio/v1.2.1.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "9e107d9d372bb6826bd81d3542a419d6cdebb5f6b8a32bdf8f7b77c61cbe3f30",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wgs_trio/v1.3.0.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wgs_trio/v1.3.0.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "9e107d9d372bb6826bd81d3542a419d6cdebb5f6b8a32bdf8f7b77c61cbe3f30",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wgs_tumor_germline/v1.2.1.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wgs_tumor_germline/v1.2.1.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "9e107d9d372bb6826bd81d3542a419d6cdebb5f6b8a32bdf8f7b77c61cbe3f30",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wgs_tumor_germline/v1.3.0.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/example_metadata/wgs_tumor_germline/v1.3.0.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "9e107d9d372bb6826bd81d3542a419d6cdebb5f6b8a32bdf8f7b77c61cbe3f30",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/failing_metadata/duplicate-run-id.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/failing_metadata/duplicate-run-id.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000",
+      "donorPseudonym": "index",
       "gender": "female",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/failing_metadata/incompatible-reference-genomes.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/failing_metadata/incompatible-reference-genomes.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000",
+      "donorPseudonym": "index",
       "gender": "female",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/failing_metadata/missing-fastq-r2.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/failing_metadata/missing-fastq-r2.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000",
+      "donorPseudonym": "index",
       "gender": "female",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/failing_metadata/missing-read-order.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/failing_metadata/missing-read-order.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000",
+      "donorPseudonym": "index",
       "gender": "female",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/failing_metadata/missing-target-regions.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/failing_metadata/missing-target-regions.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "a2b6c3d9e8f7123456789abcdef0123456789abcdef0123456789abcdef01234",
+      "donorPseudonym": "index",
       "gender": "other",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/failing_metadata/missing-vcf-file.json
+++ b/packages/grz-pydantic-models-testing/src/grz_pydantic_models_testing/failing_metadata/missing-vcf-file.json
@@ -16,7 +16,7 @@
   },
   "donors": [
     {
-      "donorPseudonym": "aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000aaaaaaaa00000000",
+      "donorPseudonym": "index",
       "gender": "female",
       "relation": "index",
       "mvConsent": {

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
@@ -11,17 +11,12 @@ from pydantic_core import core_schema
 from ..common import StrictBaseModel, as_aware_datetime
 
 
-class StrictIgnoringBaseModel(StrictBaseModel):
-    """A FHIR element that models the fields this package uses and keeps the rest.
+class LosslessBaseModel(StrictBaseModel):
+    """A FHIR element that is strict about its declared fields and keeps everything else.
 
-    These models cover a subset of each FHIR resource, so a real consent document carries
-    fields they do not declare (``id``, ``meta``, ``extension``, ``organization``,
-    ``policyRule`` on a Consent, among others). Retaining them costs nothing and is what
-    lets a parsed document round-trip: archival records what the submitter sent, and a
-    dump that had silently dropped these could not be that record.
-
-    ``extra="allow"`` accepts exactly what ``extra="ignore"`` accepted; it only stops
-    discarding it.
+    A real consent document carries fields these models do not declare (``id``, ``meta``,
+    ``extension``, ``organization``, ``policyRule`` on a Consent, among others); discarding
+    them would make a parsed submission lossy.
     """
 
     model_config = ConfigDict(extra="allow")
@@ -305,7 +300,7 @@ class Period(FhirElement):
         return moment <= self.end.last_moment
 
 
-class Policy(StrictIgnoringBaseModel):
+class Policy(LosslessBaseModel):
     uri: str
 
 
@@ -327,7 +322,7 @@ class CodeableConcept(FhirElement):
         return frozenset((coding.system, coding.code) for coding in self.coding)
 
 
-class ConsentProvision(StrictIgnoringBaseModel):
+class ConsentProvision(LosslessBaseModel):
     type: ProvisionType
     period: Period
     code: Annotated[list[CodeableConcept], Field(min_length=1)]
@@ -346,7 +341,7 @@ class ConsentProvision(StrictIgnoringBaseModel):
         return self
 
 
-class RootConsentProvision(StrictIgnoringBaseModel):
+class RootConsentProvision(LosslessBaseModel):
     type: ProvisionType
     period: Period
     """
@@ -370,13 +365,13 @@ class RootConsentProvision(StrictIgnoringBaseModel):
         return self
 
 
-class Identifier(StrictIgnoringBaseModel):
+class Identifier(LosslessBaseModel):
     # The profile requires both on Consent.patient.identifier (1..1 each).
     system: str
     value: str
 
 
-class Patient(StrictIgnoringBaseModel):
+class Patient(LosslessBaseModel):
     # The profile marks both as mustSupport yet requires neither, so the patient may be identified
     # either way. A patient stating neither (e.g. display only) carries nothing this model keeps
     # and is rejected rather than silently reduced to an empty object.
@@ -390,7 +385,7 @@ class Patient(StrictIgnoringBaseModel):
         return self
 
 
-class Verification(StrictIgnoringBaseModel):
+class Verification(LosslessBaseModel):
     verified: bool
     verification_date: FhirDateTime | None = None
 
@@ -482,7 +477,7 @@ def _strip_oid_prefix(uri: str) -> str:
     return uri.removeprefix(_OID_URI_PREFIX)
 
 
-class Consent(StrictIgnoringBaseModel):
+class Consent(LosslessBaseModel):
     resource_type: Literal["Consent"] | None = None
     status: Status
     scope: CodeableConcept

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/mii/consent.py
@@ -12,11 +12,23 @@ from ..common import StrictBaseModel, as_aware_datetime
 
 
 class StrictIgnoringBaseModel(StrictBaseModel):
-    model_config = ConfigDict(extra="ignore")
+    """A FHIR element that models the fields this package uses and keeps the rest.
+
+    These models cover a subset of each FHIR resource, so a real consent document carries
+    fields they do not declare (``id``, ``meta``, ``extension``, ``organization``,
+    ``policyRule`` on a Consent, among others). Retaining them costs nothing and is what
+    lets a parsed document round-trip: archival records what the submitter sent, and a
+    dump that had silently dropped these could not be that record.
+
+    ``extra="allow"`` accepts exactly what ``extra="ignore"`` accepted; it only stops
+    discarding it.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
 
 class Extension(StrictBaseModel):
-    # Extensions carry an open-ended value[x] payload, so extra keys are allowed here only.
+    # Extensions carry an open-ended value[x] payload, so extra keys are allowed here too.
     model_config = ConfigDict(extra="allow")
     url: str
 

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -41,30 +42,31 @@ REDACTED_LOCAL_CASE_ID = "REDACTED_LOCAL_CASE_ID"
 
 
 def redact_metadata_dict(metadata: dict[str, Any]) -> dict[str, Any]:
-    """Redact a metadata document's sensitive fields, in place.
+    """Redact a metadata document's sensitive fields in a copy, leaving the argument untouched.
 
     Replaces ``tanG`` with :data:`REDACTED_TAN`, ``localCaseId`` with
     :data:`REDACTED_LOCAL_CASE_ID`, and the index donor's pseudonym with ``"index"``.
-    That last one is the value every accepted schema version prescribes anyway, so it only
-    removes something on a v1.1.x document, whose description named the tanG instead.
+    v1.1.1 to v1.1.7 (still supported) told submitters to put the tanG in ``donorPseudonym``;
+    v1.1.8 onward says ``"index"``. So that overwrite can be removing a real tanG.
 
     Takes a plain dict so archival can apply it to the raw metadata.json it read from disk,
     keeping the archived record faithful to what the submitter sent, while
     :meth:`GrzSubmissionMetadata.to_redacted_dict` applies the same rule to a model dump.
     One list of sensitive fields, two carriers.
 
-    Archival wrote an empty ``localCaseId`` before this was shared, so that spelling is in
-    the archive too and a reader has to treat both as redacted.
+    Archived documents may also carry an empty ``localCaseId`` instead of the
+    :data:`REDACTED_LOCAL_CASE_ID` placeholder, so a reader has to treat both as redacted.
 
-    :param metadata: Parsed metadata JSON, mutated in place.
-    :returns: The same dict, for convenience.
+    :param metadata: Parsed metadata JSON. Not modified.
+    :returns: A deep copy of ``metadata`` with the sensitive fields redacted.
     """
-    metadata["submission"]["tanG"] = REDACTED_TAN
-    metadata["submission"]["localCaseId"] = REDACTED_LOCAL_CASE_ID
-    for donor in metadata.get("donors", []):
+    redacted = copy.deepcopy(metadata)
+    redacted["submission"]["tanG"] = REDACTED_TAN
+    redacted["submission"]["localCaseId"] = REDACTED_LOCAL_CASE_ID
+    for donor in redacted.get("donors", []):
         if donor.get("relation") == "index":
             donor["donorPseudonym"] = "index"
-    return metadata
+    return redacted
 
 
 log = logging.getLogger(__name__)
@@ -1106,8 +1108,8 @@ class LabDatum(StrictBaseModel):
 
 
 class Donor(StrictBaseModel):
-    # Up to schema v1.1.7 the description below ended "For Index patient use TanG", so a
-    # document from that era may carry the tanG here. Every accepted version says "index".
+    # v1.1.1 to v1.1.7 (still supported) said "For Index patient use TanG", so a document in
+    # that range may carry the tanG here. v1.1.8 onward says "index".
     donor_pseudonym: str
     """
     A unique identifier given by the Leistungserbringer for each donor of a single, duo or trio sequencing;
@@ -1292,19 +1294,26 @@ class GrzSubmissionMetadata(StrictBaseModel):
             patterns.append((self.submission.local_case_id, REDACTED_LOCAL_CASE_ID))
         return patterns
 
+    def get_raw_dict(self) -> dict[str, Any]:
+        """
+        Return this metadata as the submitter sent it: keys and all.
+
+        Uses the schema's aliases and includes only the keys the submitter actually set,
+        so this is the parsed document reproduced, not a canonicalized re-serialization.
+
+        :returns: The submitted metadata document as a dictionary.
+        """
+        return self.model_dump(mode="json", by_alias=True, exclude_unset=True)
+
     def to_redacted_dict(self) -> dict[str, Any]:
         """
         Create a redacted dictionary representation suitable for archiving.
 
         Redacts the fields listed in :func:`redact_metadata_dict`.
 
-        ``exclude_unset`` keeps the dump to what the submitter actually sent: emitting
-        every optional field with its default would add keys that were never submitted,
-        and this dump has to stand in for the submitted document.
-
         :returns: Redacted metadata dictionary
         """
-        return redact_metadata_dict(self.model_dump(mode="json", by_alias=True, exclude_unset=True))
+        return redact_metadata_dict(self.get_raw_dict())
 
     @field_validator("donors", mode="after")
     @classmethod

--- a/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
+++ b/packages/grz-pydantic-models/src/grz_pydantic_models/submission/metadata/v1.py
@@ -39,6 +39,34 @@ SCHEMA_URL_PATTERN = r"https://raw\.githubusercontent\.com/BfArM-MVH/MVGenomseq/
 REDACTED_TAN = "0" * 64
 REDACTED_LOCAL_CASE_ID = "REDACTED_LOCAL_CASE_ID"
 
+
+def redact_metadata_dict(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Redact a metadata document's sensitive fields, in place.
+
+    Replaces ``tanG`` with :data:`REDACTED_TAN`, ``localCaseId`` with
+    :data:`REDACTED_LOCAL_CASE_ID`, and the index donor's pseudonym with ``"index"``.
+    That last one is the value every accepted schema version prescribes anyway, so it only
+    removes something on a v1.1.x document, whose description named the tanG instead.
+
+    Takes a plain dict so archival can apply it to the raw metadata.json it read from disk,
+    keeping the archived record faithful to what the submitter sent, while
+    :meth:`GrzSubmissionMetadata.to_redacted_dict` applies the same rule to a model dump.
+    One list of sensitive fields, two carriers.
+
+    Archival wrote an empty ``localCaseId`` before this was shared, so that spelling is in
+    the archive too and a reader has to treat both as redacted.
+
+    :param metadata: Parsed metadata JSON, mutated in place.
+    :returns: The same dict, for convenience.
+    """
+    metadata["submission"]["tanG"] = REDACTED_TAN
+    metadata["submission"]["localCaseId"] = REDACTED_LOCAL_CASE_ID
+    for donor in metadata.get("donors", []):
+        if donor.get("relation") == "index":
+            donor["donorPseudonym"] = "index"
+    return metadata
+
+
 log = logging.getLogger(__name__)
 
 
@@ -1078,12 +1106,14 @@ class LabDatum(StrictBaseModel):
 
 
 class Donor(StrictBaseModel):
+    # Up to schema v1.1.7 the description below ended "For Index patient use TanG", so a
+    # document from that era may carry the tanG here. Every accepted version says "index".
     donor_pseudonym: str
     """
-    A unique identifier given by the Leistungserbringer for each donor of a single, duo or trio sequencing; 
-    the donorPseudonym needs to be identifiable by the Leistungserbringer 
-    in case of changes to the consents by one of the donors. 
-    For Index patient use TanG.
+    A unique identifier given by the Leistungserbringer for each donor of a single, duo or trio sequencing;
+    the donorPseudonym needs to be identifiable by the Leistungserbringer
+    in case of changes to the consents by one of the donors.
+    For Index patient use index.
     """
 
     gender: Gender
@@ -1266,26 +1296,15 @@ class GrzSubmissionMetadata(StrictBaseModel):
         """
         Create a redacted dictionary representation suitable for archiving.
 
-        Redacts:
-        - tanG (replaced with REDACTED_TAN constant)
-        - localCaseId (replaced with REDACTED_LOCAL_CASE_ID constant)
-        - Index donor pseudonym (replaced with "index")
+        Redacts the fields listed in :func:`redact_metadata_dict`.
+
+        ``exclude_unset`` keeps the dump to what the submitter actually sent: emitting
+        every optional field with its default would add keys that were never submitted,
+        and this dump has to stand in for the submitted document.
 
         :returns: Redacted metadata dictionary
         """
-        # get the base dictionary representation
-        metadata_dict = self.model_dump(mode="json", by_alias=True)
-
-        # redact sensitive fields
-        metadata_dict["submission"]["tanG"] = REDACTED_TAN
-        metadata_dict["submission"]["localCaseId"] = REDACTED_LOCAL_CASE_ID
-
-        # redact index donor pseudonym
-        for donor in metadata_dict.get("donors", []):
-            if donor.get("relation") == "index":
-                donor["donorPseudonym"] = "index"
-
-        return metadata_dict
+        return redact_metadata_dict(self.model_dump(mode="json", by_alias=True, exclude_unset=True))
 
     @field_validator("donors", mode="after")
     @classmethod

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -1772,11 +1772,11 @@ def test_model_round_trips_the_submitted_document(example: str) -> None:
 
     metadata = GrzSubmissionMetadata.model_validate(raw)
 
-    assert metadata.model_dump(mode="json", by_alias=True, exclude_unset=True) == raw
+    assert metadata.get_raw_dict() == raw
 
 
 def test_redaction_names_every_field_it_replaces() -> None:
-    """Archival wrote an empty localCaseId where the model wrote the named placeholder."""
+    """redact_metadata_dict replaces tanG, localCaseId, and the index donor's pseudonym on a raw dict."""
     raw = json.loads(_metadata_raw("wgs_tumor_germline", "1.3.0"))
 
     redacted = redact_metadata_dict(raw)
@@ -1787,10 +1787,10 @@ def test_redaction_names_every_field_it_replaces() -> None:
 
 
 def test_both_carriers_of_the_redaction_rule_agree() -> None:
-    """The raw metadata.json archival redacts and the model dump must come out the same.
-
-    These were separate copies of one rule and had already drifted on localCaseId, which is
-    why both spellings are in the archive.
+    """redact_metadata_dict on the raw dict and GrzSubmissionMetadata.to_redacted_dict on the
+    parsed model must redact the same document identically, since both are built from the one
+    rule in :func:`redact_metadata_dict` (see its docstring for why the archive may still hold
+    either spelling of a redacted localCaseId).
     """
     raw = json.loads(_metadata_raw("wgs_tumor_germline", "1.3.0"))
     metadata = GrzSubmissionMetadata.model_validate(copy.deepcopy(raw))

--- a/packages/grz-pydantic-models/tests/test_metadata.py
+++ b/packages/grz-pydantic-models/tests/test_metadata.py
@@ -30,6 +30,8 @@ from grz_pydantic_models.submission.metadata import (
 )
 from grz_pydantic_models.submission.metadata.v1 import (
     PROFILES_REQUIRING_PERIOD_END,
+    REDACTED_LOCAL_CASE_ID,
+    REDACTED_TAN,
     RESEARCH_CONSENT_PACKAGE_PROFILES,
     RESEARCH_CONSENT_SCHEMA_VERSIONS,
     File,
@@ -38,6 +40,7 @@ from grz_pydantic_models.submission.metadata.v1 import (
     LibraryType,
     ResearchConsent,
     ResearchConsentCodes,
+    redact_metadata_dict,
 )
 from grz_pydantic_models_testing import example_metadata, example_research_consent, example_terminology
 from packaging.version import Version
@@ -1745,3 +1748,51 @@ def test_no_scope_justification_standard_passes_after_cutoff(version: str, justi
             consent.pop("scope", None)
 
     GrzSubmissionMetadata.model_validate_json(json.dumps(metadata))
+
+
+ALL_EXAMPLES = sorted(
+    f"{dataset.name}/{path.name}"
+    for dataset in importlib.resources.files(example_metadata).iterdir()
+    if dataset.is_dir() and not dataset.name.startswith("__")
+    for path in dataset.iterdir()
+    if path.name.endswith(".json")
+)
+
+
+@pytest.mark.parametrize("example", ALL_EXAMPLES)
+def test_model_round_trips_the_submitted_document(example: str) -> None:
+    """Parsing and dumping must not change a submitted document.
+
+    Archival records what the submitter sent, so a field this package does not model may
+    not be dropped on the way through, and one the submitter omitted may not appear.
+    Losing either would make ``to_redacted_dict`` unfit to stand in for the document.
+    """
+    dataset, name = example.split("/")
+    raw = json.loads(importlib.resources.files(example_metadata).joinpath(dataset, name).read_text())
+
+    metadata = GrzSubmissionMetadata.model_validate(raw)
+
+    assert metadata.model_dump(mode="json", by_alias=True, exclude_unset=True) == raw
+
+
+def test_redaction_names_every_field_it_replaces() -> None:
+    """Archival wrote an empty localCaseId where the model wrote the named placeholder."""
+    raw = json.loads(_metadata_raw("wgs_tumor_germline", "1.3.0"))
+
+    redacted = redact_metadata_dict(raw)
+
+    assert redacted["submission"]["tanG"] == REDACTED_TAN
+    assert redacted["submission"]["localCaseId"] == REDACTED_LOCAL_CASE_ID
+    assert all(donor["donorPseudonym"] == "index" for donor in redacted["donors"] if donor["relation"] == "index")
+
+
+def test_both_carriers_of_the_redaction_rule_agree() -> None:
+    """The raw metadata.json archival redacts and the model dump must come out the same.
+
+    These were separate copies of one rule and had already drifted on localCaseId, which is
+    why both spellings are in the archive.
+    """
+    raw = json.loads(_metadata_raw("wgs_tumor_germline", "1.3.0"))
+    metadata = GrzSubmissionMetadata.model_validate(copy.deepcopy(raw))
+
+    assert redact_metadata_dict(raw) == metadata.to_redacted_dict()

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -543,9 +543,9 @@ def update(  # noqa: C901, PLR0913
         raise click.ClickException(f"Failed to update submission state: {e}") from e
 
 
-# Exactly what SubmissionDb.modify_submission accepts. The epilog below already subtracted the
-# immutable fields while the choices did not, so `id` was offered and then refused. Built from
-# SubmissionBase to match the --allow-overwrite choices, which name the same set.
+# Exactly what SubmissionDb.modify_submission accepts. The epilog and the KEY choices below both
+# build from this, so --help always advertises what the command accepts. Same set as the
+# --allow-overwrite choices.
 _MODIFIABLE_SUBMISSION_KEYS = sorted(SubmissionBase.model_fields.keys() - SubmissionBase.immutable_fields)
 
 
@@ -1158,10 +1158,9 @@ def _fetch_metadata_json(s3_client: Any, bucket: str, submission_id: str) -> str
         raise
 
 
-# Metadata re-read from S3 is redacted, so these are never taken from it. The set named
-# "local_case_id", which is not a Submission field at all: the column carrying the submitter's
-# local case ID is "pseudonym". Nothing was ignored under that name, so backfill diffed the
-# redacted placeholder against the stored pseudonym and offered to write it in.
+# tan_g and pseudonym: metadata re-read from S3 is redacted, so diffing it would only offer to
+# overwrite real values with placeholders. submission_uploaded_date: computed above and passed to
+# db_service.diff() directly, so the generic field diff must not also read it from metadata.
 _BACKFILL_IGNORE_FIELDS = frozenset({"submission_uploaded_date", "tan_g", "pseudonym"})
 
 

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -543,12 +543,15 @@ def update(  # noqa: C901, PLR0913
         raise click.ClickException(f"Failed to update submission state: {e}") from e
 
 
-@submission.command(
-    epilog="Currently available KEYs are: "
-    + ", ".join(sorted(Submission.model_fields.keys() - Submission.immutable_fields))
-)
+# Exactly what SubmissionDb.modify_submission accepts. The epilog below already subtracted the
+# immutable fields while the choices did not, so `id` was offered and then refused. Built from
+# SubmissionBase to match the --allow-overwrite choices, which name the same set.
+_MODIFIABLE_SUBMISSION_KEYS = sorted(SubmissionBase.model_fields.keys() - SubmissionBase.immutable_fields)
+
+
+@submission.command(epilog="Currently available KEYs are: " + ", ".join(_MODIFIABLE_SUBMISSION_KEYS))
 @click.argument("submission_id", type=str)
-@click.argument("key", metavar="KEY", type=click.Choice(Submission.model_fields.keys()))
+@click.argument("key", metavar="KEY", type=click.Choice(_MODIFIABLE_SUBMISSION_KEYS))
 @click.argument("value", metavar="VALUE", type=str)
 @click.pass_context
 def modify(ctx: click.Context, submission_id: str, key: str, value: str):
@@ -1155,6 +1158,13 @@ def _fetch_metadata_json(s3_client: Any, bucket: str, submission_id: str) -> str
         raise
 
 
+# Metadata re-read from S3 is redacted, so these are never taken from it. The set named
+# "local_case_id", which is not a Submission field at all: the column carrying the submitter's
+# local case ID is "pseudonym". Nothing was ignored under that name, so backfill diffed the
+# redacted placeholder against the stored pseudonym and offered to write it in.
+_BACKFILL_IGNORE_FIELDS = frozenset({"submission_uploaded_date", "tan_g", "pseudonym"})
+
+
 class _BackfillResult(StrEnum):
     UPDATED = "updated"
     UP_TO_DATE = "up_to_date"
@@ -1343,11 +1353,7 @@ def backfill(  # noqa: C901, PLR0912, PLR0913, PLR0915
     if force and allow_overwrite:
         raise click.UsageError("--force and --allow-overwrite are mutually exclusive; --force already permits all.")
 
-    ignore_fields = set(ignore_field) | {
-        "submission_uploaded_date",
-        "tan_g",
-        "local_case_id",
-    }
+    ignore_fields = set(ignore_field) | _BACKFILL_IGNORE_FIELDS
 
     # ── Build S3 clients for both archive targets ────────────────────────────
     archive_targets = [

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -1158,10 +1158,10 @@ def _fetch_metadata_json(s3_client: Any, bucket: str, submission_id: str) -> str
         raise
 
 
-# tan_g and pseudonym: metadata re-read from S3 is redacted, so diffing it would only offer to
-# overwrite real values with placeholders. submission_uploaded_date: computed above and passed to
-# db_service.diff() directly, so the generic field diff must not also read it from metadata.
-_BACKFILL_IGNORE_FIELDS = frozenset({"submission_uploaded_date", "tan_g", "pseudonym"})
+# Archival redacts before writing, so a metadata.json re-read from S3 always carries placeholders
+# for these two and is never authoritative about them. Diffing them would only offer to overwrite
+# a real value with a placeholder.
+_BACKFILL_IGNORE_FIELDS = frozenset({"tan_g", "pseudonym"})
 
 
 class _BackfillResult(StrEnum):
@@ -1215,18 +1215,17 @@ def _backfill_submission(  # noqa: PLR0911, PLR0913
         return _BackfillResult.ERROR
 
     try:
-        # If submission_uploaded_date is not set in the DB, replace it with the one from metadata.json.
-        # This case is expected for submissions that were created before the submission_date field was added.
-        submission_uploaded_date = (
-            current_submission.submission_uploaded_date
-            if current_submission.submission_uploaded_date
-            else metadata.submission.submission_date
-        )
-
+        # Backfill has no authoritative date to offer: the archive does not carry one, and the
+        # submitter's declared submission_date is not when the upload finished, which is what this
+        # column means and what the reporting windows filter on. populate reads the real one from
+        # the S3 object; backfill does not fetch it. Passing None lets diff() supply a value for
+        # construction and then exclude the field, so backfill never writes it. Passing the row's
+        # own value instead would compare a snapshot taken before the run against the row diff()
+        # re-reads, and write the stale one.
         submission_diff, donors_diff = db_service.diff(
             submission_id,
             metadata,
-            submission_uploaded_date=submission_uploaded_date,
+            submission_uploaded_date=None,
             ignore_fields=ignore_fields or None,
         )
     except Exception as exc:

--- a/packages/grzctl/src/grzctl/commands/db/tui.py
+++ b/packages/grzctl/src/grzctl/commands/db/tui.py
@@ -44,7 +44,7 @@ class SubmissionCountByStateTable(Static):
     @textual.work
     async def load(self, database: SubmissionDb) -> None:
         self.loading = True
-        with database._get_session() as session:
+        with database.transaction() as session:
             # credit: https://stackoverflow.com/a/28090544
             log1 = sqlalchemy.orm.aliased(SubmissionStateLog, name="log1")
             log2 = sqlalchemy.orm.aliased(SubmissionStateLog, name="log2")
@@ -87,7 +87,7 @@ class SubmissionCountByConsentTable(Static):
     @textual.work
     async def load(self, database: SubmissionDb) -> None:
         self.loading = True
-        with database._get_session() as session:
+        with database.transaction() as session:
             statement = select(Submission.consented, sqlfn.count(Submission.consented)).group_by(Submission.consented)  # type: ignore[arg-type]
             counts_by_consent = session.exec(statement).all()
 
@@ -117,7 +117,7 @@ class SubmissionCountByDetailedQCByLETable(Static):
     @textual.work
     async def load(self, database: SubmissionDb, quarter: int | None = None, year: int | None = None) -> None:
         self.loading = True
-        with database._get_session() as session:
+        with database.transaction() as session:
             statement = (
                 select(  # type: ignore[type-var]
                     Submission.submitter_id, Submission.submission_uploaded_date, Submission.detailed_qc_passed
@@ -215,7 +215,7 @@ class SearchResultsDataTable(DataTable):
     ) -> None:
         self.loading = True
         self.clear()
-        with database._get_session() as session:
+        with database.transaction() as session:
             latest_state_per_submission = (
                 select(
                     SubmissionStateLog.submission_id.label("submission_id"),  # type: ignore[attr-defined]
@@ -338,7 +338,7 @@ class DatabaseBrowser(App):
         )
         table_states_latest = self.query_exactly_one("#table-states-latest", DataTable)
         table_states_latest.loading = True
-        with self._database._get_session() as session:
+        with self._database.transaction() as session:
             statement = (
                 select(SubmissionStateLog).order_by(SubmissionStateLog.timestamp.desc()).limit(_DEFAULT_SEARCH_LIMIT)  # type: ignore[attr-defined]
             )

--- a/packages/grzctl/src/grzctl/commands/report.py
+++ b/packages/grzctl/src/grzctl/commands/report.py
@@ -229,7 +229,7 @@ def _dump_overview_report(output_path: Path, database: SubmissionDb, year: int, 
     quarter_start_date, quarter_end_date = quarter_date_bounds(year=year, quarter=quarter)
 
     node_submitter_id_combos: set[tuple[str | None, str | None]] = set()
-    with database._get_session() as session:
+    with database.transaction() as session:
         # number_of_end-to-end_tests
         stmt_number_of_end_to_end_tests = (
             select(Submission.data_node_id, Submission.submitter_id, sqlfn.count(1))
@@ -374,7 +374,7 @@ def _dump_dataset_report(
 ) -> None:
     quarter_start_date, quarter_end_date = quarter_date_bounds(year=year, quarter=quarter)
 
-    with database._get_session() as session:
+    with database.transaction() as session:
         query_quarter_submissions = (
             select(Submission).where(Submission.submission_uploaded_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
         )
@@ -486,7 +486,7 @@ def _dump_qc_report(
 ) -> None:
     quarter_start_date, quarter_end_date = quarter_date_bounds(year=year, quarter=quarter)
 
-    with database._get_session() as session:
+    with database.transaction() as session:
         query_submissions_that_failed_detailed_qc = (
             select(Submission)
             .where(Submission.submission_uploaded_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -52,11 +52,14 @@ def s3_client_mock() -> Iterator[Any]:
 
 
 def _put_metadata(s3_client: Any, submission_id: str, metadata: GrzSubmissionMetadata) -> None:
-    """Write *metadata* to S3 the way archival writes it: what was submitted, nothing added."""
+    """Write *metadata* unredacted, unlike archival, which redacts first.
+
+    No test here covers the redacted shape backfill actually reads from the archive.
+    """
     s3_client.put_object(
         Bucket=BUCKET,
         Key=f"{submission_id}/metadata/metadata.json",
-        Body=metadata.model_dump_json(by_alias=True, exclude_unset=True).encode("utf-8"),
+        Body=json.dumps(metadata.get_raw_dict()).encode("utf-8"),
     )
 
 
@@ -394,14 +397,10 @@ def test_backfill_submission_allow_overwrite_reports_would_overwrite_when_nothin
 
 
 def test_backfill_ignores_only_fields_that_exist() -> None:
-    """A key that names no column ignores nothing.
+    """Every name in ``_BACKFILL_IGNORE_FIELDS`` must be an actual Submission column.
 
-    The set named "local_case_id", which is not a Submission field; the column holding the
-    submitter's local case ID is "pseudonym". Archived metadata.json always carries a redacted
-    localCaseId, so backfill diffed the placeholder against the stored pseudonym: withheld as
-    destructive where a value was already there, written straight in where the column was NULL.
-
-    These tests did not catch it because they passed their own ignore set rather than the one
-    the command builds.
+    A name that matches no column silently ignores nothing (set difference against a
+    non-member is a no-op), so a typo here would only surface once it let backfill overwrite
+    a field it was meant to skip; this asserts it directly instead.
     """
     assert _BACKFILL_IGNORE_FIELDS <= SubmissionBase.model_fields.keys()

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -292,6 +292,70 @@ def test_backfill_submission_force_does_not_overwrite_ignore_fields(
     assert persisted.submission_metadata == metadata.to_redacted_dict()
 
 
+def test_backfill_leaves_a_missing_upload_date_alone(
+    db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata, submission_id: str
+) -> None:
+    """A NULL upload date stays NULL, even with --force.
+
+    The column records when the upload finished; the metadata's submission_date is what the
+    submitter declared, and it drives the reporting windows, so a declared date must not stand in
+    for a real one. diff() makes that call: given no date it falls back to the metadata's and then
+    ignores the field, so backfill passes the stored value straight through rather than deciding
+    again.
+    """
+    current = db.add_submission(submission_id)
+    assert current.submission_uploaded_date is None
+    assert metadata.submission.submission_date is not None
+    _put_metadata(s3_client_mock, submission_id, metadata)
+
+    result = _backfill_submission(
+        current_submission=current,
+        s3_client=s3_client_mock,
+        bucket=BUCKET,
+        db_service=db,
+        dry_run=False,
+        force=True,
+        ignore_fields=IGNORE_FIELDS,
+    )
+
+    assert result == _BackfillResult.UPDATED
+    assert db.get_submission(submission_id).submission_uploaded_date is None
+
+
+def test_backfill_does_not_write_an_upload_date_from_a_stale_snapshot(
+    db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata, submission_id: str
+) -> None:
+    """A row corrected mid-run keeps the correction, not the value the run started with.
+
+    Backfill builds its candidate list once and then spends the run fetching from S3, so the
+    Submission it holds is a snapshot: diff() re-reads the row from the database, and the two can
+    disagree if an operator writes in between. Offering the snapshot's date would write it back over
+    the correction, and over a deliberate clear it would not even need --force, since filling a NULL
+    is additive.
+    """
+    db.add_submission(submission_id)
+    db.modify_submission(submission_id, "submission_uploaded_date", DIFFERENT_DATE)
+    stale = db.get_submission(submission_id)
+    assert stale.submission_uploaded_date == DIFFERENT_DATE
+
+    # the operator clears the column while the run is in flight
+    db.modify_submission(submission_id, "submission_uploaded_date", None)
+    _put_metadata(s3_client_mock, submission_id, metadata)
+
+    result = _backfill_submission(
+        current_submission=stale,
+        s3_client=s3_client_mock,
+        bucket=BUCKET,
+        db_service=db,
+        dry_run=False,
+        force=True,
+        ignore_fields=IGNORE_FIELDS,
+    )
+
+    assert result == _BackfillResult.UPDATED
+    assert db.get_submission(submission_id).submission_uploaded_date is None
+
+
 def test_backfill_submission_reads_a_consent_datetime_without_a_timezone(
     db: SubmissionDb, s3_client_mock: Any, metadata: GrzSubmissionMetadata, submission_id: str
 ) -> None:

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -15,15 +15,15 @@ from typing import Any
 
 import boto3
 import pytest
-from grz_db.models.submission import Submission, SubmissionDb
+from grz_db.models.submission import Submission, SubmissionBase, SubmissionDb
 from grz_pydantic_models.submission.metadata import GrzSubmissionMetadata
 from grz_pydantic_models_testing.example_metadata import grzctl as grzctl_metadata
-from grzctl.commands.db.cli import _backfill_submission, _BackfillResult
+from grzctl.commands.db.cli import _BACKFILL_IGNORE_FIELDS, _backfill_submission, _BackfillResult
 from moto import mock_aws
 
 BUCKET = "test-backfill-bucket"
 REGION = "us-east-1"
-IGNORE_FIELDS = {"submission_uploaded_date", "tan_g", "pseudonym"}
+IGNORE_FIELDS = set(_BACKFILL_IGNORE_FIELDS)
 DIFFERENT_TAN_G = "b" * 64
 DIFFERENT_PSEUDONYM = "different-pseudonym"
 DIFFERENT_DATE = datetime.date(1999, 1, 1)
@@ -391,3 +391,17 @@ def test_backfill_submission_allow_overwrite_reports_would_overwrite_when_nothin
 
     assert result == _BackfillResult.WOULD_OVERWRITE
     assert db.get_submission(submission_id).submission_size == 1
+
+
+def test_backfill_ignores_only_fields_that_exist() -> None:
+    """A key that names no column ignores nothing.
+
+    The set named "local_case_id", which is not a Submission field; the column holding the
+    submitter's local case ID is "pseudonym". Archived metadata.json always carries a redacted
+    localCaseId, so backfill diffed the placeholder against the stored pseudonym: withheld as
+    destructive where a value was already there, written straight in where the column was NULL.
+
+    These tests did not catch it because they passed their own ignore set rather than the one
+    the command builds.
+    """
+    assert _BACKFILL_IGNORE_FIELDS <= SubmissionBase.model_fields.keys()

--- a/packages/grzctl/tests/cli/test_backfill.py
+++ b/packages/grzctl/tests/cli/test_backfill.py
@@ -52,10 +52,11 @@ def s3_client_mock() -> Iterator[Any]:
 
 
 def _put_metadata(s3_client: Any, submission_id: str, metadata: GrzSubmissionMetadata) -> None:
+    """Write *metadata* to S3 the way archival writes it: what was submitted, nothing added."""
     s3_client.put_object(
         Bucket=BUCKET,
         Key=f"{submission_id}/metadata/metadata.json",
-        Body=metadata.model_dump_json(by_alias=True).encode("utf-8"),
+        Body=metadata.model_dump_json(by_alias=True, exclude_unset=True).encode("utf-8"),
     )
 
 

--- a/packages/grzctl/tests/cli/test_db.py
+++ b/packages/grzctl/tests/cli/test_db.py
@@ -17,7 +17,7 @@ import grzctl.cli
 import pytest
 import sqlalchemy
 import yaml
-from grz_db.models.submission import FailureReasonEnum, Submission, SubmissionDb, SubmissionStateEnum
+from grz_db.models.submission import FailureReasonEnum, Submission, SubmissionBase, SubmissionDb, SubmissionStateEnum
 from grz_pydantic_models.submission.metadata import REDACTED_TAN, GrzSubmissionMetadata
 from grzctl.models.config import GrzctlConfig
 
@@ -1683,3 +1683,28 @@ def test_submission_show_json_includes_failure_reason(migrated_database_config_p
     assert error_state["failure_reason"] == "decryption_error"
     # No metadata stored for this submission -> current research consent cannot be evaluated.
     assert parsed["research_consented_now"] is None
+
+
+def test_modify_offers_exactly_the_keys_it_accepts():
+    """A key the command lists must be one it can honour.
+
+    The choices and the epilog were built from two different field sets, so `modify` offered
+    `id` and then died on a traceback when it was chosen.
+    """
+    from grzctl.commands.db.cli import _MODIFIABLE_SUBMISSION_KEYS
+
+    assert set(_MODIFIABLE_SUBMISSION_KEYS) == SubmissionBase.model_fields.keys() - SubmissionBase.immutable_fields
+
+
+def test_modify_refuses_an_unofferable_key_with_a_usage_error(migrated_database_config_path):
+    runner = click.testing.CliRunner()
+    cli = grzctl.cli.build_cli()
+    args_common = ["--config", str(migrated_database_config_path), "db"]
+    submission_id = "111111111_2025-01-01_0000000a"
+    assert runner.invoke(cli, [*args_common, "submission", "add", submission_id]).exit_code == 0
+
+    result = runner.invoke(cli, [*args_common, "submission", "modify", submission_id, "id", "1"])
+
+    assert result.exit_code == 2, result.output
+    assert "An unexpected error occurred" not in result.output
+    assert "Traceback" not in result.output

--- a/tests/cli/test_archive.py
+++ b/tests/cli/test_archive.py
@@ -8,7 +8,11 @@ import json
 import boto3
 import click.testing
 import grzctl.cli
-from grz_pydantic_models.submission.metadata import REDACTED_TAN, GrzSubmissionMetadata
+from grz_pydantic_models.submission.metadata import (
+    REDACTED_LOCAL_CASE_ID,
+    REDACTED_TAN,
+    GrzSubmissionMetadata,
+)
 
 from .. import mock_files
 from .common import copy_submission
@@ -62,7 +66,7 @@ def test_archive(temp_grzctl_s3_config_file_path, remote_bucket_with_version, wo
         assert metadata.submission.tan_g == REDACTED_TAN
 
         # ensure local case ID is redacted
-        assert not metadata.submission.local_case_id
+        assert metadata.submission.local_case_id == REDACTED_LOCAL_CASE_ID
 
         # ensure index patient donor pseudonym is redacted
         assert metadata.index_donor.donor_pseudonym == "index"


### PR DESCRIPTION
### A parsed submission was not lossless

The FHIR consent models declare only some of the fields in each resource, and `extra="ignore"`
discarded the rest at parse time. Any code that serialised a parsed submission again lost them
too, including the `submission_metadata` that `db submission populate` stores. `extra="allow"`
accepts exactly the same documents, it just stops discarding the rest. The base model is
`LosslessBaseModel` now, because it no longer ignores anything.

`get_raw_dict()` returns the document as the submitter sent it. `to_redacted_dict()` is redaction
applied to that, so the stored copy no longer contains optional fields the submitter never sent.

### Two copies of the redaction rule disagreed

Archiving redacted the raw `metadata.json` with its own copy of the rule, and `to_redacted_dict()`
kept a second copy for the parsed model. They did not match: archiving wrote an empty
`localCaseId`, the model wrote `REDACTED_LOCAL_CASE_ID`. Both spellings are in the archive as a
result. `redact_metadata_dict()` is the one rule now, used for the raw `metadata.json` and the
parsed model alike.

### `db backfill` ignored a column that does not exist

The ignore set named `local_case_id`, but the column carrying the submitter's local case ID is
`pseudonym`, so nothing was ignored under that name. Archived metadata always carries a redacted
`localCaseId`, so backfill derived `pseudonym` from that placeholder and **wrote it straight in
wherever the column was NULL**, because filling a NULL is always allowed. The tests did not catch
it: they pass their own ignore set, spelled correctly, instead of the one the command builds.

`db submission modify` had the same mistake. It built its `click.Choice` from the model fields
alone, so `id` was offered, Click accepted it, and the code then refused it as "An unexpected error
occurred".

### A change set was not applied as one transaction

`commit_changes` wrote every field and donor through a session of its own. A write that failed
partway left the earlier ones in the database, and the next preview started from a state the
operator had never seen. `transaction()` replaces `_get_session` and can be joined: writes inside
it flush instead of committing, and only the caller that opened the session commits. That is what
makes a change set land completely or not at all. `grzctl` was using grz-db's private
`_get_session`, so its call sites in `tui.py` and `report.py` move with it.

### `grz_db.testing` did not export `db_backend`

`__all__` left out the fixture that parametrizes every database test over sqlite and PostgreSQL,
even though the module docstring tells you to import it. Nothing was broken: explicit imports
ignore `__all__`.

### Backfill and diff both decided the upload date

`db backfill` computed its own fallback for `submission_uploaded_date`, then named the field in its
ignore set, which threw the result away. The comment above it said it fills a NULL date for old
rows. It never did.

Backfill passes `None` now and lets `SubmissionDb.diff` decide. Given `None`, `diff` uses the
metadata's `submission_date` to build the candidate row, then leaves the field out of the
comparison, so nothing is written either way. Backfill has no authoritative date to offer in any
case: the archive does not carry one, and `populate` reads the real one from the S3 object.

### Deployment note

Archived `metadata.json` and the stored `submission_metadata` change shape. `localCaseId` is now
spelled `REDACTED_LOCAL_CASE_ID` rather than `""`, undeclared FHIR consent fields survive, and
optional fields the submitter never sent no longer appear. Documents already in the archive are not
rewritten. Anything that reads them should treat both spellings as redacted, which
`assert_metadata_not_redacted` already does.

Rows already in the database keep the old shape and are not converted automatically. Rewrite them
once per archive bucket with `grzctl db backfill --allow-overwrite submission_metadata`. Do not use
`--force` for this: it permits every other destructive overwrite in the same run. Until that has
run, backfill reports the field on every pass, and `grzctl download --populate` fails outright on a
submission that is already populated, because `populate()` rejects a destructive change unless
forced.

This cannot be a database migration. Parsing a stored copy and writing it out again produces the
same wrong fields, so the archived `metadata.json` is the only remaining source of the document as
submitted.

fix(grzctl): name the submission fields the database actually has

fix(grz-common): require grz-pydantic-models >=3.1 for redact_metadata_dict

feat(grz-pydantic-models): add get_raw_dict for the document as submitted

fix(grz-db): apply a change set as one transaction

fix(grz-db): export db_backend from grz_db.testing
