### PR TITLE
feat(grzctl): report QC deviations without failing and add recompute-qc backfill

### DIFF
--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -3,7 +3,6 @@
 import csv
 import json
 import logging
-import math
 import sys
 import traceback
 from collections import Counter, namedtuple
@@ -1040,7 +1039,7 @@ def _recompute_result(
         deviation_attr = f"{prefix}_percent_deviation"
         changed = getattr(result, passed_attr) != verdict.passed_qc or (
             verdict.deviation is not None
-            and not math.isclose(getattr(result, deviation_attr), verdict.deviation, abs_tol=DEVIATION_TOLERANCE)
+            and abs(getattr(result, deviation_attr) - verdict.deviation) > DEVIATION_TOLERANCE
         )
         if not changed:
             continue

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -786,7 +786,7 @@ class RecomputeOutcome(NamedTuple):
     meets_thresholds: bool
     """Whether all computed values meet their required BfArM thresholds."""
     metrics_changed: int
-    """Number of per-metric fields that would change."""
+    """Number of per-metric fields that would change (or have been changed, with apply_changes)."""
 
 
 def _recompute_metric[

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -1023,6 +1023,9 @@ def _recompute_result(
     """
     meets_all_thresholds = True
     metrics_changed = 0
+    # One (prefix, verdict) pair per metric.
+    # prefix: name prefix of the row's `<prefix>_passed_qc` and `<prefix>_percent_deviation` columns.
+    # verdict: the MetricVerdict recomputed for that metric.
     verdicts = (
         (
             "mean_depth_of_coverage",

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -9,7 +9,7 @@ from collections import Counter, namedtuple
 from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import botocore.exceptions
 import click
@@ -760,7 +760,27 @@ class QCStatus(StrEnum):
 PCT_DEV_CUTOFF = 10
 
 
-def _recompute_metric(measured: float, provided: float | None, required: float) -> tuple[bool, float | None, bool]:
+class MetricVerdict(NamedTuple):
+    """Verdict of one recomputed detailed QC metric."""
+
+    meets_threshold: bool
+    """Whether the computed value meets the required BfArM threshold."""
+    deviation: float | None
+    """Percent deviation of the provided value from the computed value, if computable."""
+    passed_qc: bool
+    """Per-metric passed_qc flag (meets the threshold and deviates at most PCT_DEV_CUTOFF percent)."""
+
+
+class RecomputeOutcome(NamedTuple):
+    """Outcome of recomputing the detailed QC metrics of a result row or a submission."""
+
+    meets_thresholds: bool
+    """Whether all computed values meet their required BfArM thresholds."""
+    metrics_changed: int
+    """Number of per-metric fields that would change."""
+
+
+def _recompute_metric(measured: float, provided: float | None, required: float) -> MetricVerdict:
     """Re-evaluate a single detailed QC metric under the GRZ_QC_Workflow >= 4.0.0 rules.
 
     ``measured``, ``provided``, and ``required`` must share the same unit (the metric's
@@ -772,15 +792,13 @@ def _recompute_metric(measured: float, provided: float | None, required: float) 
     :param measured: value computed by the QC pipeline (stored in the database)
     :param provided: value provided by the Leistungserbringer in the submission metadata
     :param required: threshold required by BfArM (0 for non-index donors)
-    :return: tuple of (computed value meets the required threshold, percent deviation of the
-        provided value from the computed value, per-metric passed_qc flag)
     """
     meets_threshold = measured >= required
     if not provided or not measured:
         # no provided value (or computed value of zero): deviation is undefined
-        return meets_threshold, None, meets_threshold
+        return MetricVerdict(meets_threshold, None, meets_threshold)
     deviation = (measured - provided) / measured * 100
-    return meets_threshold, deviation, meets_threshold and abs(deviation) <= PCT_DEV_CUTOFF
+    return MetricVerdict(meets_threshold, deviation, meets_threshold and abs(deviation) <= PCT_DEV_CUTOFF)
 
 
 class QCReportRow(StrictBaseModel):
@@ -958,12 +976,11 @@ def _metadata_lab_data(metadata: GrzSubmissionMetadata) -> dict[str, tuple[Any, 
 
 def _recompute_result(
     result: DetailedQCResult, thresholds: Any, sequence_data: Any, apply_changes: bool
-) -> tuple[bool, int]:
+) -> RecomputeOutcome:
     """Recompute the three metrics of one detailed QC result row.
 
     Mutates the row in place when ``apply_changes`` is set (the enclosing session tracks the
-    changes). Returns whether all computed values meet their required thresholds and how
-    many metric fields would change.
+    changes).
     """
     meets_all_thresholds = True
     metrics_changed = 0
@@ -988,28 +1005,27 @@ def _recompute_result(
         ),
     )
     for measured, provided, required, prefix in metrics:
-        meets_threshold, deviation, passed = _recompute_metric(measured, provided, required)
-        meets_all_thresholds &= meets_threshold
+        verdict = _recompute_metric(measured, provided, required)
+        meets_all_thresholds &= verdict.meets_threshold
         passed_attr = f"{prefix}_passed_qc"
         deviation_attr = f"{prefix}_percent_deviation"
-        changed = getattr(result, passed_attr) != passed or (
-            deviation is not None and abs(getattr(result, deviation_attr) - deviation) > 1e-6
+        changed = getattr(result, passed_attr) != verdict.passed_qc or (
+            verdict.deviation is not None and abs(getattr(result, deviation_attr) - verdict.deviation) > 1e-6
         )
         if not changed:
             continue
         metrics_changed += 1
         if apply_changes:
-            setattr(result, passed_attr, passed)
-            if deviation is not None:
-                setattr(result, deviation_attr, deviation)
-    return meets_all_thresholds, metrics_changed
+            setattr(result, passed_attr, verdict.passed_qc)
+            if verdict.deviation is not None:
+                setattr(result, deviation_attr, verdict.deviation)
+    return RecomputeOutcome(meets_all_thresholds, metrics_changed)
 
 
-def _recompute_submission(session, submission: Submission, apply_changes: bool) -> tuple[bool, int] | None:
+def _recompute_submission(session, submission: Submission, apply_changes: bool) -> RecomputeOutcome | None:
     """Recompute the detailed QC results of one submission.
 
-    Returns whether all computed values meet their required thresholds and how many metric
-    fields would change, or ``None`` if the submission has no recomputable QC results.
+    Returns ``None`` if the submission has no recomputable QC results.
     """
     results = session.exec(select(DetailedQCResult).where(DetailedQCResult.submission_id == submission.id)).all()
     if not results:
@@ -1039,10 +1055,10 @@ def _recompute_submission(session, submission: Submission, apply_changes: bool) 
     metrics_updated = 0
     for result in latest_results.values():
         thresholds, sequence_data = lab_data[result.lab_datum_id]
-        meets_all_thresholds, metrics_changed = _recompute_result(result, thresholds, sequence_data, apply_changes)
-        submission_meets_thresholds &= meets_all_thresholds
-        metrics_updated += metrics_changed
-    return submission_meets_thresholds, metrics_updated
+        outcome = _recompute_result(result, thresholds, sequence_data, apply_changes)
+        submission_meets_thresholds &= outcome.meets_thresholds
+        metrics_updated += outcome.metrics_changed
+    return RecomputeOutcome(submission_meets_thresholds, metrics_updated)
 
 
 @submission.command(name="recompute-qc")
@@ -1086,18 +1102,17 @@ def recompute_qc(ctx: click.Context, year: int, quarter: int, apply_changes: boo
             outcome = _recompute_submission(session, submission, apply_changes)
             if outcome is None:
                 continue
-            submission_meets_thresholds, metrics_updated = outcome
 
-            if submission.detailed_qc_passed is not submission_meets_thresholds:
-                verdict_changes[submission.id] = submission_meets_thresholds
-            total_metrics_updated += metrics_updated
-            if metrics_updated or submission.id in verdict_changes:
+            if submission.detailed_qc_passed is not outcome.meets_thresholds:
+                verdict_changes[submission.id] = outcome.meets_thresholds
+            total_metrics_updated += outcome.metrics_changed
+            if outcome.metrics_changed or submission.id in verdict_changes:
                 old_verdict = {True: "yes", False: "no", None: "unset"}[submission.detailed_qc_passed]
-                new_verdict = "yes" if submission_meets_thresholds else "no"
+                new_verdict = "yes" if outcome.meets_thresholds else "no"
                 table.add_row(
                     submission.id,
                     old_verdict if old_verdict == new_verdict else f"{old_verdict} -> {new_verdict}",
-                    str(metrics_updated),
+                    str(outcome.metrics_changed),
                 )
         if apply_changes:
             session.commit()

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -770,9 +770,11 @@ def _recompute_metric(measured: float, provided: float | None, required: float) 
         provided value from the computed value, per-metric passed_qc flag)
     """
     meets_threshold = measured >= required
-    deviation = None if not provided or not measured else (measured - provided) / measured * 100
-    flagged = deviation is not None and abs(deviation) > PCT_DEV_CUTOFF
-    return meets_threshold, deviation, meets_threshold and not flagged
+    if not provided or not measured:
+        # no provided value (or computed value of zero): deviation is undefined
+        return meets_threshold, None, meets_threshold
+    deviation = (measured - provided) / measured * 100
+    return meets_threshold, deviation, meets_threshold and abs(deviation) <= PCT_DEV_CUTOFF
 
 
 class QCReportRow(StrictBaseModel):

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -9,7 +9,7 @@ from collections import Counter, namedtuple
 from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, NamedTuple, NewType
+from typing import Any, NamedTuple
 
 import botocore.exceptions
 import click
@@ -764,15 +764,6 @@ PCT_DEV_CUTOFF = 10
 # count as a change.
 DEVIATION_TOLERANCE = 1e-6
 
-# Metric-tagged values for the three detailed QC metrics: mean depth of coverage in fold
-# coverage, percent of bases above the quality threshold in percent (0-100), and targeted
-# regions above minimum coverage as a proportion (0-1). ``_recompute_metric`` requires all
-# of its arguments to come from the same metric; its constrained type parameter makes
-# mixing metrics (and thus units) within a single call a type error.
-MeanDepthOfCoverage = NewType("MeanDepthOfCoverage", float)
-PercentBasesAboveQualityThreshold = NewType("PercentBasesAboveQualityThreshold", float)
-TargetedRegionsAboveMinCoverage = NewType("TargetedRegionsAboveMinCoverage", float)
-
 
 class MetricVerdict(NamedTuple):
     """Verdict of one recomputed detailed QC metric."""
@@ -794,17 +785,14 @@ class RecomputeOutcome(NamedTuple):
     """Number of per-metric fields that would change (or have been changed, with apply_changes)."""
 
 
-def _recompute_metric[
-    MetricValue: (MeanDepthOfCoverage, PercentBasesAboveQualityThreshold, TargetedRegionsAboveMinCoverage)
-](measured: MetricValue, provided: MetricValue | None, required: MetricValue) -> MetricVerdict:
+def _recompute_metric(measured: float, provided: float | None, required: float) -> MetricVerdict:
     """Re-evaluate a single detailed QC metric under the GRZ_QC_Workflow >= 4.0.0 rules.
 
-    ``measured``, ``provided``, and ``required`` must belong to the same metric (and thus
-    share its unit), enforced through the metric-tagged ``MetricValue`` types; the relative
-    deviation is then unit-independent.
-    The returned deviation is expressed in percent (e.g. ``-42.0`` for -42%), matching the
-    ``*_percent_deviation`` columns and ``PCT_DEV_CUTOFF``. It is signed (negative when the
-    provided value exceeds the computed one) and not bounded to [0, 100].
+    ``measured``, ``provided``, and ``required`` must all be in the metric's native unit
+    (fold coverage, percent 0-100, or proportion 0-1); the relative deviation is then
+    unit-independent. The returned deviation is expressed in percent (e.g. ``-42.0`` for
+    -42%), matching the ``*_percent_deviation`` columns and ``PCT_DEV_CUTOFF``, signed
+    (negative when the provided value exceeds the computed one), and not bounded to [0, 100].
 
     :param measured: value computed by the QC pipeline (stored in the database)
     :param provided: value provided by the Leistungserbringer in the submission metadata
@@ -1007,29 +995,25 @@ def _recompute_result(
         (
             "mean_depth_of_coverage",
             _recompute_metric(
-                MeanDepthOfCoverage(result.mean_depth_of_coverage),
-                MeanDepthOfCoverage(sequence_data.mean_depth_of_coverage),
-                MeanDepthOfCoverage(thresholds.mean_depth_of_coverage) if thresholds else MeanDepthOfCoverage(0),
+                measured=result.mean_depth_of_coverage,
+                provided=sequence_data.mean_depth_of_coverage,
+                required=thresholds.mean_depth_of_coverage if thresholds else 0,
             ),
         ),
         (
             "percent_bases_above_quality_threshold",
             _recompute_metric(
-                PercentBasesAboveQualityThreshold(result.percent_bases_above_quality_threshold_percent),
-                PercentBasesAboveQualityThreshold(sequence_data.percent_bases_above_quality_threshold.percent),
-                PercentBasesAboveQualityThreshold(thresholds.percent_bases_above_quality_threshold.percent_bases_above)
-                if thresholds
-                else PercentBasesAboveQualityThreshold(0),
+                measured=result.percent_bases_above_quality_threshold_percent,
+                provided=sequence_data.percent_bases_above_quality_threshold.percent,
+                required=thresholds.percent_bases_above_quality_threshold.percent_bases_above if thresholds else 0,
             ),
         ),
         (
             "targeted_regions_above_min_coverage",
             _recompute_metric(
-                TargetedRegionsAboveMinCoverage(result.targeted_regions_above_min_coverage),
-                TargetedRegionsAboveMinCoverage(sequence_data.targeted_regions_above_min_coverage),
-                TargetedRegionsAboveMinCoverage(thresholds.targeted_regions_above_min_coverage.fraction_above)
-                if thresholds
-                else TargetedRegionsAboveMinCoverage(0),
+                measured=result.targeted_regions_above_min_coverage,
+                provided=sequence_data.targeted_regions_above_min_coverage,
+                required=thresholds.targeted_regions_above_min_coverage.fraction_above if thresholds else 0,
             ),
         ),
     )

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -806,8 +806,10 @@ def _recompute_metric[
     :param required: threshold required by BfArM (0 for non-index donors)
     """
     meets_threshold = measured >= required
-    if not provided or not measured:
-        # no provided value (or computed value of zero): deviation is undefined
+    # A provided value of zero is treated like a missing one, mirroring the QC workflow
+    # (whose Nextflow module omits zero-valued provided metrics entirely); a computed value
+    # of zero leaves the relative deviation undefined.
+    if provided is None or provided == 0 or measured == 0:
         return MetricVerdict(meets_threshold, None, meets_threshold)
     deviation = (measured - provided) / measured * 100
     return MetricVerdict(meets_threshold, deviation, meets_threshold and abs(deviation) <= PCT_DEV_CUTOFF)

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -763,6 +763,12 @@ PCT_DEV_CUTOFF = 10
 def _recompute_metric(measured: float, provided: float | None, required: float) -> tuple[bool, float | None, bool]:
     """Re-evaluate a single detailed QC metric under the GRZ_QC_Workflow >= 4.0.0 rules.
 
+    ``measured``, ``provided``, and ``required`` must share the same unit (the metric's
+    native unit, e.g. fold coverage, percent, or fraction); the relative deviation is then
+    unit-independent. The returned deviation is expressed in percent (e.g. ``-42.0`` for
+    -42%), matching the ``*_percent_deviation`` columns and ``PCT_DEV_CUTOFF``. It is signed
+    (negative when the provided value exceeds the computed one) and not bounded to [0, 100].
+
     :param measured: value computed by the QC pipeline (stored in the database)
     :param provided: value provided by the Leistungserbringer in the submission metadata
     :param required: threshold required by BfArM (0 for non-index donors)

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -46,14 +46,18 @@ from grz_db.models.submission import (
     SubmissionStateLog,
 )
 from grz_pydantic_models.common import StrictBaseModel
+from grz_pydantic_models.dates import quarter_date_bounds
 from grz_pydantic_models.submission.metadata import (
     GenomicStudySubtype,
     GrzSubmissionMetadata,
     LibraryType,
+    MissingThresholdsException,
+    Relation,
     SequenceSubtype,
     SequenceType,
 )
 from pydantic import Field, ValidationError
+from sqlmodel import select
 from tqdm.auto import tqdm
 
 from ... import get_versions
@@ -746,8 +750,29 @@ def populate(  # noqa: C901, PLR0913
 class QCStatus(StrEnum):
     PASS = "PASS"  # noqa: S105
     FAIL = "FAIL"
+    DEVIATION = "DEVIATION"
+    # Superseded by DEVIATION in GRZ_QC_Workflow >= 4.0.0; kept to parse reports from older versions.
     TOO_LOW = "TOO LOW"
     THRESHOLD_NOT_MET = "THRESHOLD NOT MET"
+
+
+# Keep in sync with PCT_DEV_CUTOFF in GRZ_QC_Workflow's compare_threshold.py
+PCT_DEV_CUTOFF = 10
+
+
+def _recompute_metric(measured: float, provided: float | None, required: float) -> tuple[bool, float | None, bool]:
+    """Re-evaluate a single detailed QC metric under the GRZ_QC_Workflow >= 4.0.0 rules.
+
+    :param measured: value computed by the QC pipeline (stored in the database)
+    :param provided: value provided by the Leistungserbringer in the submission metadata
+    :param required: threshold required by BfArM (0 for non-index donors)
+    :return: tuple of (computed value meets the required threshold, percent deviation of the
+        provided value from the computed value, per-metric passed_qc flag)
+    """
+    meets_threshold = measured >= required
+    deviation = None if not provided or not measured else (measured - provided) / measured * 100
+    flagged = deviation is not None and abs(deviation) > PCT_DEV_CUTOFF
+    return meets_threshold, deviation, meets_threshold and not flagged
 
 
 class QCReportRow(StrictBaseModel):
@@ -898,6 +923,188 @@ def populate_qc(
     ):
         for result in results:
             db_service.add_detailed_qc_result(result)
+
+
+def _metadata_lab_data(metadata: GrzSubmissionMetadata) -> dict[str, tuple[Any, Any]]:
+    """Map lab datum IDs to (required thresholds, provided sequence data) from the metadata.
+
+    Derives the lab datum IDs the same way GRZ_QC_Workflow's metadata_to_samplesheet.py
+    does. Only index donors have required thresholds; for all other donors the thresholds
+    are ``None`` (mirroring metadata_to_samplesheet.py, which sets their requirements to 0).
+    """
+    lab_data = {}
+    for donor_index, donor in enumerate(metadata.donors):
+        for lab_datum_index, lab_datum in enumerate(donor.lab_data):
+            if lab_datum.sequence_data is None:
+                continue
+            lab_datum_id = f"{donor.relation}{donor_index}_{lab_datum.sequence_subtype}{lab_datum_index}"
+            try:
+                thresholds = metadata.determine_thresholds_for(donor, lab_datum)
+            except MissingThresholdsException:
+                thresholds = None
+            if donor.relation != Relation.index_:
+                thresholds = None
+            lab_data[lab_datum_id] = (thresholds, lab_datum.sequence_data)
+    return lab_data
+
+
+def _recompute_result(
+    result: DetailedQCResult, thresholds: Any, sequence_data: Any, apply_changes: bool
+) -> tuple[bool, int]:
+    """Recompute the three metrics of one detailed QC result row.
+
+    Mutates the row in place when ``apply_changes`` is set (the enclosing session tracks the
+    changes). Returns whether all computed values meet their required thresholds and how
+    many metric fields would change.
+    """
+    meets_all_thresholds = True
+    metrics_changed = 0
+    metrics = (
+        (
+            result.mean_depth_of_coverage,
+            sequence_data.mean_depth_of_coverage,
+            thresholds.mean_depth_of_coverage if thresholds else 0,
+            "mean_depth_of_coverage",
+        ),
+        (
+            result.percent_bases_above_quality_threshold_percent,
+            sequence_data.percent_bases_above_quality_threshold.percent,
+            thresholds.percent_bases_above_quality_threshold.percent_bases_above if thresholds else 0,
+            "percent_bases_above_quality_threshold",
+        ),
+        (
+            result.targeted_regions_above_min_coverage,
+            sequence_data.targeted_regions_above_min_coverage,
+            thresholds.targeted_regions_above_min_coverage.fraction_above if thresholds else 0,
+            "targeted_regions_above_min_coverage",
+        ),
+    )
+    for measured, provided, required, prefix in metrics:
+        meets_threshold, deviation, passed = _recompute_metric(measured, provided, required)
+        meets_all_thresholds &= meets_threshold
+        passed_attr = f"{prefix}_passed_qc"
+        deviation_attr = f"{prefix}_percent_deviation"
+        changed = getattr(result, passed_attr) != passed or (
+            deviation is not None and abs(getattr(result, deviation_attr) - deviation) > 1e-6
+        )
+        if not changed:
+            continue
+        metrics_changed += 1
+        if apply_changes:
+            setattr(result, passed_attr, passed)
+            if deviation is not None:
+                setattr(result, deviation_attr, deviation)
+    return meets_all_thresholds, metrics_changed
+
+
+def _recompute_submission(session, submission: Submission, apply_changes: bool) -> tuple[bool, int] | None:
+    """Recompute the detailed QC results of one submission.
+
+    Returns whether all computed values meet their required thresholds and how many metric
+    fields would change, or ``None`` if the submission has no recomputable QC results.
+    """
+    results = session.exec(select(DetailedQCResult).where(DetailedQCResult.submission_id == submission.id)).all()
+    if not results:
+        return None
+    if not submission.submission_metadata:
+        console_err.print(f"[yellow]Skipping {submission.id}: no submission metadata stored.[/yellow]")
+        return None
+    metadata = GrzSubmissionMetadata.model_validate(submission.submission_metadata)
+    lab_data = _metadata_lab_data(metadata)
+
+    # only the most recent QC run per lab datum decides
+    latest_results: dict[str, DetailedQCResult] = {}
+    for result in results:
+        current = latest_results.get(result.lab_datum_id)
+        if current is None or result.timestamp > current.timestamp:
+            latest_results[result.lab_datum_id] = result
+
+    unmatched = set(latest_results) - set(lab_data)
+    if unmatched:
+        console_err.print(
+            f"[yellow]Skipping {submission.id}: QC results {sorted(unmatched)} cannot be matched "
+            f"to the submission metadata.[/yellow]"
+        )
+        return None
+
+    submission_meets_thresholds = True
+    metrics_updated = 0
+    for result in latest_results.values():
+        thresholds, sequence_data = lab_data[result.lab_datum_id]
+        meets_all_thresholds, metrics_changed = _recompute_result(result, thresholds, sequence_data, apply_changes)
+        submission_meets_thresholds &= meets_all_thresholds
+        metrics_updated += metrics_changed
+    return submission_meets_thresholds, metrics_updated
+
+
+@submission.command(name="recompute-qc")
+@click.option("--year", "year", type=click.IntRange(min=2025), required=True, help="Year of the quarter to recompute.")
+@click.option("--quarter", "quarter", type=click.IntRange(min=1, max=4), required=True, help="Quarter to recompute.")
+@click.option(
+    "--apply",
+    "apply_changes",
+    is_flag=True,
+    default=False,
+    help="Write the recomputed verdicts to the database. Without this flag, only report what would change.",
+)
+@click.pass_context
+def recompute_qc(ctx: click.Context, year: int, quarter: int, apply_changes: bool):
+    """Recompute detailed QC verdicts under the current rules (GRZ_QC_Workflow >= 4.0.0).
+
+    Re-evaluates the stored detailed QC results of all submissions uploaded in the given
+    quarter: a metric fails only if the value computed by the pipeline is below the required
+    BfArM threshold, and a deviation of more than 10% between the computed and provided
+    values (in either direction, relative to the computed value) is flagged without failing
+    quality control. Use this to backfill verdicts produced by older workflow versions
+    before generating the quarterly report.
+    """
+    db = ctx.obj["db_url"]
+    db_service = get_submission_db_instance(db, author=ctx.obj["author"])
+    quarter_start_date, quarter_end_date = quarter_date_bounds(year=year, quarter=quarter)
+
+    table = rich.table.Table(
+        "Submission ID",
+        "Detailed QC Passed",
+        "Metrics Updated",
+        title=f"Recomputed Detailed QC Verdicts Q{quarter}/{year}",
+    )
+    verdict_changes: dict[str, bool] = {}
+    total_metrics_updated = 0
+    with db_service._get_session() as session:
+        submissions = session.exec(
+            select(Submission).where(Submission.submission_uploaded_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
+        ).all()
+        for submission in sorted(submissions, key=lambda s: s.id):
+            outcome = _recompute_submission(session, submission, apply_changes)
+            if outcome is None:
+                continue
+            submission_meets_thresholds, metrics_updated = outcome
+
+            if submission.detailed_qc_passed is not submission_meets_thresholds:
+                verdict_changes[submission.id] = submission_meets_thresholds
+            total_metrics_updated += metrics_updated
+            if metrics_updated or submission.id in verdict_changes:
+                old_verdict = {True: "yes", False: "no", None: "unset"}[submission.detailed_qc_passed]
+                new_verdict = "yes" if submission_meets_thresholds else "no"
+                table.add_row(
+                    submission.id,
+                    old_verdict if old_verdict == new_verdict else f"{old_verdict} -> {new_verdict}",
+                    str(metrics_updated),
+                )
+        if apply_changes:
+            session.commit()
+
+    console.print(table)
+    if apply_changes:
+        # modify_submission logs the change with the configured author
+        for submission_id, passed in verdict_changes.items():
+            db_service.modify_submission(submission_id, "detailed_qc_passed", passed)
+        console.print(f"Updated {total_metrics_updated} metric(s) and {len(verdict_changes)} verdict(s).")
+    else:
+        console.print(
+            f"Would update {total_metrics_updated} metric(s) and {len(verdict_changes)} verdict(s). "
+            "Run with --apply to write these changes."
+        )
 
 
 @submission.command()

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -3,6 +3,7 @@
 import csv
 import json
 import logging
+import math
 import sys
 import traceback
 from collections import Counter, namedtuple
@@ -759,6 +760,11 @@ class QCStatus(StrEnum):
 # Keep in sync with PCT_DEV_CUTOFF in GRZ_QC_Workflow's compare_threshold.py
 PCT_DEV_CUTOFF = 10
 
+# Absolute tolerance (in percentage points) below which a stored and a recomputed percent
+# deviation are considered equal, so that float noise (e.g. from CSV round-trips) does not
+# count as a change.
+DEVIATION_TOLERANCE = 1e-6
+
 # Metric-tagged values for the three detailed QC metrics: mean depth of coverage in fold
 # coverage, percent of bases above the quality threshold in percent (0-100), and targeted
 # regions above minimum coverage as a proportion (0-1). ``_recompute_metric`` requires all
@@ -1033,7 +1039,8 @@ def _recompute_result(
         passed_attr = f"{prefix}_passed_qc"
         deviation_attr = f"{prefix}_percent_deviation"
         changed = getattr(result, passed_attr) != verdict.passed_qc or (
-            verdict.deviation is not None and abs(getattr(result, deviation_attr) - verdict.deviation) > 1e-6
+            verdict.deviation is not None
+            and not math.isclose(getattr(result, deviation_attr), verdict.deviation, abs_tol=DEVIATION_TOLERANCE)
         )
         if not changed:
             continue

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -9,7 +9,7 @@ from collections import Counter, namedtuple
 from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, NewType
 
 import botocore.exceptions
 import click
@@ -759,6 +759,15 @@ class QCStatus(StrEnum):
 # Keep in sync with PCT_DEV_CUTOFF in GRZ_QC_Workflow's compare_threshold.py
 PCT_DEV_CUTOFF = 10
 
+# Metric-tagged values for the three detailed QC metrics: mean depth of coverage in fold
+# coverage, percent of bases above the quality threshold in percent (0-100), and targeted
+# regions above minimum coverage as a proportion (0-1). ``_recompute_metric`` requires all
+# of its arguments to come from the same metric; its constrained type parameter makes
+# mixing metrics (and thus units) within a single call a type error.
+MeanDepthOfCoverage = NewType("MeanDepthOfCoverage", float)
+PercentBasesAboveQualityThreshold = NewType("PercentBasesAboveQualityThreshold", float)
+TargetedRegionsAboveMinCoverage = NewType("TargetedRegionsAboveMinCoverage", float)
+
 
 class MetricVerdict(NamedTuple):
     """Verdict of one recomputed detailed QC metric."""
@@ -780,14 +789,17 @@ class RecomputeOutcome(NamedTuple):
     """Number of per-metric fields that would change."""
 
 
-def _recompute_metric(measured: float, provided: float | None, required: float) -> MetricVerdict:
+def _recompute_metric[
+    MetricValue: (MeanDepthOfCoverage, PercentBasesAboveQualityThreshold, TargetedRegionsAboveMinCoverage)
+](measured: MetricValue, provided: MetricValue | None, required: MetricValue) -> MetricVerdict:
     """Re-evaluate a single detailed QC metric under the GRZ_QC_Workflow >= 4.0.0 rules.
 
-    ``measured``, ``provided``, and ``required`` must share the same unit (the metric's
-    native unit, e.g. fold coverage, percent, or fraction); the relative deviation is then
-    unit-independent. The returned deviation is expressed in percent (e.g. ``-42.0`` for
-    -42%), matching the ``*_percent_deviation`` columns and ``PCT_DEV_CUTOFF``. It is signed
-    (negative when the provided value exceeds the computed one) and not bounded to [0, 100].
+    ``measured``, ``provided``, and ``required`` must belong to the same metric (and thus
+    share its unit), enforced through the metric-tagged ``MetricValue`` types; the relative
+    deviation is then unit-independent.
+    The returned deviation is expressed in percent (e.g. ``-42.0`` for -42%), matching the
+    ``*_percent_deviation`` columns and ``PCT_DEV_CUTOFF``. It is signed (negative when the
+    provided value exceeds the computed one) and not bounded to [0, 100].
 
     :param measured: value computed by the QC pipeline (stored in the database)
     :param provided: value provided by the Leistungserbringer in the submission metadata
@@ -984,28 +996,37 @@ def _recompute_result(
     """
     meets_all_thresholds = True
     metrics_changed = 0
-    metrics = (
+    verdicts = (
         (
-            result.mean_depth_of_coverage,
-            sequence_data.mean_depth_of_coverage,
-            thresholds.mean_depth_of_coverage if thresholds else 0,
             "mean_depth_of_coverage",
+            _recompute_metric(
+                MeanDepthOfCoverage(result.mean_depth_of_coverage),
+                MeanDepthOfCoverage(sequence_data.mean_depth_of_coverage),
+                MeanDepthOfCoverage(thresholds.mean_depth_of_coverage) if thresholds else MeanDepthOfCoverage(0),
+            ),
         ),
         (
-            result.percent_bases_above_quality_threshold_percent,
-            sequence_data.percent_bases_above_quality_threshold.percent,
-            thresholds.percent_bases_above_quality_threshold.percent_bases_above if thresholds else 0,
             "percent_bases_above_quality_threshold",
+            _recompute_metric(
+                PercentBasesAboveQualityThreshold(result.percent_bases_above_quality_threshold_percent),
+                PercentBasesAboveQualityThreshold(sequence_data.percent_bases_above_quality_threshold.percent),
+                PercentBasesAboveQualityThreshold(thresholds.percent_bases_above_quality_threshold.percent_bases_above)
+                if thresholds
+                else PercentBasesAboveQualityThreshold(0),
+            ),
         ),
         (
-            result.targeted_regions_above_min_coverage,
-            sequence_data.targeted_regions_above_min_coverage,
-            thresholds.targeted_regions_above_min_coverage.fraction_above if thresholds else 0,
             "targeted_regions_above_min_coverage",
+            _recompute_metric(
+                TargetedRegionsAboveMinCoverage(result.targeted_regions_above_min_coverage),
+                TargetedRegionsAboveMinCoverage(sequence_data.targeted_regions_above_min_coverage),
+                TargetedRegionsAboveMinCoverage(thresholds.targeted_regions_above_min_coverage.fraction_above)
+                if thresholds
+                else TargetedRegionsAboveMinCoverage(0),
+            ),
         ),
     )
-    for measured, provided, required, prefix in metrics:
-        verdict = _recompute_metric(measured, provided, required)
+    for prefix, verdict in verdicts:
         meets_all_thresholds &= verdict.meets_threshold
         passed_attr = f"{prefix}_passed_qc"
         deviation_attr = f"{prefix}_percent_deviation"

--- a/packages/grzctl/src/grzctl/commands/db/cli.py
+++ b/packages/grzctl/src/grzctl/commands/db/cli.py
@@ -48,16 +48,20 @@ from grz_db.models.submission import (
 from grz_pydantic_models.common import StrictBaseModel
 from grz_pydantic_models.dates import quarter_date_bounds
 from grz_pydantic_models.submission.metadata import (
+    Donor,
     GenomicStudySubtype,
     GrzSubmissionMetadata,
+    LabDatum,
     LibraryType,
     MissingThresholdsException,
     Relation,
+    SequenceData,
     SequenceSubtype,
     SequenceType,
 )
+from grz_pydantic_models.submission.thresholds import Thresholds
 from pydantic import Field, ValidationError
-from sqlmodel import select
+from sqlmodel import Session, select
 from tqdm.auto import tqdm
 
 from ... import get_versions
@@ -797,6 +801,7 @@ def _recompute_metric(measured: float, provided: float | None, required: float) 
     :param measured: value computed by the QC pipeline (stored in the database)
     :param provided: value provided by the Leistungserbringer in the submission metadata
     :param required: threshold required by BfArM (0 for non-index donors)
+    :return: verdict with the threshold check, the deviation, and the per-metric passed_qc flag
     """
     meets_threshold = measured >= required
     # A provided value of zero is treated like a missing one, mirroring the QC workflow
@@ -958,19 +963,39 @@ def populate_qc(
             db_service.add_detailed_qc_result(result)
 
 
-def _metadata_lab_data(metadata: GrzSubmissionMetadata) -> dict[str, tuple[Any, Any]]:
+def _lab_datum_id(donor_index: int, donor: Donor, lab_datum_index: int, lab_datum: LabDatum) -> str:
+    """Derive the lab datum ID under which the QC workflow reports a lab datum.
+
+    Must match the sample ID scheme of GRZ_QC_Workflow's metadata_to_samplesheet.py
+    (``{relation}{donor_index}_{sequence_subtype}{lab_datum_index}``), which ends up as
+    ``DetailedQCResult.lab_datum_id`` via populate-qc. It is the only unambiguous link
+    between a stored QC result and its lab datum in the submission metadata.
+
+    :param donor_index: position of the donor in the submission metadata
+    :param donor: the donor
+    :param lab_datum_index: position of the lab datum within the donor's lab data
+    :param lab_datum: the lab datum
+    :return: the lab datum ID, e.g. ``index0_germline0``
+    """
+    return f"{donor.relation}{donor_index}_{lab_datum.sequence_subtype}{lab_datum_index}"
+
+
+def _metadata_lab_data(metadata: GrzSubmissionMetadata) -> dict[str, tuple[Thresholds | None, SequenceData]]:
     """Map lab datum IDs to (required thresholds, provided sequence data) from the metadata.
 
-    Derives the lab datum IDs the same way GRZ_QC_Workflow's metadata_to_samplesheet.py
-    does. Only index donors have required thresholds; for all other donors the thresholds
-    are ``None`` (mirroring metadata_to_samplesheet.py, which sets their requirements to 0).
+    Only index donors have required thresholds; for all other donors the thresholds are
+    ``None`` (mirroring metadata_to_samplesheet.py, which sets their requirements to 0).
+
+    :param metadata: the submission metadata stored in the database
+    :return: mapping of lab datum ID to (required thresholds or ``None``, provided sequence
+        data) for every lab datum with sequence data
     """
     lab_data = {}
     for donor_index, donor in enumerate(metadata.donors):
         for lab_datum_index, lab_datum in enumerate(donor.lab_data):
             if lab_datum.sequence_data is None:
                 continue
-            lab_datum_id = f"{donor.relation}{donor_index}_{lab_datum.sequence_subtype}{lab_datum_index}"
+            lab_datum_id = _lab_datum_id(donor_index, donor, lab_datum_index, lab_datum)
             try:
                 thresholds = metadata.determine_thresholds_for(donor, lab_datum)
             except MissingThresholdsException:
@@ -982,12 +1007,19 @@ def _metadata_lab_data(metadata: GrzSubmissionMetadata) -> dict[str, tuple[Any, 
 
 
 def _recompute_result(
-    result: DetailedQCResult, thresholds: Any, sequence_data: Any, apply_changes: bool
+    result: DetailedQCResult, thresholds: Thresholds | None, sequence_data: SequenceData, apply_changes: bool
 ) -> RecomputeOutcome:
     """Recompute the three metrics of one detailed QC result row.
 
     Mutates the row in place when ``apply_changes`` is set (the enclosing session tracks the
     changes).
+
+    :param result: the stored detailed QC result row
+    :param thresholds: thresholds required by BfArM, or ``None`` for non-index donors
+    :param sequence_data: sequence data of the lab datum as provided in the submission metadata
+    :param apply_changes: whether to write the recomputed values to the row
+    :return: whether all computed values meet their thresholds and how many metric fields
+        differ from the recomputed values
     """
     meets_all_thresholds = True
     metrics_changed = 0
@@ -1035,10 +1067,14 @@ def _recompute_result(
     return RecomputeOutcome(meets_all_thresholds, metrics_changed)
 
 
-def _recompute_submission(session, submission: Submission, apply_changes: bool) -> RecomputeOutcome | None:
+def _recompute_submission(session: Session, submission: Submission, apply_changes: bool) -> RecomputeOutcome | None:
     """Recompute the detailed QC results of one submission.
 
-    Returns ``None`` if the submission has no recomputable QC results.
+    :param session: open database session the submission and its results are loaded in
+    :param submission: the submission to recompute
+    :param apply_changes: whether to write the recomputed values to the result rows
+    :return: the combined outcome over the most recent QC result of each lab datum, or
+        ``None`` if the submission has no QC results or they cannot be matched to its metadata
     """
     results = session.exec(select(DetailedQCResult).where(DetailedQCResult.submission_id == submission.id)).all()
     if not results:

--- a/packages/grzctl/src/grzctl/commands/report.py
+++ b/packages/grzctl/src/grzctl/commands/report.py
@@ -493,9 +493,9 @@ def _dump_qc_report(
         # BfArM requires both to be reported; the latter does not count as a failure.
         submission_ids_with_deviation = select(DetailedQCResult.submission_id).where(
             sa.or_(
-                sa.not_(DetailedQCResult.percent_bases_above_quality_threshold_passed_qc),
-                sa.not_(DetailedQCResult.mean_depth_of_coverage_passed_qc),
-                sa.not_(DetailedQCResult.targeted_regions_above_min_coverage_passed_qc),
+                sa.not_(DetailedQCResult.percent_bases_above_quality_threshold_passed_qc),  # type: ignore[call-overload]
+                sa.not_(DetailedQCResult.mean_depth_of_coverage_passed_qc),  # type: ignore[call-overload]
+                sa.not_(DetailedQCResult.targeted_regions_above_min_coverage_passed_qc),  # type: ignore[call-overload]
             )
         )
         query_submissions_to_report = (

--- a/packages/grzctl/src/grzctl/commands/report.py
+++ b/packages/grzctl/src/grzctl/commands/report.py
@@ -487,25 +487,41 @@ def _dump_qc_report(
     quarter_start_date, quarter_end_date = quarter_date_bounds(year=year, quarter=quarter)
 
     with database._get_session() as session:
-        query_submissions_that_failed_detailed_qc = (
+        # The quarterly QC report lists submissions that failed the detailed QC (a computed
+        # metric below the required threshold) as well as submissions that passed but carry a
+        # deviation of more than 10% between the computed and provided values on any metric.
+        # BfArM requires both to be reported; the latter does not count as a failure.
+        submission_ids_with_deviation = select(DetailedQCResult.submission_id).where(
+            sa.or_(
+                sa.not_(DetailedQCResult.percent_bases_above_quality_threshold_passed_qc),
+                sa.not_(DetailedQCResult.mean_depth_of_coverage_passed_qc),
+                sa.not_(DetailedQCResult.targeted_regions_above_min_coverage_passed_qc),
+            )
+        )
+        query_submissions_to_report = (
             select(Submission)
             .where(Submission.submission_uploaded_date.between(quarter_start_date, quarter_end_date))  # type: ignore[union-attr]
-            .filter(sa.not_(Submission.detailed_qc_passed))  # type: ignore[call-overload]
+            .filter(
+                sa.or_(
+                    sa.not_(Submission.detailed_qc_passed),  # type: ignore[call-overload]
+                    Submission.id.in_(submission_ids_with_deviation),  # type: ignore[attr-defined]
+                )
+            )
         )
-        submissions_that_failed_detailed_qc = session.exec(query_submissions_that_failed_detailed_qc).all()
+        submissions_to_report = session.exec(query_submissions_to_report).all()
 
-        subquery_submissions_that_failed_detailed_qc = query_submissions_that_failed_detailed_qc.subquery()
-        query_reports_of_failed_submissions = select(DetailedQCResult).join(
-            subquery_submissions_that_failed_detailed_qc,
-            subquery_submissions_that_failed_detailed_qc.c.id == DetailedQCResult.submission_id,
+        subquery_submissions_to_report = query_submissions_to_report.subquery()
+        query_reports_to_include = select(DetailedQCResult).join(
+            subquery_submissions_to_report,
+            subquery_submissions_to_report.c.id == DetailedQCResult.submission_id,
         )
-        reports_of_failed_submissions = session.exec(query_reports_of_failed_submissions).all()
+        reports_to_include = session.exec(query_reports_to_include).all()
 
-        subquery_reports_of_failed_submissions = query_reports_of_failed_submissions.subquery()
+        subquery_reports_to_include = query_reports_to_include.subquery()
         query_relevant_donors = select(Donor).join(
-            subquery_reports_of_failed_submissions,
-            (subquery_reports_of_failed_submissions.c.submission_id == Donor.submission_id)  # type: ignore[arg-type]
-            & (subquery_reports_of_failed_submissions.c.pseudonym == Donor.pseudonym),
+            subquery_reports_to_include,
+            (subquery_reports_to_include.c.submission_id == Donor.submission_id)  # type: ignore[arg-type]
+            & (subquery_reports_to_include.c.pseudonym == Donor.pseudonym),
         )
         relevant_donors = session.exec(query_relevant_donors).all()
 
@@ -513,7 +529,7 @@ def _dump_qc_report(
     # and Donor store index pseudonym as "index", since the submission table
     # has the index pseudonym
     idpseudo2relation = {(donor.submission_id, donor.pseudonym): donor.relation for donor in relevant_donors}
-    id2submission = {submission.id: submission for submission in submissions_that_failed_detailed_qc}
+    id2submission = {submission.id: submission for submission in submissions_to_report}
     with open(output_path, mode="w", encoding="utf-8", newline="") as output_file:
         writer = csv.writer(output_file, delimiter="\t")
         # header
@@ -547,7 +563,7 @@ def _dump_qc_report(
             + (["submission_id"] if with_submission_ids else [])
         )
 
-        for report in reports_of_failed_submissions:
+        for report in reports_to_include:
             submission = id2submission[report.submission_id]
             relation = Relation(idpseudo2relation[(report.submission_id, report.pseudonym)])
             writer.writerow(

--- a/packages/grzctl/tests/cli/test_report.py
+++ b/packages/grzctl/tests/cli/test_report.py
@@ -484,3 +484,110 @@ def test_quarterly_migrated_database(migrated_database_config_path: Path, tmp_pa
         qc_reader = csv.reader(qc_file, delimiter="\t")
         # header + no detailed QC failures
         assert len(list(qc_reader)) == 1
+
+
+def test_quarterly_qc_includes_passing_submission_with_deviation(migrated_database_config_path: Path, tmp_path: Path):
+    """A submission that passes detailed QC but deviates by more than 10% from the
+    provided values on a metric must still appear in the quarterly QC report,
+    without being counted as a failed QC (BfArM section B).
+    """
+    env = {
+        "GRZ_IDENTIFIERS__GRZ": "GRZX00000",
+    }
+
+    runner = CliRunner(env=env)
+    cli = grzctl.cli.build_cli()
+
+    metadata_raw = json.loads(TEST_METADATA_PATH.read_text())
+    metadata = GrzSubmissionMetadata.model_validate(metadata_raw)
+    result_add = runner.invoke(
+        cli, ["--config", migrated_database_config_path, "db", "submission", "add", metadata.submission_id]
+    )
+    assert result_add.exit_code == 0, result_add.output
+    metadata_path = tmp_path / "submission.metadata.json"
+    with open(metadata_path, mode="w", encoding="utf-8") as metadata_file:
+        json.dump(metadata_raw, metadata_file)
+    result_populate = runner.invoke(
+        cli,
+        [
+            "--config",
+            migrated_database_config_path,
+            "db",
+            "submission",
+            "populate",
+            "--no-confirm",
+            metadata.submission_id,
+            str(metadata_path),
+        ],
+    )
+    assert result_populate.exit_code == 0, result_populate.output
+    for field, value in (("basic_qc_passed", "yes"), ("detailed_qc_passed", "yes")):
+        result_modify = runner.invoke(
+            cli,
+            [
+                "--config",
+                migrated_database_config_path,
+                "db",
+                "submission",
+                "modify",
+                metadata.submission_id,
+                field,
+                value,
+            ],
+        )
+        assert result_modify.exit_code == 0, result_modify.output
+
+    # detailed QC passed, but the computed germline depth deviates -42% from the provided value
+    report_csv_path = tmp_path / "submission.report.csv"
+    with open(report_csv_path, "w") as report_csv_file:
+        report_csv_file.write(
+            dedent("""\
+            sampleId,donorPseudonym,labDataName,libraryType,sequenceSubtype,genomicStudySubtype,qualityControlStatus,meanDepthOfCoverage,meanDepthOfCoverageProvided,meanDepthOfCoverageRequired,meanDepthOfCoverageDeviation,meanDepthOfCoverageQCStatus,percentBasesAboveQualityThreshold,qualityThreshold,percentBasesAboveQualityThresholdProvided,percentBasesAboveQualityThresholdRequired,percentBasesAboveQualityThresholdDeviation,percentBasesAboveQualityThresholdQCStatus,targetedRegionsAboveMinCoverage,minCoverage,targetedRegionsAboveMinCoverageProvided,targetedRegionsAboveMinCoverageRequired,targetedRegionsAboveMinCoverageDeviation,targetedRegionsAboveMinCoverageQCStatus
+            index0_germline0,index,Blut DNA normal,wes,germline,tumor+germline,PASS,35.0,60.0,30.0,-42.0,DEVIATION,90.65953529937444,30,88.0,85,3.022199203834591,PASS,1.0,20,1.0,0.8,0.0,PASS
+            index0_somatic0,index,Blut DNA Tumor,wes,somatic,tumor+germline,PASS,110.0,112.0,100.0,-1.8,PASS,90.65953529937444,30,88.0,85,3.022199203834591,PASS,1.0,100,1.0,0.8,0.0,PASS
+            """)
+        )
+    result_qc_populate = runner.invoke(
+        cli,
+        [
+            "--config",
+            migrated_database_config_path,
+            "db",
+            "submission",
+            "populate-qc",
+            metadata.submission_id,
+            str(report_csv_path),
+            "--no-confirm",
+            "--qc-workflow-version",
+            "v4.0.0",
+        ],
+    )
+    assert result_qc_populate.exit_code == 0, result_qc_populate.output
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as report_tmp_dir:
+        result_report = runner.invoke(
+            cli,
+            ["--config", migrated_database_config_path, "report", "quarterly", "--year", "2025", "--quarter", "3"],
+            catch_exceptions=False,
+        )
+        assert result_report.exit_code == 0, result_report.output
+
+    # the submission appears in the QC report despite having passed detailed QC
+    qc_output_path = Path(report_tmp_dir) / "3-Detailprüfung_GRZX00000_3_2025.tsv"
+    with open(qc_output_path, newline="", encoding="utf-8") as qc_file:
+        qc_reader = csv.reader(qc_file, delimiter="\t")
+        # sort by sequence subtype: germline before somatic
+        rows = sorted(list(qc_reader)[1:], key=itemgetter(11))
+    assert len(rows) == 2
+    germline_row, somatic_row = rows
+    # the deviating metric is reported as not passed, with its deviation
+    assert germline_row[18] == "no"
+    assert float(germline_row[19]) == pytest.approx(-42.0)
+    assert somatic_row[18] == "yes"
+
+    # ...but it is not counted as a failed QC in the overview
+    overview_output_path = Path(report_tmp_dir) / "1-Gesamtübersicht_GRZX00000_3_2025.tsv"
+    with open(overview_output_path, newline="", encoding="utf-8") as overview_file:
+        overview_rows = list(csv.reader(overview_file, delimiter="\t"))[1:]
+    assert len(overview_rows) == 1
+    assert overview_rows[0][10] == "0"  # number_of_failed_qcs


### PR DESCRIPTION
GRZ_QC_Workflow >= 4.0.0 implements the detailed QC logic from the latest
BfArM documentation: a metric fails only if the computed value is below the
required threshold, and a deviation of more than 10% between the computed
and LE-provided values (two-sided, relative to the computed value) is
reported as DEVIATION without failing the check. Adapt grzctl so the new
verdicts flow through correctly; this PR should land together with
BfArM-MVH/GRZ_QC_Workflow#210.

populate-qc:
- add DEVIATION to the QCStatus enum, keeping TOO LOW so reports from
  older workflow versions still parse (both map to passed_qc = false)

quarterly report:
- the detailed QC table only listed submissions with detailed_qc_passed =
  false; deviating-but-passing submissions would silently drop out now
  that a deviation no longer fails. Widen the filter to also include
  submissions where any per-metric passed_qc flag is false. Row format and
  columns are unchanged; number_of_failed_qcs in the overview deliberately
  still counts only failed submissions, since a deviation is not a failure.

backfill:
- add `db submission recompute-qc --year Y --quarter Q [--apply]` to
  recompute the verdicts of a quarter under the new rules from the stored
  QC results and submission metadata, without re-running the pipeline.
  Dry-run by default; flips detailed_qc_passed in both directions
  (deviation-only failures become passed, computed values below the
  thresholds - previously unchecked - become failed), updates the
  per-metric flags and deviation values, and logs verdict changes via
  modify_submission. Intended sequence per GRZ: deploy workflow 4.0.0,
  run recompute-qc --apply for the current quarter, then generate the
  quarterly report.

Tests cover the new quarterly inclusion (present in the QC table, absent
from the failed count), both backfill directions, dry-run/no-op behaviour,
and legacy TOO LOW parsing.

Closes #644
