### PR TITLE
feat(grz-db, grzctl): record a failed download under its own reason

### DIFF
--- a/packages/grz-common/src/grz_common/workers/download.py
+++ b/packages/grz-common/src/grz_common/workers/download.py
@@ -40,7 +40,7 @@ botocore.handlers.VALID_BUCKET = re.compile(r"^[:a-zA-Z0-9.\-_]{1,255}$")
 
 
 class DownloadError(Exception):
-    """Exception raised when an upload fails"""
+    """Exception raised when a download fails"""
 
     pass
 

--- a/packages/grz-db/src/grz_db/migrations/versions/a7e3b1c94f20_add_download_error_failure_reason.py
+++ b/packages/grz-db/src/grz_db/migrations/versions/a7e3b1c94f20_add_download_error_failure_reason.py
@@ -1,0 +1,32 @@
+"""add download_error to failurereasonenum
+
+Recorded when a submission cannot be downloaded from the inbox, the mirror image of the
+existing ``upload_error``. Such failures were previously recorded as ``unknown``.
+
+Revision ID: a7e3b1c94f20
+Revises: c8d4a7f2b1e6
+Create Date: 2026-08-19 00:00:00.000000+00:00
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "a7e3b1c94f20"
+down_revision: str | Sequence[str] | None = "c8d4a7f2b1e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # SQLite stores the enum as plain VARCHAR, so only PostgreSQL needs the type extended.
+    # ADD VALUE inside a transaction requires PostgreSQL 12+, and even then the new value
+    # cannot be used in the same transaction; this migration does not use it.
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute("ALTER TYPE failurereasonenum ADD VALUE IF NOT EXISTS 'download_error'")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    raise RuntimeError("Downgrades not supported.")

--- a/packages/grz-db/src/grz_db/models/submission/__init__.py
+++ b/packages/grz-db/src/grz_db/models/submission/__init__.py
@@ -276,6 +276,7 @@ class FailureReasonEnum(CaseInsensitiveStrEnum, ListableEnum):  # type: ignore[m
     FILE_NOT_FOUND = "file_not_found"
     ENCRYPTION_ERROR = "encryption_error"
     UPLOAD_ERROR = "upload_error"
+    DOWNLOAD_ERROR = "download_error"
     UNKNOWN = "unknown"
 
 

--- a/packages/grzctl/pyproject.toml
+++ b/packages/grzctl/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 dynamic = ["version"]
 dependencies = [
     "requests >=2.32.3,<3",
-    "grz-db >=3,<4",
+    "grz-db >=3.1,<4",
     "grz-cli >=2,<3",
     "textual~=5.3"
 ]

--- a/packages/grzctl/src/grzctl/dbcontext.py
+++ b/packages/grzctl/src/grzctl/dbcontext.py
@@ -10,6 +10,7 @@ from grz_common.exceptions import (
     NetworkError,
     UploadError,
 )
+from grz_common.workers.download import DownloadError
 from grz_db.errors import DuplicateTanGError, SubmissionNotFoundError
 from grz_db.models.author import Author
 from grz_db.models.submission import FailureReasonEnum, SubmissionDb, SubmissionStateEnum
@@ -218,6 +219,7 @@ class DbContext:
             EncryptionError: FailureReasonEnum.ENCRYPTION_ERROR,
             NetworkError: FailureReasonEnum.NETWORK_ERROR,
             UploadError: FailureReasonEnum.UPLOAD_ERROR,
+            DownloadError: FailureReasonEnum.DOWNLOAD_ERROR,
             DuplicateTanGError: FailureReasonEnum.DUPLICATE_TANG,
             IncompleteSubmissionError: FailureReasonEnum.INCOMPLETE_SUBMISSION,
         }

--- a/packages/grzctl/src/grzctl/dbcontext.py
+++ b/packages/grzctl/src/grzctl/dbcontext.py
@@ -203,7 +203,14 @@ class DbContext:
     def _map_exception_to_failure_reason(
         self, exc_type: type[BaseException], exc_val: BaseException | None
     ) -> FailureReasonEnum:
-        """Maps an exception to the closest FailureReasonEnum value."""
+        """Maps an exception to the closest FailureReasonEnum value.
+
+        A wrapped exception keeps its reason: metadata that violates the schema, for example,
+        arrives as a ``SystemExit`` raised from a ``ValidationError``. The outermost exception
+        wins, then each ``__cause__`` in turn. Only ``__cause__`` is followed, since
+        ``__context__`` merely records what was in flight at the time and would attribute
+        unrelated failures.
+        """
         exception_map: dict[type[BaseException], FailureReasonEnum] = {
             FileNotFoundError: FailureReasonEnum.FILE_NOT_FOUND,
             ValidationError: FailureReasonEnum.VALIDATION_ERROR,
@@ -214,9 +221,14 @@ class DbContext:
             DuplicateTanGError: FailureReasonEnum.DUPLICATE_TANG,
             IncompleteSubmissionError: FailureReasonEnum.INCOMPLETE_SUBMISSION,
         }
-        for exc_class, failure_reason in exception_map.items():
-            if isinstance(exc_val, exc_class):
-                return failure_reason
+        seen: set[int] = set()
+        exc: BaseException | None = exc_val
+        while exc is not None and id(exc) not in seen:
+            seen.add(id(exc))
+            for exc_class, failure_reason in exception_map.items():
+                if isinstance(exc, exc_class):
+                    return failure_reason
+            exc = exc.__cause__
         return FailureReasonEnum.UNKNOWN
 
     def _check_prerequisites(self):

--- a/packages/grzctl/tests/test_dbcontext.py
+++ b/packages/grzctl/tests/test_dbcontext.py
@@ -9,6 +9,7 @@ from grz_common.exceptions import (
     NetworkError,
     UploadError,
 )
+from grz_common.workers.download import DownloadError
 from grz_db.errors import DuplicateTanGError
 from grz_db.models.submission import FailureReasonEnum, SubmissionStateEnum
 from grzctl.dbcontext import DbContext
@@ -51,6 +52,7 @@ class TestMapExceptionToFailureReason:
             (EncryptionError("failed"), FailureReasonEnum.ENCRYPTION_ERROR),
             (NetworkError("failed"), FailureReasonEnum.NETWORK_ERROR),
             (UploadError("failed"), FailureReasonEnum.UPLOAD_ERROR),
+            (DownloadError("failed"), FailureReasonEnum.DOWNLOAD_ERROR),
             (DuplicateTanGError(), FailureReasonEnum.DUPLICATE_TANG),
             (IncompleteSubmissionError("failed"), FailureReasonEnum.INCOMPLETE_SUBMISSION),
             (RuntimeError("unexpected"), FailureReasonEnum.UNKNOWN),
@@ -139,6 +141,7 @@ class TestMapExceptionToFailureReason:
                 EncryptionError(),
                 NetworkError(),
                 UploadError(),
+                DownloadError(),
                 DuplicateTanGError(),
                 IncompleteSubmissionError(),
                 validation_exc,

--- a/packages/grzctl/tests/test_dbcontext.py
+++ b/packages/grzctl/tests/test_dbcontext.py
@@ -79,6 +79,42 @@ class TestMapExceptionToFailureReason:
         result = db_context._map_exception_to_failure_reason(type(None), None)
         assert result == FailureReasonEnum.UNKNOWN
 
+    def test_wrapped_exception_keeps_its_reason(self, db_context: DbContext):
+        """Metadata that violates the schema reaches the recorder as SystemExit raised from a
+        ValidationError, which is how a real download failure loses its reason.
+        """
+        from pydantic import BaseModel
+
+        class _Dummy(BaseModel):
+            x: int
+
+        # Mirrors how grz_common parses metadata: the ValidationError is re-raised as SystemExit.
+        with pytest.raises(SystemExit) as raised:
+            try:
+                _Dummy(x="not_an_int")  # type: ignore
+            except ValidationError as validation_error:
+                raise SystemExit(validation_error) from validation_error
+
+        wrapped = raised.value
+        result = db_context._map_exception_to_failure_reason(type(wrapped), wrapped)
+        assert result == FailureReasonEnum.VALIDATION_ERROR
+
+    def test_outermost_mapped_exception_wins(self, db_context: DbContext):
+        """A wrapper that has a reason of its own keeps it rather than reporting its cause's."""
+        upload_error = UploadError("upload failed")
+        upload_error.__cause__ = NetworkError("connection reset")
+
+        result = db_context._map_exception_to_failure_reason(type(upload_error), upload_error)
+        assert result == FailureReasonEnum.UPLOAD_ERROR
+
+    def test_self_referential_cause_terminates(self, db_context: DbContext):
+        """A cause chain that loops back on itself must not spin forever."""
+        exc = RuntimeError("outer")
+        exc.__cause__ = exc
+
+        result = db_context._map_exception_to_failure_reason(type(exc), exc)
+        assert result == FailureReasonEnum.UNKNOWN
+
     def test_all_enum_values_are_covered(self, db_context: DbContext):
         """Ensures every FailureReasonEnum value except UNKNOWN is reachable via a mapped exception."""
         from pydantic import BaseModel


### PR DESCRIPTION
`grzctl download` filed failures under the wrong reason: a download that failed because a file was missing from the inbox, and metadata that violates the schema, were both recorded as `unknown`.

A new `download_error` reason covers a failed download, the mirror image of the existing `upload_error`, and the reason mapping now follows the `__cause__` chain so a wrapped failure keeps its reason.

Deploying requires `grzctl db upgrade`; the migration is additive. Rows already written keep their wrong reason, since state log entries are signed and cannot be rewritten.

Merge ordering: this migration and #633's both claim `c8d4a7f2b1e6` as parent. Whichever merges second repoints the other's `down_revision`.
